### PR TITLE
Sync event-speaker relationships bidirectionally

### DIFF
--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -525,25 +525,6 @@ class Wpfaevent_Admin {
 					'order'                  => 'ASC',
 					'update_post_meta_cache' => false,
 					'update_post_term_cache' => false,
-					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
-					'meta_query'             => array(
-						'relation' => 'OR',
-						array(
-							'key'     => 'wpfa_speaker_events',
-							'value'   => 'i:' . $event_id . ';',
-							'compare' => 'LIKE',
-						),
-						array(
-							'key'     => 'wpfa_speaker_events',
-							'value'   => '"' . $event_id . '"',
-							'compare' => 'LIKE',
-						),
-						array(
-							'key'     => 'wpfa_speaker_events',
-							'value'   => (string) $event_id,
-							'compare' => '=',
-						),
-					),
 				)
 			);
 
@@ -551,8 +532,15 @@ class Wpfaevent_Admin {
 				break;
 			}
 
-			$speaker_ids = array_merge( $speaker_ids, $batch_ids );
 			$batch_count = count( $batch_ids );
+			update_meta_cache( 'post', $batch_ids );
+
+			foreach ( $batch_ids as $speaker_id ) {
+				if ( in_array( $event_id, $this->get_speaker_event_ids( $speaker_id ), true ) ) {
+					$speaker_ids[] = $speaker_id;
+				}
+			}
+
 			++$current_page;
 		} while ( $batch_count === $batch_size );
 

