### PR TITLE
ci: configure Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,32 @@
 version: 2
+
 updates:
+  # PHP Composer dependencies
   - package-ecosystem: "composer"
     directory: "/"
     target-branch: "main"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "php"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main" 
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 15
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"


### PR DESCRIPTION
## Summary
Updates Dependabot configuration to add automated GitHub Actions dependency tracking and improves the existing Composer setup with labels and structured commit messages.

## Changes

### GitHub Actions (new)
- Added `github-actions` ecosystem block
- Configured weekly schedule (Mondays at 06:00)
- Set labels: `dependencies`, `github-actions`
- Set commit prefix: `chore(ci)`

### Composer (updated)
- Added labels: `dependencies`, `php`
- Added commit message prefix: `chore(deps)` with scope

## Related
- Closes #85

## Summary by Sourcery

Configure Dependabot to manage both Composer and GitHub Actions dependencies with labeled, scoped commit messages.

Build:
- Add labels and scoped chore(deps) commit messages for Composer dependency updates.
- Introduce weekly GitHub Actions dependency updates with dependency- and CI-specific labels and chore(ci) commit messages.