### PR TITLE
CI: Scope PHPCS workflow to PHP changes (paths-filter)

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changes:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -6,22 +6,44 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      php: ${{ steps.filter.outputs.php }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            php:
+              - '**/*.php'
+
   phpcs:
+    needs: changes
+    if: |
+      always() &&
+      (github.event_name == 'push' || needs.changes.outputs.php == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-      
+
       - name: Validate composer.json
         run: composer validate
-      
+
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
-      
+
       - name: Run PHPCS
         run: composer phpcs


### PR DESCRIPTION
## Summary

Use [dorny/paths-filter](https://github.com/dorny/paths-filter) so PHPCS runs on pull requests only when `**/*.php` files change. Pushes to `main` always run PHPCS.

## Why

PHPCS should only run on pull requests that modify `.php` files. This avoids unnecessary workflow runs and prevents configuration-only or workflow-only changes from triggering PHPCS checks unrelated to the actual PR changes.

## Changes

- Add `changes` job with `dorny/paths-filter@v3` (`php` filter on `**/*.php`)
- Run `phpcs` when `php=true` on PRs, or on every push to `main`

## Behavior

| Event | `changes` job | `phpcs` job |
|-------|---------------|-------------|
| PR — only `phpcs.xml` / workflow YAML | Runs → `php=false` | **Skipped** |
| PR — any `.php` file changed | Runs → `php=true` | **Runs** |
| Push to `main` | Skipped | **Always runs** |

---

- Fixes: #67