### PR TITLE
Exclude legacy files from PHPCS (prerequisite)

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,4 +23,17 @@
   <!-- Exclude patterns -->
   <exclude-pattern>*/vendor/*</exclude-pattern>
   <exclude-pattern>*/node_modules/*</exclude-pattern>
+
+  <!--
+    Legacy files pending refactor (issue #57). admin/partials is excluded
+    entirely (both files are legacy). Other public/partials files stay in scope.
+    Remove each pattern when its file is refactored.
+  -->
+  <exclude-pattern>*/admin/partials/*</exclude-pattern>
+  <exclude-pattern>*/includes/class-wpfaevent-landing.php</exclude-pattern>
+  <exclude-pattern>*/includes/class-wpfaevent-uninstaller.php</exclude-pattern>
+  <exclude-pattern>*/public/partials/events-listing-page.php</exclude-pattern>
+  <exclude-pattern>*/public/partials/schedule-page.php</exclude-pattern>
+  <exclude-pattern>*/public/partials/wpfaevent-landing-template.php</exclude-pattern>
 </ruleset>
+


### PR DESCRIPTION
## Summary

Refs #57 — separate PR as requested in review of https://github.com/fossasia/WPFAevent/pull/62#discussion_r3254132957.

Temporarily excludes legacy files from PHPCS scans until they are refactored in follow-up work.

## Why these files are excluded

These files contain hardcoded logic and need dedicated refactors rather than bulk PHPCS formatting:

* `admin/partials/*` (both partials are legacy)
* `includes/class-wpfaevent-landing.php`
* `includes/class-wpfaevent-uninstaller.php`
* `public/partials/events-listing-page.php`
* `public/partials/schedule-page.php`
* `public/partials/wpfaevent-landing-template.php`

`admin/partials` uses a directory exclude because that folder only contains legacy files. Other `public/partials` files remain in scope.

## CI note

The **phpcs** check on this PR will fail against `main` alone because in-scope files are fixed in the baseline cleanup PR. That is expected. Merge this PR first, then rebase the baseline PR on `main` for a green CI run.

## Follow-up plan

Each file will be addressed in a focused refactor PR (not PHPCS-only churn). After refactors land, the matching `exclude-pattern` entry will be removed.

## Related

Stack for the same issue: baseline cleanup, `array()` syntax, and `__DIR__` paths (PRs 62–64).