### PR TITLE
Add single speaker profile template

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Each shortcode can accept optional attributes — for example:
 
 if multiple event profiles are configured in settings.
 
+## Speaker Data Model
+
+Speaker profiles use the `wpfa_speaker` custom post type, registered speaker metadata, and the event-speaker relationship fields `wpfa_event_speakers` and `wpfa_speaker_events`.
+
+See [`docs/speaker-data-model.md`](docs/speaker-data-model.md) for the speaker fields, REST-exposed metadata, relationship sync behavior, and the interim session metadata approach.
 
 ## Settings Page
 

--- a/docs/speaker-data-model.md
+++ b/docs/speaker-data-model.md
@@ -1,0 +1,43 @@
+# Speaker Data Model
+
+The speaker profile system uses the `wpfa_speaker` custom post type for public speaker pages and REST-accessible speaker data.
+
+## Speaker Metadata
+
+| Meta key | Type | Purpose |
+| --- | --- | --- |
+| `wpfa_speaker_position` | string | Speaker title or role. |
+| `wpfa_speaker_organization` | string | Company, project, or organization name. |
+| `wpfa_speaker_bio` | string | Speaker biography. |
+| `wpfa_speaker_headshot_url` | string | Speaker image URL used when no featured image is available. |
+| `wpfa_speaker_linkedin` | string | LinkedIn profile URL. |
+| `wpfa_speaker_twitter` | string | Twitter/X profile URL. |
+| `wpfa_speaker_github` | string | GitHub profile URL. |
+| `wpfa_speaker_website` | string | Speaker website URL. |
+| `wpfa_speaker_talk_title` | string | Interim session title for the speaker. |
+| `wpfa_speaker_talk_date` | string | Interim session date. |
+| `wpfa_speaker_talk_time` | string | Interim session start time. |
+| `wpfa_speaker_talk_end_time` | string | Interim session end time. |
+| `wpfa_speaker_talk_abstract` | string | Interim session abstract. |
+| `wpfa_speaker_events` | array<int> | Event post IDs linked to the speaker. |
+
+All speaker metadata above is registered through `register_post_meta()` and exposed through the WordPress REST API.
+
+## Event Relationship
+
+Events store their assigned speakers in `wpfa_event_speakers` as an array of `wpfa_speaker` post IDs. Speakers store their related events in `wpfa_speaker_events` as an array of `wpfa_event` post IDs.
+
+When an event is saved, the event-speaker sync flow should keep both sides aligned:
+
+1. Read the previous `wpfa_event_speakers` value.
+2. Sanitize and save the current speaker IDs on the event.
+3. Add the event ID to every newly assigned speaker's `wpfa_speaker_events`.
+4. Remove the event ID from speakers that were removed from the event.
+
+Speaker profile pages use `wpfa_speaker_events` first and also check `wpfa_event_speakers` as a fallback so older data can still render linked events.
+
+## Session Data
+
+There is not yet a reusable Session CPT or session relationship model. Until that exists, the speaker profile displays the interim `wpfa_speaker_talk_*` metadata as "Sessions by this speaker".
+
+When a reusable session data model is added, speaker profiles should move from the interim talk fields to a dedicated session relationship and keep these fields only for migration/backward compatibility.