--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -244,12 +244,7 @@ class Wpfaevent_Admin {
 		$lead_text  = get_post_meta( $post->ID, 'wpfa_event_lead_text', true );
 		$reg_link   = get_post_meta( $post->ID, 'wpfa_event_registration_link', true );
 		$cfs_link   = get_post_meta( $post->ID, 'wpfa_event_cfs_link', true );
-		$speakers   = get_post_meta( $post->ID, 'wpfa_event_speakers', true );
-
-		// Normalize to array.
-		if ( ! is_array( $speakers ) ) {
-			$speakers = ! empty( $speakers ) ? array( $speakers ) : array();
-		}
+		$speakers   = $this->get_event_speaker_ids( $post->ID );
 
 		?>
 		<table class="form-table">
@@ -292,6 +287,7 @@ class Wpfaevent_Admin {
 					$speaker_ids = get_posts(
 						array(
 							'post_type'      => 'wpfa_speaker',
+							'post_status'    => 'any',
 							'posts_per_page' => -1,
 							'orderby'        => 'title',
 							'order'          => 'ASC',
@@ -301,7 +297,7 @@ class Wpfaevent_Admin {
 					);
 					if ( $speaker_ids ) :
 						?>
-						<select name="wpfa_event_speakers[]" id="wpfa_event_speakers" multiple class="wpfaevent-speakers-select">
+						<select name="wpfa_event_speakers[]" id="wpfa_event_speakers" multiple class="wpfaevent-relationship-select wpfaevent-speakers-select">
 							<?php foreach ( $speaker_ids as $speaker_id ) : ?>
 								<?php $is_selected = is_array( $speakers ) && in_array( $speaker_id, $speakers, true ); ?>
 									<option value="<?php echo esc_attr( $speaker_id ); ?>"
@@ -335,6 +331,12 @@ class Wpfaevent_Admin {
 		$organization = get_post_meta( $post->ID, 'wpfa_speaker_organization', true );
 		$bio          = get_post_meta( $post->ID, 'wpfa_speaker_bio', true );
 		$headshot_url = get_post_meta( $post->ID, 'wpfa_speaker_headshot_url', true );
+		$events       = $this->sanitize_post_id_list(
+			array_merge(
+				$this->get_speaker_event_ids( $post->ID ),
+				$this->get_events_linked_to_speaker( $post->ID )
+			)
+		);
 		?>
 		<table class="form-table">
 			<tr>
@@ -364,6 +366,39 @@ class Wpfaevent_Admin {
 			<tr>
 				<th><label for="wpfa_speaker_headshot_url"><?php esc_html_e( 'Headshot URL', 'wpfaevent' ); ?></label></th>
 				<td><input type="url" id="wpfa_speaker_headshot_url" name="wpfa_speaker_headshot_url" value="<?php echo esc_attr( $headshot_url ); ?>" class="regular-text" placeholder="https://"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_speaker_events"><?php esc_html_e( 'Related Events', 'wpfaevent' ); ?></label></th>
+				<td>
+					<?php
+					$event_ids = get_posts(
+						array(
+							'post_type'      => 'wpfa_event',
+							'post_status'    => 'any',
+							'posts_per_page' => -1,
+							'orderby'        => 'title',
+							'order'          => 'ASC',
+							'fields'         => 'ids',
+							'no_found_rows'  => true,
+						)
+					);
+					if ( $event_ids ) :
+						?>
+						<select name="wpfa_speaker_events[]" id="wpfa_speaker_events" multiple class="wpfaevent-relationship-select wpfaevent-events-select">
+							<?php foreach ( $event_ids as $event_id ) : ?>
+								<?php $is_selected = in_array( $event_id, $events, true ); ?>
+								<option value="<?php echo esc_attr( $event_id ); ?>" <?php selected( $is_selected, true ); ?>>
+									<?php echo esc_html( get_the_title( $event_id ) ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+						<p class="description">
+							<?php esc_html_e( 'Hold Ctrl (Cmd on Mac) to select multiple events.', 'wpfaevent' ); ?>
+						</p>
+					<?php else : ?>
+						<p><?php esc_html_e( 'No events found. Create events first.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</td>
 			</tr>
 		</table>
 		<?php
@@ -430,11 +465,7 @@ class Wpfaevent_Admin {
 			);
 		}
 
-		if ( ! empty( $speakers ) ) {
-			update_post_meta( $post_id, 'wpfa_event_speakers', $speakers );
-		} else {
-			delete_post_meta( $post_id, 'wpfa_event_speakers' );
-		}
+		$this->update_post_id_list_meta( $post_id, 'wpfa_event_speakers', $speakers );
 
 		$this->sync_event_speaker_relationships( $post_id, $previous_speakers, $speakers );
 	}
@@ -484,6 +515,27 @@ class Wpfaevent_Admin {
 		$post_ids = array_filter( $post_ids );
 
 		return array_values( array_unique( $post_ids ) );
+	}
+
+	/**
+	 * Save a normalized post ID list as post meta.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int        $post_id  Post ID.
+	 * @param string     $meta_key Meta key.
+	 * @param array<int> $post_ids Post IDs to save.
+	 * @return void
+	 */
+	private function update_post_id_list_meta( $post_id, $meta_key, $post_ids ) {
+		$post_ids = $this->sanitize_post_id_list( $post_ids );
+
+		if ( empty( $post_ids ) ) {
+			delete_post_meta( $post_id, $meta_key );
+			return;
+		}
+
+		update_post_meta( $post_id, $meta_key, $post_ids );
 	}
 
 	/**
@@ -600,15 +652,10 @@ class Wpfaevent_Admin {
 			return;
 		}
 
-		if ( ! current_user_can( 'edit_post', $speaker_id ) ) {
-			return;
-		}
-
 		$event_ids   = $this->get_speaker_event_ids( $speaker_id );
 		$event_ids[] = $event_id;
-		$event_ids   = $this->sanitize_post_id_list( $event_ids );
 
-		update_post_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
+		$this->update_post_id_list_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
 	}
 
 	/**
@@ -632,19 +679,9 @@ class Wpfaevent_Admin {
 			return;
 		}
 
-		if ( ! current_user_can( 'edit_post', $speaker_id ) ) {
-			return;
-		}
-
 		$event_ids = array_diff( $this->get_speaker_event_ids( $speaker_id ), array( $event_id ) );
-		$event_ids = $this->sanitize_post_id_list( $event_ids );
 
-		if ( empty( $event_ids ) ) {
-			delete_post_meta( $speaker_id, 'wpfa_speaker_events' );
-			return;
-		}
-
-		update_post_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
+		$this->update_post_id_list_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
 	}
 
 	/**
@@ -683,6 +720,175 @@ class Wpfaevent_Admin {
 		if ( isset( $_POST['wpfa_speaker_headshot_url'] ) ) {
 			update_post_meta( $post_id, 'wpfa_speaker_headshot_url', esc_url_raw( wp_unslash( $_POST['wpfa_speaker_headshot_url'] ) ) );
 		}
+
+		$previous_events = $this->get_speaker_event_ids( $post_id );
+		$events          = array();
+
+		if ( isset( $_POST['wpfa_speaker_events'] ) && is_array( $_POST['wpfa_speaker_events'] ) ) {
+			$events = $this->sanitize_post_id_list(
+				array_map(
+					'sanitize_text_field',
+					wp_unslash( $_POST['wpfa_speaker_events'] )
+				)
+			);
+		}
+
+		$this->update_post_id_list_meta( $post_id, 'wpfa_speaker_events', $events );
+		$this->sync_speaker_event_relationships( $post_id, $previous_events, $events );
+	}
+
+	/**
+	 * Sync event-side speaker relationship meta after a speaker is saved.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int        $speaker_id      Speaker post ID.
+	 * @param array<int> $previous_events Event IDs before save.
+	 * @param array<int> $current_events  Event IDs after save.
+	 * @return void
+	 */
+	private function sync_speaker_event_relationships( $speaker_id, $previous_events, $current_events ) {
+		$speaker_id      = absint( $speaker_id );
+		$previous_events = $this->sanitize_post_id_list( $previous_events );
+		$current_events  = $this->sanitize_post_id_list( $current_events );
+
+		if ( ! $speaker_id || 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
+			return;
+		}
+
+		$previous_events = array_values(
+			array_unique(
+				array_merge(
+					$previous_events,
+					$this->get_events_linked_to_speaker( $speaker_id )
+				)
+			)
+		);
+
+		$removed_events = array_diff( $previous_events, $current_events );
+
+		foreach ( $removed_events as $event_id ) {
+			$this->remove_speaker_from_event( $event_id, $speaker_id );
+		}
+
+		foreach ( $current_events as $event_id ) {
+			$this->add_speaker_to_event( $event_id, $speaker_id );
+		}
+	}
+
+	/**
+	 * Find events whose event-side speaker meta includes a speaker.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @return array<int> Event post IDs.
+	 */
+	private function get_events_linked_to_speaker( $speaker_id ) {
+		$speaker_id = absint( $speaker_id );
+
+		if ( ! $speaker_id ) {
+			return array();
+		}
+
+		$batch_size   = 100;
+		$current_page = 1;
+		$event_ids    = array();
+
+		do {
+			$batch_ids = get_posts(
+				array(
+					'post_type'              => 'wpfa_event',
+					'post_status'            => 'any',
+					'posts_per_page'         => $batch_size,
+					'paged'                  => $current_page,
+					'fields'                 => 'ids',
+					'no_found_rows'          => true,
+					'orderby'                => 'ID',
+					'order'                  => 'ASC',
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				)
+			);
+
+			if ( empty( $batch_ids ) ) {
+				break;
+			}
+
+			$batch_count = count( $batch_ids );
+			update_meta_cache( 'post', $batch_ids );
+
+			foreach ( $batch_ids as $event_id ) {
+				if ( in_array( $speaker_id, $this->get_event_speaker_ids( $event_id ), true ) ) {
+					$event_ids[] = $event_id;
+				}
+			}
+
+			++$current_page;
+		} while ( $batch_count === $batch_size );
+
+		return $this->sanitize_post_id_list( $event_ids );
+	}
+
+	/**
+	 * Add a speaker ID to an event's related speakers.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id   Event post ID.
+	 * @param int $speaker_id Speaker post ID.
+	 * @return void
+	 */
+	private function add_speaker_to_event( $event_id, $speaker_id ) {
+		$event_id   = absint( $event_id );
+		$speaker_id = absint( $speaker_id );
+
+		if ( ! $event_id || ! $speaker_id ) {
+			return;
+		}
+
+		if ( 'wpfa_event' !== get_post_type( $event_id ) ) {
+			return;
+		}
+
+		if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
+			return;
+		}
+
+		$speaker_ids   = $this->get_event_speaker_ids( $event_id );
+		$speaker_ids[] = $speaker_id;
+
+		$this->update_post_id_list_meta( $event_id, 'wpfa_event_speakers', $speaker_ids );
+	}
+
+	/**
+	 * Remove a speaker ID from an event's related speakers.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id   Event post ID.
+	 * @param int $speaker_id Speaker post ID.
+	 * @return void
+	 */
+	private function remove_speaker_from_event( $event_id, $speaker_id ) {
+		$event_id   = absint( $event_id );
+		$speaker_id = absint( $speaker_id );
+
+		if ( ! $event_id || ! $speaker_id ) {
+			return;
+		}
+
+		if ( 'wpfa_event' !== get_post_type( $event_id ) ) {
+			return;
+		}
+
+		if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
+			return;
+		}
+
+		$speaker_ids = array_diff( $this->get_event_speaker_ids( $event_id ), array( $speaker_id ) );
+
+		$this->update_post_id_list_meta( $event_id, 'wpfa_event_speakers', $speaker_ids );
 	}
 
 	/**

--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -509,34 +509,52 @@ class Wpfaevent_Admin {
 			return array();
 		}
 
-		$speaker_ids = get_posts(
-			array(
-				'post_type'      => 'wpfa_speaker',
-				'post_status'    => 'any',
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
-				'meta_query'     => array(
-					'relation' => 'OR',
-					array(
-						'key'     => 'wpfa_speaker_events',
-						'value'   => 'i:' . $event_id . ';',
-						'compare' => 'LIKE',
+		$batch_size  = 100;
+		$current_page = 1;
+		$speaker_ids = array();
+
+		do {
+			$batch_ids = get_posts(
+				array(
+					'post_type'              => 'wpfa_speaker',
+					'post_status'            => 'any',
+					'posts_per_page'         => $batch_size,
+					'paged'                  => $current_page,
+					'fields'                 => 'ids',
+					'no_found_rows'          => true,
+					'orderby'                => 'ID',
+					'order'                  => 'ASC',
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
+					'meta_query'             => array(
+						'relation' => 'OR',
+						array(
+							'key'     => 'wpfa_speaker_events',
+							'value'   => 'i:' . $event_id . ';',
+							'compare' => 'LIKE',
+						),
+						array(
+							'key'     => 'wpfa_speaker_events',
+							'value'   => '"' . $event_id . '"',
+							'compare' => 'LIKE',
+						),
+						array(
+							'key'     => 'wpfa_speaker_events',
+							'value'   => (string) $event_id,
+							'compare' => '=',
+						),
 					),
-					array(
-						'key'     => 'wpfa_speaker_events',
-						'value'   => '"' . $event_id . '"',
-						'compare' => 'LIKE',
-					),
-					array(
-						'key'     => 'wpfa_speaker_events',
-						'value'   => (string) $event_id,
-						'compare' => '=',
-					),
-				),
-			)
-		);
+				)
+			);
+
+			if ( empty( $batch_ids ) ) {
+				break;
+			}
+
+			$speaker_ids = array_merge( $speaker_ids, $batch_ids );
+			$current_page++;
+		} while ( count( $batch_ids ) === $batch_size );
 
 		return $this->sanitize_post_id_list( $speaker_ids );
 	}

--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -357,7 +357,9 @@ class Wpfaevent_Admin {
 	 * @param int $post_id The post ID.
 	 */
 	public function save_event_meta( $post_id ) {
-		if ( ! isset( $_POST['wpfa_event_meta_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['wpfa_event_meta_nonce'] ), 'wpfa_event_meta_nonce' ) ) {
+		$event_nonce = isset( $_POST['wpfa_event_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_meta_nonce'] ) ) : '';
+
+		if ( ! $event_nonce || ! wp_verify_nonce( $event_nonce, 'wpfa_event_meta_nonce' ) ) {
 			return;
 		}
 
@@ -385,12 +387,214 @@ class Wpfaevent_Admin {
 			update_post_meta( $post_id, 'wpfa_event_url', esc_url_raw( wp_unslash( $_POST['wpfa_event_url'] ) ) );
 		}
 
+		$previous_speakers = $this->get_event_speaker_ids( $post_id );
+		$speakers          = array();
+
 		if ( isset( $_POST['wpfa_event_speakers'] ) && is_array( $_POST['wpfa_event_speakers'] ) ) {
-			$speakers = array_map( 'absint', $_POST['wpfa_event_speakers'] );
+			$speakers = $this->sanitize_post_id_list(
+				array_map(
+					'sanitize_text_field',
+					wp_unslash( $_POST['wpfa_event_speakers'] )
+				)
+			);
+		}
+
+		if ( ! empty( $speakers ) ) {
 			update_post_meta( $post_id, 'wpfa_event_speakers', $speakers );
 		} else {
 			delete_post_meta( $post_id, 'wpfa_event_speakers' );
 		}
+
+		$this->sync_event_speaker_relationships( $post_id, $previous_speakers, $speakers );
+	}
+
+	/**
+	 * Get normalized speaker IDs assigned to an event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int> Speaker post IDs.
+	 */
+	private function get_event_speaker_ids( $event_id ) {
+		$speaker_ids = get_post_meta( $event_id, 'wpfa_event_speakers', true );
+
+		return $this->sanitize_post_id_list( $speaker_ids );
+	}
+
+	/**
+	 * Get normalized event IDs assigned to a speaker.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @return array<int> Event post IDs.
+	 */
+	private function get_speaker_event_ids( $speaker_id ) {
+		$event_ids = get_post_meta( $speaker_id, 'wpfa_speaker_events', true );
+
+		return $this->sanitize_post_id_list( $event_ids );
+	}
+
+	/**
+	 * Sanitize, deduplicate, and reindex a list of post IDs.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $post_ids Raw post IDs.
+	 * @return array<int> Sanitized post IDs.
+	 */
+	private function sanitize_post_id_list( $post_ids ) {
+		if ( ! is_array( $post_ids ) ) {
+			return array();
+		}
+
+		$post_ids = array_map( 'absint', $post_ids );
+		$post_ids = array_filter( $post_ids );
+
+		return array_values( array_unique( $post_ids ) );
+	}
+
+	/**
+	 * Sync speaker-side event relationship meta after an event is saved.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int        $event_id          Event post ID.
+	 * @param array<int> $previous_speakers Speaker IDs before save.
+	 * @param array<int> $current_speakers  Speaker IDs after save.
+	 * @return void
+	 */
+	private function sync_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers ) {
+		$event_id          = absint( $event_id );
+		$previous_speakers = $this->sanitize_post_id_list( $previous_speakers );
+		$current_speakers  = $this->sanitize_post_id_list( $current_speakers );
+
+		if ( ! $event_id ) {
+			return;
+		}
+
+		$previous_speakers = array_values(
+			array_unique(
+				array_merge(
+					$previous_speakers,
+					$this->get_speakers_linked_to_event( $event_id )
+				)
+			)
+		);
+
+		$removed_speakers = array_diff( $previous_speakers, $current_speakers );
+
+		foreach ( $removed_speakers as $speaker_id ) {
+			$this->remove_event_from_speaker( $speaker_id, $event_id );
+		}
+
+		foreach ( $current_speakers as $speaker_id ) {
+			$this->add_event_to_speaker( $speaker_id, $event_id );
+		}
+	}
+
+	/**
+	 * Find speakers whose speaker-side event meta includes an event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int> Speaker post IDs.
+	 */
+	private function get_speakers_linked_to_event( $event_id ) {
+		$event_id = absint( $event_id );
+
+		if ( ! $event_id ) {
+			return array();
+		}
+
+		$speaker_ids = get_posts(
+			array(
+				'post_type'      => 'wpfa_speaker',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
+				'meta_query'     => array(
+					'relation' => 'OR',
+					array(
+						'key'     => 'wpfa_speaker_events',
+						'value'   => 'i:' . $event_id . ';',
+						'compare' => 'LIKE',
+					),
+					array(
+						'key'     => 'wpfa_speaker_events',
+						'value'   => '"' . $event_id . '"',
+						'compare' => 'LIKE',
+					),
+					array(
+						'key'     => 'wpfa_speaker_events',
+						'value'   => (string) $event_id,
+						'compare' => '=',
+					),
+				),
+			)
+		);
+
+		return $this->sanitize_post_id_list( $speaker_ids );
+	}
+
+	/**
+	 * Add an event ID to a speaker's related events.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @param int $event_id Event post ID.
+	 * @return void
+	 */
+	private function add_event_to_speaker( $speaker_id, $event_id ) {
+		$speaker_id = absint( $speaker_id );
+		$event_id   = absint( $event_id );
+
+		if ( ! $speaker_id || ! $event_id ) {
+			return;
+		}
+
+		if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
+			return;
+		}
+
+		$event_ids   = $this->get_speaker_event_ids( $speaker_id );
+		$event_ids[] = $event_id;
+		$event_ids   = $this->sanitize_post_id_list( $event_ids );
+
+		update_post_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
+	}
+
+	/**
+	 * Remove an event ID from a speaker's related events.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @param int $event_id Event post ID.
+	 * @return void
+	 */
+	private function remove_event_from_speaker( $speaker_id, $event_id ) {
+		$speaker_id = absint( $speaker_id );
+		$event_id   = absint( $event_id );
+
+		if ( ! $speaker_id || ! $event_id ) {
+			return;
+		}
+
+		$event_ids = array_diff( $this->get_speaker_event_ids( $speaker_id ), array( $event_id ) );
+		$event_ids = $this->sanitize_post_id_list( $event_ids );
+
+		if ( empty( $event_ids ) ) {
+			delete_post_meta( $speaker_id, 'wpfa_speaker_events' );
+			return;
+		}
+
+		update_post_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
 	}
 
 	/**

--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -446,7 +446,7 @@ class Wpfaevent_Admin {
 	 */
 	private function sanitize_post_id_list( $post_ids ) {
 		if ( ! is_array( $post_ids ) ) {
-			return array();
+			$post_ids = array( $post_ids );
 		}
 
 		$post_ids = array_map( 'absint', $post_ids );
@@ -509,9 +509,9 @@ class Wpfaevent_Admin {
 			return array();
 		}
 
-		$batch_size  = 100;
+		$batch_size   = 100;
 		$current_page = 1;
-		$speaker_ids = array();
+		$speaker_ids  = array();
 
 		do {
 			$batch_ids = get_posts(
@@ -553,8 +553,9 @@ class Wpfaevent_Admin {
 			}
 
 			$speaker_ids = array_merge( $speaker_ids, $batch_ids );
-			$current_page++;
-		} while ( count( $batch_ids ) === $batch_size );
+			$batch_count = count( $batch_ids );
+			++$current_page;
+		} while ( $batch_count === $batch_size );
 
 		return $this->sanitize_post_id_list( $speaker_ids );
 	}
@@ -580,6 +581,10 @@ class Wpfaevent_Admin {
 			return;
 		}
 
+		if ( ! current_user_can( 'edit_post', $speaker_id ) ) {
+			return;
+		}
+
 		$event_ids   = $this->get_speaker_event_ids( $speaker_id );
 		$event_ids[] = $event_id;
 		$event_ids   = $this->sanitize_post_id_list( $event_ids );
@@ -601,6 +606,14 @@ class Wpfaevent_Admin {
 		$event_id   = absint( $event_id );
 
 		if ( ! $speaker_id || ! $event_id ) {
+			return;
+		}
+
+		if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_post', $speaker_id ) ) {
 			return;
 		}
 

--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -6,13 +6,13 @@
  /**
  * Meta Box Styling
  */
-.wpfaevent-speakers-select {
+.wpfaevent-relationship-select {
     width: 100%;
     min-height: 150px;
     padding: 4px;
 }
 
 /* Ensure proper spacing in meta boxes */
-.wpfaevent-speakers-select option {
+.wpfaevent-relationship-select option {
     padding: 2px 2px;
 }

--- a/docs/speaker-data-model.md
+++ b/docs/speaker-data-model.md
@@ -27,12 +27,14 @@ All speaker metadata above is registered through `register_post_meta()` and expo
 
 Events store their assigned speakers in `wpfa_event_speakers` as an array of `wpfa_speaker` post IDs. Speakers store their related events in `wpfa_speaker_events` as an array of `wpfa_event` post IDs.
 
-When an event is saved, the event-speaker sync flow should keep both sides aligned:
+When an event is saved, the event-speaker sync flow keeps both sides aligned:
 
 1. Read the previous `wpfa_event_speakers` value.
 2. Sanitize and save the current speaker IDs on the event.
 3. Add the event ID to every newly assigned speaker's `wpfa_speaker_events`.
 4. Remove the event ID from speakers that were removed from the event.
+
+The Speaker edit screen also exposes the same relationship from the speaker side. Saving the speaker's related events writes `wpfa_speaker_events` and syncs each selected or removed event's `wpfa_event_speakers` list.
 
 Speaker profile pages use `wpfa_speaker_events` first and also check `wpfa_event_speakers` as a fallback so older data can still render linked events.
 

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -168,6 +168,9 @@ class Wpfaevent_Meta_Event {
 			return array();
 		}
 
-		return array_map( 'absint', $speaker_ids );
+		$speaker_ids = array_map( 'absint', $speaker_ids );
+		$speaker_ids = array_filter( $speaker_ids );
+
+		return array_values( array_unique( $speaker_ids ) );
 	}
 }


### PR DESCRIPTION
## Summary 

-  sync speaker-side wpfa_speaker_events whenever an event's wpfa_event_speakers list changes
- remove stale event IDs from speakers that are unassigned from an event
- normalize and deduplicate event/speaker relationship ID arrays before saving\n\n## Related
- Part of #73 

### Enhancements:
- Normalize and deduplicate stored event and speaker ID meta lists via shared helper methods.
- Synchronize speaker-side wpfa_speaker_events meta based on changes to an event's wpfa_event_speakers assignments, including adding and removing links as needed.
- Improve nonce and input sanitization when saving event speaker metadata.

### 🛢️ Database Verification Testing (Step-by-Step)

Refer https://github.com/fossasia/WPFAevent/pull/76#pullrequestreview-4480678888

---

- Fixes: #73