### PR TITLE
fix: exclude PHPStan cache directory from PHPCS analysis

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,6 +23,7 @@
   <!-- Exclude patterns -->
   <exclude-pattern>*/vendor/*</exclude-pattern>
   <exclude-pattern>*/node_modules/*</exclude-pattern>
+  <exclude-pattern>*/tmp/phpstan/*</exclude-pattern>
 
   <!--
     Legacy files pending refactor (issue #57). admin/partials is excluded

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,8 +23,7 @@
   <!-- Exclude patterns -->
   <exclude-pattern>*/vendor/*</exclude-pattern>
   <exclude-pattern>*/node_modules/*</exclude-pattern>
-  <exclude-pattern>*/tmp/phpstan/*</exclude-pattern>
-
+  <exclude-pattern>*/tmp/*</exclude-pattern>
   <!--
     Legacy files pending refactor (issue #57). admin/partials is excluded
     entirely (both files are legacy). Other public/partials files stay in scope.


### PR DESCRIPTION
## Summary

Exclude the temporary `tmp` directory from PHPCS analysis.

## Changes Made

* Updated the exclusion pattern in `phpcs.xml` to exclude the entire `tmp` directory.
* This prevents PHPCS from scanning temporary/generated files that are not part of the project source code.

## Why

The `tmp` directory contains temporary files generated during development and analysis. These files do not need to be scanned by PHPCS and can increase processing time unnecessarily.

## Screenshot (Before)

Unable to provide a before screencast because the local PHP/Composer environment was not available when I initially started working on this issue. I have since set up the environment and verified the PHPCS execution locally.

## Screenshot (After)

<img width="1163" height="276" alt="after1" src="https://github.com/user-attachments/assets/ca579f42-258e-40fd-a0f1-dc1f372b68ba" />

---

Closes #86