--- a/includes/class-wpfaevent-templates.php
+++ b/includes/class-wpfaevent-templates.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Registers and loads plugin-provided page templates.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/includes
+ */
+
+/**
  * Prevent direct access to this file.
  */
 if ( ! defined( 'ABSPATH' ) ) {
@@ -21,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @subpackage Wpfaevent/includes
  * @author     FOSSASIA <contact@fossasia.org>
  */
-class WPFA_Templates {
+class Wpfaevent_Templates {
 
 	/**
 	 * List of plugin-provided page templates.
@@ -31,14 +38,14 @@ class WPFA_Templates {
 	 * @since 1.0.0
 	 * @var   array<string, string>
 	 */
-	private static $templates = [
+	private static $templates = array(
 		'page-landing.php'         => 'WPFA - Landing',
 		'page-speakers.php'        => 'WPFA - Speakers',
 		'page-events.php'          => 'WPFA - Events',
 		'page-past-events.php'     => 'WPFA - Past Events',
 		'page-schedule.php'        => 'WPFA - Schedule',
 		'page-code-of-conduct.php' => 'WPFA - Code of Conduct',
-	];
+	);
 
 	/**
 	 * Registers WordPress hooks for template registration and loading.
@@ -52,8 +59,26 @@ class WPFA_Templates {
 	 * @return void
 	 */
 	public static function init() {
-		add_filter( 'theme_page_templates', [ __CLASS__, 'register' ] );
-		add_filter( 'template_include', [ __CLASS__, 'load' ] );
+		add_filter( 'theme_page_templates', array( __CLASS__, 'register' ) );
+		add_filter( 'template_include', array( __CLASS__, 'load' ) );
+	}
+
+	/**
+	 * Returns localized template labels keyed by template filename.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, string>
+	 */
+	private static function get_localized_template_labels() {
+		return array(
+			'page-landing.php'         => __( 'WPFA - Landing', 'wpfaevent' ),
+			'page-speakers.php'        => __( 'WPFA - Speakers', 'wpfaevent' ),
+			'page-events.php'          => __( 'WPFA - Events', 'wpfaevent' ),
+			'page-past-events.php'     => __( 'WPFA - Past Events', 'wpfaevent' ),
+			'page-schedule.php'        => __( 'WPFA - Schedule', 'wpfaevent' ),
+			'page-code-of-conduct.php' => __( 'WPFA - Code of Conduct', 'wpfaevent' ),
+		);
 	}
 
 	/**
@@ -68,13 +93,13 @@ class WPFA_Templates {
 	 * @return array<string, string> Modified templates array including plugin templates.
 	 */
 	public static function register( $templates ) {
-		// Don't register templates for block themes - they use block-based templates only
+		// Don't register templates for block themes; they use block-based templates only.
 		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 			return $templates;
 		}
 
-		foreach ( self::$templates as $file => $label ) {
-			$templates[ $file ] = __( $label, 'wpfaevent' );
+		foreach ( self::get_localized_template_labels() as $file => $label ) {
+			$templates[ $file ] = $label;
 		}
 
 		return $templates;
@@ -97,6 +122,14 @@ class WPFA_Templates {
 		// Don't load templates for block themes.
 		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 			return $template;
+		}
+
+		if ( is_singular( 'wpfa_speaker' ) ) {
+			$candidate = WPFAEVENT_PATH . 'public/templates/single-wpfa-speaker.php';
+
+			if ( file_exists( $candidate ) ) {
+				return $candidate;
+			}
 		}
 
 		if ( is_singular( 'page' ) ) {

--- a/includes/meta/class-wpfaevent-meta-speaker.php
+++ b/includes/meta/class-wpfaevent-meta-speaker.php
@@ -31,67 +31,66 @@ class Wpfaevent_Meta_Speaker {
 	 * @since 1.0.0
 	 */
 	public static function register() {
-		// Speaker position/title
-		register_post_meta(
-			self::$post_type,
-			'wpfa_speaker_position',
-			array(
-				'type'              => 'string',
-				'single'            => true,
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'sanitize_text_field',
+		$string_meta_fields = array(
+			'wpfa_speaker_position'      => array(
 				'description'       => __( 'Speaker position/title', 'wpfaevent' ),
-			)
-		);
-
-		// Speaker organization
-		register_post_meta(
-			self::$post_type,
-			'wpfa_speaker_organization',
-			array(
-				'type'              => 'string',
-				'single'            => true,
-				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'wpfa_speaker_organization'  => array(
 				'description'       => __( 'Speaker organization', 'wpfaevent' ),
-			)
-		);
-
-		// Speaker bio
-		register_post_meta(
-			self::$post_type,
-			'wpfa_speaker_bio',
-			array(
-				'type'              => 'string',
-				'single'            => true,
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'wp_kses_post',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'wpfa_speaker_bio'           => array(
 				'description'       => __( 'Speaker biography', 'wpfaevent' ),
-			)
-		);
-
-		// Speaker headshot URL
-		register_post_meta(
-			self::$post_type,
-			'wpfa_speaker_headshot_url',
-			array(
-				'type'              => 'string',
-				'single'            => true,
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'esc_url_raw',
+				'sanitize_callback' => 'wp_kses_post',
+			),
+			'wpfa_speaker_headshot_url'  => array(
 				'description'       => __( 'Speaker headshot image URL', 'wpfaevent' ),
-			)
+				'sanitize_callback' => 'esc_url_raw',
+			),
+			'wpfa_speaker_linkedin'      => array(
+				'description'       => __( 'Speaker LinkedIn URL', 'wpfaevent' ),
+				'sanitize_callback' => 'esc_url_raw',
+			),
+			'wpfa_speaker_twitter'       => array(
+				'description'       => __( 'Speaker Twitter URL', 'wpfaevent' ),
+				'sanitize_callback' => 'esc_url_raw',
+			),
+			'wpfa_speaker_github'        => array(
+				'description'       => __( 'Speaker GitHub URL', 'wpfaevent' ),
+				'sanitize_callback' => 'esc_url_raw',
+			),
+			'wpfa_speaker_website'       => array(
+				'description'       => __( 'Speaker website URL', 'wpfaevent' ),
+				'sanitize_callback' => 'esc_url_raw',
+			),
+			'wpfa_speaker_talk_title'    => array(
+				'description'       => __( 'Speaker session title', 'wpfaevent' ),
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'wpfa_speaker_talk_date'     => array(
+				'description'       => __( 'Speaker session date', 'wpfaevent' ),
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'wpfa_speaker_talk_time'     => array(
+				'description'       => __( 'Speaker session start time', 'wpfaevent' ),
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'wpfa_speaker_talk_end_time' => array(
+				'description'       => __( 'Speaker session end time', 'wpfaevent' ),
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'wpfa_speaker_talk_abstract' => array(
+				'description'       => __( 'Speaker session abstract', 'wpfaevent' ),
+				'sanitize_callback' => 'wp_kses_post',
+			),
 		);
 
-		// Related events (for bidirectional relationship)
-		// TODO: Future PR - Implement bidirectional event-speaker relationship UI
-		// This meta field is registered for REST API support but has no admin UI yet.
-		// Action items for future implementation:
-		// 1. Add meta box to Speaker edit screen with event multi-select dropdown
-		// 2. Add save handler in Wpfaevent_Admin::save_speaker_meta()
-		// 3. Implement sync logic: when event assigns speakers, update speaker's events
-		// 4. Consider using post_relationships table instead of meta for better performance
-		// Related: wpfa_event_speakers in class-wpfaevent-meta-event.php
+		foreach ( $string_meta_fields as $meta_key => $args ) {
+			self::register_string_meta( $meta_key, $args['description'], $args['sanitize_callback'] );
+		}
+
+		// Related events for the bidirectional event-speaker relationship.
 		register_post_meta(
 			self::$post_type,
 			'wpfa_speaker_events',
@@ -113,6 +112,30 @@ class Wpfaevent_Meta_Speaker {
 	}
 
 	/**
+	 * Registers a single speaker string meta field.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string          $meta_key          Meta key to register.
+	 * @param string          $description       REST/API field description.
+	 * @param callable|string $sanitize_callback Sanitization callback.
+	 * @return void
+	 */
+	private static function register_string_meta( $meta_key, $description, $sanitize_callback ) {
+		register_post_meta(
+			self::$post_type,
+			$meta_key,
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => $sanitize_callback,
+				'description'       => $description,
+			)
+		);
+	}
+
+	/**
 	 * Sanitizes an array of event IDs.
 	 *
 	 * @since 1.0.0
@@ -124,6 +147,9 @@ class Wpfaevent_Meta_Speaker {
 			return array();
 		}
 
-		return array_map( 'absint', $event_ids );
+		$event_ids = array_map( 'absint', $event_ids );
+		$event_ids = array_filter( $event_ids );
+
+		return array_values( array_unique( $event_ids ) );
 	}
 }

--- a/public/class-wpfaevent-public.php
+++ b/public/class-wpfaevent-public.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * The public-facing functionality of the plugin.
  *
@@ -75,7 +74,7 @@ class Wpfaevent_Public {
 			}
 		}
 
-		return false;
+		return is_singular( 'wpfa_speaker' );
 	}
 
 	/**
@@ -114,7 +113,7 @@ class Wpfaevent_Public {
 			'text'       => get_option( 'wpfa_text_color', '#0b0b0b' ),
 		);
 
-		// Allow filtering
+		// Allow filtering.
 		$colors['brand']      = apply_filters( 'wpfa_brand_color', $colors['brand'] );
 		$colors['background'] = apply_filters( 'wpfa_background_color', $colors['background'] );
 		$colors['text']       = apply_filters( 'wpfa_text_color', $colors['text'] );
@@ -161,45 +160,45 @@ class Wpfaevent_Public {
 		// Base public styles (global, shared).
 		wp_enqueue_style(
 			$this->plugin_name,
-			plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/wpfaevent-public.css',
+			plugin_dir_url( __DIR__ ) . 'public/css/wpfaevent-public.css',
 			array(),
 			$this->version,
 			'all'
 		);
 
-		// Only load component/template styles when WPFA template is active
+		// Only load component/template styles when WPFA template is active.
 		if ( ! $this->is_wpfa_template() ) {
 			return;
 		}
 
-		// Navigation component (shared across templates)
+		// Navigation component (shared across templates).
 		wp_enqueue_style(
 			$this->plugin_name . '-navigation',
-			plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/components/navigation.css',
+			plugin_dir_url( __DIR__ ) . 'public/css/components/navigation.css',
 			array( $this->plugin_name ),
 			$this->version,
 			'all'
 		);
 
-		// Pagination component (only templates with pagination)
+		// Pagination component (only templates with pagination).
 		if ( $this->is_paginated_template() ) {
 			wp_enqueue_style(
 				$this->plugin_name . '-pagination',
-				plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/components/pagination.css',
+				plugin_dir_url( __DIR__ ) . 'public/css/components/pagination.css',
 				array( $this->plugin_name ),
 				$this->version,
 				'all'
 			);
 		}
 
-		// Add dynamic CSS variables
+		// Add dynamic CSS variables.
 		wp_add_inline_style( $this->plugin_name, $this->generate_color_css() );
 
 		// Template-specific styles.
 		if ( is_page_template( 'page-code-of-conduct.php' ) ) {
 			wp_enqueue_style(
 				$this->plugin_name . '-code-of-conduct',
-				plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/templates/code-of-conduct.css',
+				plugin_dir_url( __DIR__ ) . 'public/css/templates/code-of-conduct.css',
 				array(
 					$this->plugin_name,
 					$this->plugin_name . '-navigation',
@@ -212,7 +211,7 @@ class Wpfaevent_Public {
 		if ( is_page_template( 'page-speakers.php' ) ) {
 			wp_enqueue_style(
 				$this->plugin_name . '-speakers',
-				plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/templates/speakers.css',
+				plugin_dir_url( __DIR__ ) . 'public/css/templates/speakers.css',
 				array(
 					$this->plugin_name,
 					$this->plugin_name . '-navigation',
@@ -222,7 +221,7 @@ class Wpfaevent_Public {
 				'all'
 			);
 
-			// Enqueue speakers JavaScript
+			// Enqueue speakers JavaScript.
 			wp_enqueue_script(
 				$this->plugin_name . '-speakers',
 				plugin_dir_url( __FILE__ ) . 'js/wpfaevent-speakers.js',
@@ -231,17 +230,17 @@ class Wpfaevent_Public {
 				true
 			);
 
-			// Pass data from PHP to JavaScript
+			// Pass data from PHP to JavaScript.
 			wp_localize_script(
 				$this->plugin_name . '-speakers',
-				'wpfaeventSpeakersConfig',      // JavaScript object name
+				'wpfaeventSpeakersConfig',
 				array(
 					'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
 					'adminNonce' => wp_create_nonce( 'wpfa_speakers_ajax' ),
 					'isAdmin'    => current_user_can( 'manage_options' ),
 
-					// All translatable strings
 					'i18n'       => array(
+						/* translators: %s: speaker name. */
 						'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
 						'deleteSuccess'      => __( 'Speaker deleted successfully. The page will now reload.', 'wpfaevent' ),
 						'deleteError'        => __( 'Error deleting speaker', 'wpfaevent' ),
@@ -256,17 +255,31 @@ class Wpfaevent_Public {
 						'fetchError'         => __( 'Error fetching speaker data', 'wpfaevent' ),
 						'fetchErrorGeneric'  => __( 'Error fetching speaker data. Please try again.', 'wpfaevent' ),
 						'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
+						/* translators: %d: number of speakers shown. */
 						'resultsCount'       => __( 'Showing %d speakers', 'wpfaevent' ),
 					),
 				)
 			);
 		}
 
-		// Past Events template
+		if ( is_singular( 'wpfa_speaker' ) ) {
+			wp_enqueue_style(
+				$this->plugin_name . '-speakers',
+				plugin_dir_url( __DIR__ ) . 'public/css/templates/speakers.css',
+				array(
+					$this->plugin_name,
+					$this->plugin_name . '-navigation',
+				),
+				$this->version,
+				'all'
+			);
+		}
+
+		// Past Events template.
 		if ( is_page_template( 'page-past-events.php' ) ) {
 			wp_enqueue_style(
 				$this->plugin_name . '-past-events',
-				plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/templates/past-events.css',
+				plugin_dir_url( __DIR__ ) . 'public/css/templates/past-events.css',
 				array(
 					$this->plugin_name,
 					$this->plugin_name . '-navigation',
@@ -274,59 +287,6 @@ class Wpfaevent_Public {
 				),
 				$this->version,
 				'all'
-			);
-		}
-
-		if ( is_page_template( 'page-speakers.php' ) ) {
-			wp_enqueue_style(
-				$this->plugin_name . '-speakers',
-				plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/templates/speakers.css',
-				array(
-					$this->plugin_name,
-					$this->plugin_name . '-navigation',
-					$this->plugin_name . '-pagination',
-				),
-				$this->version,
-				'all'
-			);
-
-			// Enqueue speakers JavaScript
-			wp_enqueue_script(
-				$this->plugin_name . '-speakers',
-				plugin_dir_url( __FILE__ ) . 'js/wpfaevent-speakers.js',
-				array( 'jquery' ),
-				$this->version,
-				true
-			);
-
-			// Pass data from PHP to JavaScript
-			wp_localize_script(
-				$this->plugin_name . '-speakers',
-				'wpfaeventSpeakersConfig',      // JavaScript object name
-				array(
-					'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
-					'adminNonce' => wp_create_nonce( 'wpfa_speakers_ajax' ),
-					'isAdmin'    => current_user_can( 'manage_options' ),
-
-					// All translatable strings
-					'i18n'       => array(
-						'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
-						'deleteSuccess'      => __( 'Speaker deleted successfully. The page will now reload.', 'wpfaevent' ),
-						'deleteError'        => __( 'Error deleting speaker', 'wpfaevent' ),
-						'deleteErrorGeneric' => __( 'Error deleting speaker. Please try again.', 'wpfaevent' ),
-						'addSuccess'         => __( 'Speaker added successfully. The page will now reload.', 'wpfaevent' ),
-						'addError'           => __( 'Error adding speaker', 'wpfaevent' ),
-						'addErrorGeneric'    => __( 'Error adding speaker. Please try again.', 'wpfaevent' ),
-						'updateSuccess'      => __( 'Speaker updated successfully. The page will now reload.', 'wpfaevent' ),
-						'updateError'        => __( 'Error updating speaker', 'wpfaevent' ),
-						'updateErrorGeneric' => __( 'Error updating speaker. Please try again.', 'wpfaevent' ),
-						'loadError'          => __( 'Error loading speaker data', 'wpfaevent' ),
-						'fetchError'         => __( 'Error fetching speaker data', 'wpfaevent' ),
-						'fetchErrorGeneric'  => __( 'Error fetching speaker data. Please try again.', 'wpfaevent' ),
-						'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
-						'resultsCount'       => __( 'Showing %d speakers', 'wpfaevent' ),
-					),
-				)
 			);
 		}
 
@@ -348,7 +308,7 @@ class Wpfaevent_Public {
 		* if ( is_page_template( 'page-speakers.php' ) ) {
 		*     wp_enqueue_style(
 		*         $this->plugin_name . '-speakers',
-		*         plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/templates/speakers.css',
+		*         plugin_dir_url( __DIR__ ) . 'public/css/templates/speakers.css',
 		*         array(
 		*             $this->plugin_name,
 		*             $this->plugin_name . '-navigation',

--- a/public/css/templates/speakers.css
+++ b/public/css/templates/speakers.css
@@ -545,3 +545,146 @@
 	background: #e9ecef;
 	color: #333;
 }
+
+/* ==========================================================================
+   SINGLE SPEAKER PROFILE
+   ========================================================================== */
+
+.wpfaevent .wpfa-speaker-profile-hero {
+	background: #fff;
+	border-bottom: 1px solid #eee;
+}
+
+.wpfaevent .wpfa-speaker-profile-hero-inner {
+	display: grid;
+	grid-template-columns: minmax(220px, 320px) 1fr;
+	gap: 36px;
+	align-items: start;
+	padding-top: 56px;
+	padding-bottom: 56px;
+}
+
+.wpfaevent .wpfa-speaker-profile-photo {
+	aspect-ratio: 1;
+	background: linear-gradient(135deg, #e9e9e9, #f6f6f6);
+	border-radius: var(--card-radius);
+	overflow: hidden;
+	box-shadow: var(--shadow);
+}
+
+.wpfaevent .wpfa-speaker-profile-photo img,
+.wpfaevent .wpfa-speaker-profile-photo svg {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: center top;
+}
+
+.wpfaevent .wpfa-speaker-profile-summary h1 {
+	margin: 10px 0 8px;
+	color: var(--brand);
+	font-size: 2.5rem;
+	line-height: 1.1;
+}
+
+.wpfaevent .wpfa-speaker-profile-categories {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.wpfaevent .wpfa-speaker-profile-role {
+	margin: 0 0 20px;
+	color: var(--muted);
+	font-size: 1.1rem;
+}
+
+.wpfaevent .wpfa-speaker-profile-bio {
+	max-width: 75ch;
+	font-size: 16px;
+	line-height: 1.7;
+	color: #333;
+}
+
+.wpfaevent .wpfa-speaker-profile-bio p:first-child {
+	margin-top: 0;
+}
+
+.wpfaevent .wpfa-speaker-profile-bio p:last-child {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-speaker-profile-social {
+	margin-top: 24px;
+}
+
+.wpfaevent .wpfa-linked-events {
+	padding: 48px 0;
+}
+
+.wpfaevent .wpfa-linked-events h2 {
+	margin: 0 0 24px;
+	color: var(--text);
+	font-size: 2rem;
+}
+
+.wpfaevent .wpfa-linked-events-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+	gap: 18px;
+}
+
+.wpfaevent .wpfa-linked-event-card {
+	background: #fff;
+	border: 1px solid #eee;
+	border-radius: var(--card-radius);
+	box-shadow: var(--shadow);
+	padding: 20px;
+}
+
+.wpfaevent .wpfa-linked-event-card h3 {
+	margin: 0 0 10px;
+	font-size: 1.2rem;
+	line-height: 1.3;
+}
+
+.wpfaevent .wpfa-linked-event-card p {
+	margin: 0 0 10px;
+	color: #333;
+	line-height: 1.6;
+}
+
+.wpfaevent .wpfa-linked-event-card p:last-child {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-linked-event-meta {
+	color: var(--muted);
+	font-size: 14px;
+}
+
+.wpfaevent .wpfa-empty-state {
+	margin: 0;
+	color: var(--muted);
+	background: #fff;
+	border: 1px solid #eee;
+	border-radius: var(--card-radius);
+	padding: 20px;
+}
+
+@media (max-width: 760px) {
+	.wpfaevent .wpfa-speaker-profile-hero-inner {
+		grid-template-columns: 1fr;
+		gap: 24px;
+		padding-top: 32px;
+		padding-bottom: 32px;
+	}
+
+	.wpfaevent .wpfa-speaker-profile-photo {
+		max-width: 280px;
+	}
+
+	.wpfaevent .wpfa-speaker-profile-summary h1 {
+		font-size: 2rem;
+	}
+}

--- a/public/css/templates/speakers.css
+++ b/public/css/templates/speakers.css
@@ -618,6 +618,52 @@
 	margin-top: 24px;
 }
 
+.wpfaevent .wpfa-speaker-sessions {
+	background: #f8f9fa;
+	padding: 48px 0;
+}
+
+.wpfaevent .wpfa-speaker-sessions h2 {
+	margin: 0 0 24px;
+	color: var(--text);
+	font-size: 2rem;
+}
+
+.wpfaevent .wpfa-speaker-session-card {
+	max-width: 760px;
+	background: #fff;
+	border: 1px solid #eee;
+	border-radius: var(--card-radius);
+	box-shadow: var(--shadow);
+	padding: 24px;
+}
+
+.wpfaevent .wpfa-speaker-session-card h3 {
+	margin: 0 0 10px;
+	color: var(--brand);
+	font-size: 1.35rem;
+	line-height: 1.3;
+}
+
+.wpfaevent .wpfa-speaker-session-meta {
+	margin: 0 0 16px;
+	color: var(--muted);
+	font-size: 14px;
+}
+
+.wpfaevent .wpfa-speaker-session-abstract {
+	color: #333;
+	line-height: 1.7;
+}
+
+.wpfaevent .wpfa-speaker-session-abstract p:first-child {
+	margin-top: 0;
+}
+
+.wpfaevent .wpfa-speaker-session-abstract p:last-child {
+	margin-bottom: 0;
+}
+
 .wpfaevent .wpfa-linked-events {
 	padding: 48px 0;
 }

--- a/public/templates/single-wpfa-speaker.php
+++ b/public/templates/single-wpfa-speaker.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Single Speaker Profile Template.
+ *
+ * Displays an individual speaker profile and events linked through the
+ * `wpfa_event_speakers` relationship.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/templates
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$speaker_id = get_queried_object_id();
+
+if ( ! $speaker_id || 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
+	return;
+}
+
+$speaker_name = get_the_title( $speaker_id );
+$position     = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_position', true ) );
+$organization = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_organization', true ) );
+$bio          = get_post_meta( $speaker_id, 'wpfa_speaker_bio', true );
+$photo_url    = get_post_meta( $speaker_id, 'wpfa_speaker_headshot_url', true );
+$linkedin     = get_post_meta( $speaker_id, 'wpfa_speaker_linkedin', true );
+$twitter      = get_post_meta( $speaker_id, 'wpfa_speaker_twitter', true );
+$github       = get_post_meta( $speaker_id, 'wpfa_speaker_github', true );
+$website      = get_post_meta( $speaker_id, 'wpfa_speaker_website', true );
+$photo_alt    = sprintf(
+	/* translators: %s: Speaker name. */
+	__( 'Photo of %s', 'wpfaevent' ),
+	$speaker_name
+);
+
+if ( empty( $bio ) ) {
+	$bio = get_post_field( 'post_content', $speaker_id );
+}
+
+if ( empty( $photo_url ) && has_post_thumbnail( $speaker_id ) ) {
+	$photo_url = get_the_post_thumbnail_url( $speaker_id, 'large' );
+}
+
+$speaker_categories = array();
+if ( taxonomy_exists( 'wpfa_speaker_category' ) ) {
+	$terms = wp_get_post_terms( $speaker_id, 'wpfa_speaker_category' );
+
+	if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+		$speaker_categories = wp_list_pluck( $terms, 'name' );
+	}
+}
+
+$stored_event_ids = get_post_meta( $speaker_id, 'wpfa_speaker_events', true );
+$stored_event_ids = is_array( $stored_event_ids ) ? array_map( 'absint', $stored_event_ids ) : array();
+$stored_event_ids = array_filter( $stored_event_ids );
+
+$relationship_event_ids = get_posts(
+	array(
+		'post_type'      => 'wpfa_event',
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
+		'meta_query'     => array(
+			'relation' => 'OR',
+			array(
+				'key'     => 'wpfa_event_speakers',
+				'value'   => 'i:' . $speaker_id . ';',
+				'compare' => 'LIKE',
+			),
+			array(
+				'key'     => 'wpfa_event_speakers',
+				'value'   => '"' . $speaker_id . '"',
+				'compare' => 'LIKE',
+			),
+			array(
+				'key'     => 'wpfa_event_speakers',
+				'value'   => (string) $speaker_id,
+				'compare' => '=',
+			),
+		),
+	)
+);
+
+$linked_event_ids = array_values(
+	array_unique(
+		array_filter(
+			array_map(
+				'absint',
+				array_merge( $stored_event_ids, $relationship_event_ids )
+			)
+		)
+	)
+);
+
+usort(
+	$linked_event_ids,
+	static function ( $event_a_id, $event_b_id ) {
+		$event_a_start = sanitize_text_field( get_post_meta( $event_a_id, 'wpfa_event_start_date', true ) );
+		$event_b_start = sanitize_text_field( get_post_meta( $event_b_id, 'wpfa_event_start_date', true ) );
+
+		if ( $event_a_start === $event_b_start ) {
+			return strcasecmp( get_the_title( $event_a_id ), get_the_title( $event_b_id ) );
+		}
+
+		if ( '' === $event_a_start ) {
+			return 1;
+		}
+
+		if ( '' === $event_b_start ) {
+			return -1;
+		}
+
+		return strcmp( $event_a_start, $event_b_start );
+	}
+);
+
+$site_logo_url = get_option( 'wpfa_site_logo_url', '' );
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+
+$speakers_page_url   = apply_filters( 'wpfa_speakers_page_url', home_url( '/speakers/' ) );
+$register_button_url = get_option( 'wpfa_register_button_url', 'https://eventyay.com/e/4c0e0c27' );
+$register_button_url = apply_filters( 'wpfa_register_button_url', $register_button_url );
+
+$header_vars = array(
+	'site_logo_url'        => $site_logo_url,
+	'event_page_url'       => $speakers_page_url,
+	'show_back_button'     => true,
+	'show_register_button' => true,
+	'back_button_text'     => __( 'Back to Speakers', 'wpfaevent' ),
+	'register_button_url'  => $register_button_url,
+	'register_button_text' => __( 'Register', 'wpfaevent' ),
+);
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class( 'wpfaevent wpfa-speaker-profile-template' ); ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+	<?php
+	$site_logo_url        = $header_vars['site_logo_url'];
+	$event_page_url       = $header_vars['event_page_url'];
+	$show_back_button     = $header_vars['show_back_button'];
+	$show_register_button = $header_vars['show_register_button'];
+	$back_button_text     = $header_vars['back_button_text'];
+	$register_button_url  = $header_vars['register_button_url'];
+	$register_button_text = $header_vars['register_button_text'];
+
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
+
+	<main class="wpfa-speaker-profile" itemscope itemtype="https://schema.org/Person">
+		<section class="wpfa-speaker-profile-hero">
+			<div class="container wpfa-speaker-profile-hero-inner">
+				<div class="wpfa-speaker-profile-photo">
+					<?php if ( $photo_url ) : ?>
+						<img
+							src="<?php echo esc_url( $photo_url ); ?>"
+							alt="<?php echo esc_attr( $photo_alt ); ?>"
+							itemprop="image"
+						>
+					<?php else : ?>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 300 300"
+							class="wpfa-placeholder-svg"
+							role="img"
+							aria-label="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>"
+						>
+							<rect width="100%" height="100%" fill="#eee" />
+							<text
+								x="50%"
+								y="50%"
+								dominant-baseline="middle"
+								text-anchor="middle"
+								font-family="sans-serif"
+								font-size="20"
+								fill="#999"
+							>
+								Speaker
+							</text>
+						</svg>
+					<?php endif; ?>
+				</div>
+
+				<div class="wpfa-speaker-profile-summary">
+					<?php if ( ! empty( $speaker_categories ) ) : ?>
+						<div class="wpfa-speaker-profile-categories">
+							<?php foreach ( $speaker_categories as $speaker_category ) : ?>
+								<span class="pill"><?php echo esc_html( $speaker_category ); ?></span>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+
+					<h1 itemprop="name"><?php echo esc_html( $speaker_name ); ?></h1>
+
+					<?php if ( $position || $organization ) : ?>
+						<p class="wpfa-speaker-profile-role">
+							<?php echo esc_html( trim( $position . ( $position && $organization ? ' | ' : '' ) . $organization ) ); ?>
+						</p>
+					<?php endif; ?>
+
+					<?php if ( $bio ) : ?>
+						<div class="wpfa-speaker-profile-bio" itemprop="description">
+							<?php echo wp_kses_post( wpautop( $bio ) ); ?>
+						</div>
+					<?php endif; ?>
+
+					<?php if ( $linkedin || $twitter || $github || $website ) : ?>
+						<div class="wpfa-speaker-social wpfa-speaker-profile-social">
+							<?php if ( $linkedin ) : ?>
+								<a
+									href="<?php echo esc_url( $linkedin ); ?>"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="wpfa-social-link"
+									itemprop="sameAs"
+								>
+									<?php esc_html_e( 'LinkedIn', 'wpfaevent' ); ?>
+								</a>
+							<?php endif; ?>
+							<?php if ( $twitter ) : ?>
+								<a
+									href="<?php echo esc_url( $twitter ); ?>"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="wpfa-social-link"
+									itemprop="sameAs"
+								>
+									<?php esc_html_e( 'Twitter', 'wpfaevent' ); ?>
+								</a>
+							<?php endif; ?>
+							<?php if ( $github ) : ?>
+								<a
+									href="<?php echo esc_url( $github ); ?>"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="wpfa-social-link"
+									itemprop="sameAs"
+								>
+									<?php esc_html_e( 'GitHub', 'wpfaevent' ); ?>
+								</a>
+							<?php endif; ?>
+							<?php if ( $website ) : ?>
+								<a
+									href="<?php echo esc_url( $website ); ?>"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="wpfa-social-link"
+									itemprop="sameAs"
+								>
+									<?php esc_html_e( 'Website', 'wpfaevent' ); ?>
+								</a>
+							<?php endif; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			</div>
+		</section>
+
+		<section class="wpfa-linked-events" aria-labelledby="wpfa-linked-events-title">
+			<div class="container">
+				<h2 id="wpfa-linked-events-title"><?php esc_html_e( 'Linked Events', 'wpfaevent' ); ?></h2>
+
+				<?php if ( ! empty( $linked_event_ids ) ) : ?>
+					<div class="wpfa-linked-events-grid">
+						<?php foreach ( $linked_event_ids as $event_id ) : ?>
+							<?php
+							$event_title = get_the_title( $event_id );
+							$event_start = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
+							$event_end   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
+							$event_loc   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+							$event_url   = get_post_meta( $event_id, 'wpfa_event_url', true );
+							$event_url   = $event_url ? $event_url : get_permalink( $event_id );
+							$event_meta  = array();
+
+							if ( $event_start ) {
+								$event_meta[] = $event_start . ( $event_end ? ' - ' . $event_end : '' );
+							}
+
+							if ( $event_loc ) {
+								$event_meta[] = $event_loc;
+							}
+							?>
+							<article class="wpfa-linked-event-card">
+								<h3><a href="<?php echo esc_url( $event_url ); ?>"><?php echo esc_html( $event_title ); ?></a></h3>
+
+								<?php if ( ! empty( $event_meta ) ) : ?>
+									<p class="wpfa-linked-event-meta"><?php echo esc_html( implode( ' | ', $event_meta ) ); ?></p>
+								<?php endif; ?>
+
+								<?php if ( has_excerpt( $event_id ) ) : ?>
+									<p><?php echo esc_html( get_the_excerpt( $event_id ) ); ?></p>
+								<?php endif; ?>
+							</article>
+						<?php endforeach; ?>
+					</div>
+				<?php else : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'No linked events found for this speaker yet.', 'wpfaevent' ); ?></p>
+				<?php endif; ?>
+			</div>
+		</section>
+	</main>
+
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
+</div><!-- #page -->
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/public/templates/single-wpfa-speaker.php
+++ b/public/templates/single-wpfa-speaker.php
@@ -20,16 +20,21 @@ if ( ! $speaker_id || 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
 	return;
 }
 
-$speaker_name = get_the_title( $speaker_id );
-$position     = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_position', true ) );
-$organization = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_organization', true ) );
-$bio          = get_post_meta( $speaker_id, 'wpfa_speaker_bio', true );
-$photo_url    = get_post_meta( $speaker_id, 'wpfa_speaker_headshot_url', true );
-$linkedin     = get_post_meta( $speaker_id, 'wpfa_speaker_linkedin', true );
-$twitter      = get_post_meta( $speaker_id, 'wpfa_speaker_twitter', true );
-$github       = get_post_meta( $speaker_id, 'wpfa_speaker_github', true );
-$website      = get_post_meta( $speaker_id, 'wpfa_speaker_website', true );
-$photo_alt    = sprintf(
+$speaker_name  = get_the_title( $speaker_id );
+$position      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_position', true ) );
+$organization  = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_organization', true ) );
+$bio           = get_post_meta( $speaker_id, 'wpfa_speaker_bio', true );
+$photo_url     = get_post_meta( $speaker_id, 'wpfa_speaker_headshot_url', true );
+$linkedin      = get_post_meta( $speaker_id, 'wpfa_speaker_linkedin', true );
+$twitter       = get_post_meta( $speaker_id, 'wpfa_speaker_twitter', true );
+$github        = get_post_meta( $speaker_id, 'wpfa_speaker_github', true );
+$website       = get_post_meta( $speaker_id, 'wpfa_speaker_website', true );
+$talk_title    = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_title', true ) );
+$talk_date     = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_date', true ) );
+$talk_start    = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_time', true ) );
+$talk_end      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_end_time', true ) );
+$talk_abstract = get_post_meta( $speaker_id, 'wpfa_speaker_talk_abstract', true );
+$photo_alt     = sprintf(
 	/* translators: %s: Speaker name. */
 	__( 'Photo of %s', 'wpfaevent' ),
 	$speaker_name
@@ -51,6 +56,17 @@ if ( taxonomy_exists( 'wpfa_speaker_category' ) ) {
 		$speaker_categories = wp_list_pluck( $terms, 'name' );
 	}
 }
+
+$session_meta = array();
+if ( $talk_date ) {
+	$session_meta[] = $talk_date;
+}
+
+if ( $talk_start || $talk_end ) {
+	$session_meta[] = trim( $talk_start . ( $talk_start && $talk_end ? ' - ' : '' ) . $talk_end );
+}
+
+$has_session_details = $talk_title || $talk_date || $talk_start || $talk_end || $talk_abstract;
 
 $stored_event_ids = get_post_meta( $speaker_id, 'wpfa_speaker_events', true );
 $stored_event_ids = is_array( $stored_event_ids ) ? array_map( 'absint', $stored_event_ids ) : array();
@@ -268,16 +284,40 @@ $header_vars = array(
 								</a>
 							<?php endif; ?>
 						</div>
-					<?php endif; ?>
+						<?php endif; ?>
+					</div>
 				</div>
-			</div>
-		</section>
+			</section>
 
-		<section class="wpfa-linked-events" aria-labelledby="wpfa-linked-events-title">
-			<div class="container">
-				<h2 id="wpfa-linked-events-title"><?php esc_html_e( 'Linked Events', 'wpfaevent' ); ?></h2>
+			<?php if ( $has_session_details ) : ?>
+				<section class="wpfa-speaker-sessions" aria-labelledby="wpfa-speaker-sessions-title">
+					<div class="container">
+						<h2 id="wpfa-speaker-sessions-title"><?php esc_html_e( 'Sessions by this speaker', 'wpfaevent' ); ?></h2>
 
-				<?php if ( ! empty( $linked_event_ids ) ) : ?>
+						<article class="wpfa-speaker-session-card" itemprop="performerIn" itemscope itemtype="https://schema.org/Event">
+							<?php if ( $talk_title ) : ?>
+								<h3 itemprop="name"><?php echo esc_html( $talk_title ); ?></h3>
+							<?php endif; ?>
+
+							<?php if ( ! empty( $session_meta ) ) : ?>
+								<p class="wpfa-speaker-session-meta"><?php echo esc_html( implode( ' | ', $session_meta ) ); ?></p>
+							<?php endif; ?>
+
+							<?php if ( $talk_abstract ) : ?>
+								<div class="wpfa-speaker-session-abstract" itemprop="description">
+									<?php echo wp_kses_post( wpautop( $talk_abstract ) ); ?>
+								</div>
+							<?php endif; ?>
+						</article>
+					</div>
+				</section>
+			<?php endif; ?>
+
+			<section class="wpfa-linked-events" aria-labelledby="wpfa-linked-events-title">
+				<div class="container">
+					<h2 id="wpfa-linked-events-title"><?php esc_html_e( 'Linked Events', 'wpfaevent' ); ?></h2>
+
+					<?php if ( ! empty( $linked_event_ids ) ) : ?>
 					<div class="wpfa-linked-events-grid">
 						<?php foreach ( $linked_event_ids as $event_id ) : ?>
 							<?php

--- a/wpfaevent.php
+++ b/wpfaevent.php
@@ -1,7 +1,6 @@
 <?php
-
 /**
- * The plugin bootstrap file
+ * The plugin bootstrap file.
  *
  * This file is read by WordPress to generate the plugin information in the plugin
  * admin area. This file also includes all of the dependencies used by the plugin,
@@ -34,12 +33,12 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version.
  */
-// Define constants
+// Define constants.
 define( 'WPFAEVENT_VERSION', '1.0.0' );
 define( 'WPFAEVENT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPFAEVENT_URL', plugin_dir_url( __FILE__ ) );
 
-// Requires
+// Requires.
 require_once WPFAEVENT_PATH . 'includes/class-wpfaevent-i18n.php';
 require_once WPFAEVENT_PATH . 'includes/class-wpfaevent-loader.php';
 require_once WPFAEVENT_PATH . 'includes/class-wpfaevent-activator.php';
@@ -47,9 +46,9 @@ require_once WPFAEVENT_PATH . 'includes/class-wpfaevent-deactivator.php';
 require_once WPFAEVENT_PATH . 'includes/class-wpfaevent-templates.php';
 require_once WPFAEVENT_PATH . 'includes/helpers/wpfaevent-pagination-helper.php';
 
-// Activation / Deactivation hooks
-register_activation_hook( __FILE__, [ 'Wpfaevent_Activator', 'activate' ] );
-register_deactivation_hook( __FILE__, [ 'Wpfaevent_Deactivator', 'deactivate' ] );
+// Activation / Deactivation hooks.
+register_activation_hook( __FILE__, array( 'Wpfaevent_Activator', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'Wpfaevent_Deactivator', 'deactivate' ) );
 
 /**
  * The core plugin class that is used to define internationalization,
@@ -68,18 +67,18 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-wpfaevent.php';
  */
 function run_wpfaevent() {
 
-	// Load translations
+	// Load translations.
 	if ( class_exists( 'Wpfaevent_i18n' ) ) {
 		$i18n = new Wpfaevent_i18n();
 		$i18n->load_plugin_textdomain();
 	}
 
-	// Initialize page templates
-	if ( class_exists( 'WPFA_Templates' ) ) {
-		WPFA_Templates::init();
+	// Initialize page templates.
+	if ( class_exists( 'Wpfaevent_Templates' ) ) {
+		Wpfaevent_Templates::init();
 	}
 
-	// Run the core plugin
+	// Run the core plugin.
 	if ( class_exists( 'Wpfaevent' ) ) {
 		$plugin = new Wpfaevent();
 		$plugin->run();
@@ -91,5 +90,5 @@ run_wpfaevent();
 // Register WP-CLI commands when running in CLI context.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once WPFAEVENT_PATH . 'includes/cli/class-wpfa-cli.php';
-	WP_CLI::add_command( 'wpfa seed', [ 'WPFA_CLI', 'seed' ] );
+	WP_CLI::add_command( 'wpfa seed', array( 'WPFA_CLI', 'seed' ) );
 }


### PR DESCRIPTION
## Summary
- add a dedicated single-speaker profile template for wpfa_speaker permalinks
- load the template for individual speaker URLs and enqueue speaker styles on those pages
- show linked events on the speaker profile using speaker/event relationship meta
- show the existing interim speaker talk fields as "Sessions by this speaker" until a reusable Session CPT/model exists
- register and expose speaker social and talk/session metadata through register_post_meta()
- add Schema.org Person/Event markup on the full speaker profile page
- document speaker fields, REST metadata, and event-speaker relationship structure

## Related
Part of #73

## Testing
- php -l public/templates/single-wpfa-speaker.php
- php -l includes/meta/class-wpfaevent-meta-speaker.php
- php -l includes/class-wpfaevent-templates.php
- php -l public/class-wpfaevent-public.php
- php -l wpfaevent.php
- composer phpcs public/templates/single-wpfa-speaker.php includes/meta/class-wpfaevent-meta-speaker.php includes/class-wpfaevent-templates.php public/class-wpfaevent-public.php wpfaevent.php
- local WP smoke test on http://gsoc.local/speakers/alex-example/ with temporary talk metadata, verified sessions section and linked events render
- checked wp-content/debug.log; no debug.log file exists