### PR TITLE
CI: Add PHPStan static analysis workflow to GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,77 @@
+name: Run PHPStan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  file-filter:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      php: ${{ steps.filter.outputs.php }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            php:
+              - '**/*.php'
+
+  phpstan-analysis:
+    name: PHPStan Static Code Analysis
+    needs: file-filter
+    if: |
+      always() &&
+      (github.event_name == 'push' || needs.file-filter.outputs.php == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP Environment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer, cs2pr
+
+      - name: Restore PHPStan Result Cache
+        id: phpstan-cache-restore
+        uses: actions/cache/restore@v5
+        with:
+          path: tmp/phpstan
+          key: phpstan-result-cache-${{ github.run_id }}
+          restore-keys: |
+            phpstan-result-cache-
+
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@v4
+        with:
+          composer-options: '--prefer-dist --optimize-autoloader --no-scripts'
+
+      - name: Run PHPStan Analysis
+        shell: bash
+        run: |
+          set -o pipefail
+          composer phpstan -- --error-format=checkstyle | cs2pr
+
+      - name: Save PHPStan Result Cache
+        uses: actions/cache/save@v5
+        if: ${{ !cancelled() }}
+        with:
+          path: tmp/phpstan
+          key: ${{ steps.phpstan-cache-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
## What This Workflow Does

This workflow runs PHPStan static analysis automatically on every push to `main` and every pull request targeting `main`.

On pull requests, a lightweight pre-filter job first checks whether any PHP files were modified. If no PHP files changed, the analysis job is skipped entirely, avoiding unnecessary CI cost. On direct pushes to `main`, the filter is bypassed and analysis always runs.

When analysis does run, it sets up a PHP 7.4 environment, installs Composer dependencies, and restores a cached PHPStan result cache from a previous run to speed up incremental analysis. PHPStan is then executed and its output is piped through `cs2pr`, which renders any violations as inline annotations directly on the changed files in the pull request diff. After analysis completes — whether it passes or fails — the updated result cache is saved for the next run.

Concurrency control ensures that if a new commit is pushed to a branch while a check is already running, the older run is cancelled automatically, keeping CI feedback fast and relevant.

## Changes Made

### 1. PHP-filtered job execution via `dorny/paths-filter`
- **Documentation**: https://github.com/dorny/paths-filter
- **Benefit**: Skips the analysis job entirely on PRs that contain no PHP file changes, reducing unnecessary CI runner usage.
- **Note**: On `push` events the filter job is skipped and the `phpstan` job always runs, handled via the `always()` condition guard.

### 2. Concurrency control
- **Documentation**
    - [GitHub Actions Concurrency Control](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency): Official documentation describing workflow-level concurrency groups, fallback patterns, and cancellation behavior used to prevent redundant CI runs in this workflow
- **Changes**:
  - Added `concurrency` block scoped to workflow + branch ref
  - `cancel-in-progress: true` cancels redundant runs when new commits are pushed to an active branch
  - Uses `${{ github.head_ref || github.ref_name }}` instead of `github.ref` — `head_ref` resolves to the PR branch name on pull request events, while `ref_name` is the fallback for push events; this prevents unrelated PRs from sharing a concurrency group

### 3. Composer dependency installation via `ramsey/composer-install`
- **Documentation**:
  - https://github.com/ramsey/composer-install
- **Changes**:
  - Uses `ramsey/composer-install` for Composer dependency installation with built-in dependency caching (no separate Composer cache action required)
  - Uses `--prefer-dist` for faster package downloads by preferring distribution archives over VCS clones
  - Uses `--optimize-autoloader` to generate an optimized autoloader for faster class resolution during analysis
  - Uses `--no-scripts` to skip Composer install hooks, reducing CI execution time and avoiding unnecessary side effects

### 4. PHP version pinned to `7.4`
- **Documentation**: https://github.com/shivammathur/setup-php
- **Reason**: Matches the project's minimum supported PHP runtime; catches syntax regressions against our target environment.

### 5. Inline PR annotations via `cs2pr`
- **Documentation**:
  - https://packagist.org/packages/staabm/annotate-pull-request-from-checkstyle
- **Changes**:
  - PHPStan output is piped through `--error-format=checkstyle` into `cs2pr`
  - Uses the documented `phpstan analyse --error-format=checkstyle | cs2pr` workflow pattern
  - Renders static analysis violations as inline file-level comments in the PR diff view rather than raw log output

### 6. Minimal permissions declared
- **Documentation**: 
    - [GitHub Workflow permissions syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions): Official documentation describing workflow and job-level permission scoping for GITHUB_TOKEN, used to implement least-privilege access in this workflow
- **Changes**:
  - Explicit `permissions` block with `contents: read` and `pull-requests: read`
  - Follows the principle of least privilege — no write access required for a read-only analysis job

### 7. Split PHPStan result cache (restore + save)
- **Documentation**
    - https://phpstan.org/user-guide/result-cache: Explains how PHPStan stores incremental analysis results in `tmpDir`, which is what this cache step persists across runs
- **Changes**:
  - Uses `actions/cache/restore@v4` and `actions/cache/save@v4` separately instead of the combined `actions/cache@v4`
  - The save step runs with `if: ${{ !cancelled() }}`, meaning the cache is written even when PHPStan finds errors — preserving partial analysis results for the next run
  - Cache key is scoped to `phpstan-result-cache-` with a prefix fallback, allowing stale-but-useful cache hits when inputs change
  - The combined `actions/cache` action only saves on job success, making it unsuitable here

## References

- [Pascal Birchler — PHPStan in WordPress](https://pascalbirchler.com/phpstan-wordpress/) — Reference implementation for this workflow structure
- [PHPStan Rule Levels](https://phpstan.org/user-guide/rule-levels) — Current level set to 1; CI enforces this consistently across all contributors
- [PHPStan Result Cache](https://phpstan.org/user-guide/result-cache) — Documents how PHPStan stores and reuses analysis results via tmpDir caching. This is the mechanism leveraged by GitHub Actions caching to significantly speed up incremental CI runs.
- [GitHub Cache Action](https://github.com/actions/cache) — Official documentation for cache restore/save architecture used in this workflow

---

- Fixes: #72

## Summary by Sourcery

Add a GitHub Actions workflow to run PHPStan static analysis on pushes and pull requests to main with concurrency control and caching.

New Features:
- Introduce a PHPStan static analysis job in GitHub Actions triggered on pushes and pull requests to main.
- Add a file-filter job to skip PHPStan analysis on pull requests that do not modify PHP files.
- Cache PHPStan result data across CI runs to speed up subsequent analyses.
- Use Composer-based dependency installation with built-in caching for the PHPStan workflow.
- Surface PHPStan violations as inline pull request annotations via cs2pr.

Enhancements:
- Configure workflow-level concurrency to cancel redundant PHPStan runs per branch.
- Pin the CI PHP version to 7.4 to align with the project's minimum supported runtime.
- Restrict GitHub Actions permissions for the workflow to read-only access for contents and pull requests.