### PR TITLE
chore: enable Dependabot for automated Composer dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     target-branch: "main"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "composer"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary

Adds a `dependabot.yml` configuration to automate dependency update checks
for Composer packages.

## Motivation

Currently, checking for `phpcs` updates is a manual process. This change
delegates that responsibility to GitHub Dependabot, which will:

- Scan `composer.json` for outdated packages
- Automatically open PRs when newer versions are available
- Keep development tooling up to date without manual intervention

## Changes

- Added `.github/dependabot.yml` with a weekly Composer update schedule
- Set `open-pull-requests-limit: 1` to prevent stale PRs from stacking up,
  since we are tracking a single dev tool (`phpcs`)
- Explicitly set `target-branch: main` to avoid ambiguity

## References

- https://github.com/PHPCSStandards/PHP_CodeSniffer/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-

---

- Fixes: https://github.com/fossasia/WPFAevent/issues/60

## Summary by Sourcery

Build:
- Add Dependabot configuration file to run weekly Composer dependency update checks.

## Summary by Sourcery

Build:
- Add Dependabot configuration to run weekly Composer dependency update checks with a single open PR limit.