### PR TITLE
Revert uninstall.php to original skeleton (cleanup safety)

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,33 +1,30 @@
 <?php
 /**
- * Uninstall handler for WPFAevent / FOSSASIA Landing plugin.
+ * Fired when the plugin is uninstalled.
+ *
+ * When populating this file, consider the following flow
+ * of control:
+ *
+ * - This method should be static
+ * - Check if the $_REQUEST content actually is the plugin name
+ * - Run an admin referrer check to make sure it goes through authentication
+ * - Verify the output of $_GET makes sense
+ * - Repeat with other user roles. Best directly by using the links/query string parameters.
+ * - Repeat things for multisite. Once for a single site in the network, once sitewide.
+ *
+ * This file may be updated more in future version of the Boilerplate; however, this is the
+ * general skeleton and outline for how the file should work.
+ *
+ * For more information, see the following discussion:
+ * https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/pull/123#issuecomment-28541913
+ *
+ * @link       https://fossasia.org
+ * @since      1.0.0
+ *
+ * @package    Wpfaevent
  */
 
+// If uninstall not called from WordPress, then exit.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-    exit;
-}
-
-// Delete uploaded data files in uploads/fossasia-data
-$upload_dir = wp_upload_dir();
-$data_dir = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data';
-
-if ( is_dir( $data_dir ) ) {
-    $files = glob( $data_dir . '/*' );
-    if ( is_array( $files ) ) {
-        foreach ( $files as $file ) {
-            if ( is_file( $file ) ) {
-                @unlink( $file );
-            }
-        }
-    }
-    @rmdir( $data_dir );
-}
-
-// Remove pages created by the plugin (by slug)
-$slugs = [ 'fossasia-summit', 'speakers', 'full-schedule', 'admin-dashboard', 'events', 'past-events', 'code-of-conduct' ];
-foreach ( $slugs as $slug ) {
-    $page = get_page_by_path( $slug );
-    if ( $page ) {
-        wp_delete_post( $page->ID, true );
-    }
+	exit;
 }


### PR DESCRIPTION
### Why this revert is needed

The earlier `uninstall.php` contained logic that **automatically deleted**:

- All files in `wp-content/uploads/fossasia-data`
- Pages created by the plugin (identified by a hard‑coded slug list)

These actions were too aggressive for the current version and could cause
unexpected data loss for site owners. Restoring the file to the original
boilerplate skeleton removes that destructive behavior while we design a more
controlled uninstall procedure (e.g., optional cleanup, trash‑based page removal,
multisite handling).

The revert brings the plugin back to a safe baseline and prevents accidental
deletions during plugin uninstallation.

Tested with:

- [x] composer phpcbf uninstall.php
- [x] composer phpcs uninstall.php