### PR TITLE
ci: add automated trailing whitespace check for PRs

### DIFF
--- a/.github/workflows/whitespace-check.yml
+++ b/.github/workflows/whitespace-check.yml
@@ -1,0 +1,25 @@
+name: Trailing Whitespace Check
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  whitespace-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run trailing whitespace diff check
+        run: |
+          if ! git diff --check origin/${{ github.base_ref }}...HEAD; then
+            echo "❌ Trailing whitespace or space-before-tab errors found above."
+            echo "Run locally: git diff --check origin/${{ github.base_ref }}...HEAD"
+            exit 1
+          fi


### PR DESCRIPTION
## What This Workflow Does

This workflow runs a trailing whitespace check automatically on every pull request targeting `main`.

A single job checks out the full repository history and runs `git diff --check` against the merge base of the PR branch, catching any trailing whitespace or space-before-tab errors introduced by the incoming changes. If violations are found, the job fails with a clear error message and the offending lines are printed to the log, blocking the PR from being merged until resolved.

## Changes Made

### 1. Trailing whitespace check via `git diff --check`
- **Documentation**: https://git-scm.com/docs/git-diff
- **Changes**:
  - Triggers on all pull requests targeting `main`
  - Uses `origin/${{ github.base_ref }}...HEAD` (three-dot range) to diff only the changes introduced by the PR against the merge base, not the full branch divergence
  - `--check` exits non-zero on trailing whitespace or space-before-tab errors and prints the offending lines

### 2. Minimal permissions declared
- **Documentation**: [GitHub Workflow permissions syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions)
- **Changes**:
  - Explicit `permissions` block scoped to `contents: read`
  - Follows the principle of least privilege — no write access required for a read-only diff check

### 3. Full history fetch
- **Documentation**: https://github.com/actions/checkout
- **Changes**:
  - `fetch-depth: 0` ensures the full commit history is available so `git diff` can correctly resolve the merge base via the three-dot range syntax

## References

- [GitHub Actions Contexts](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts) — `github.base_ref` is available on `pull_request` events and resolves to the target branch name, used to construct the diff range

---

- Fixes: #96

## Summary by Sourcery

CI:
- Introduce a pull_request workflow on main that runs git diff --check against the PR’s merge base to block trailing whitespace and space-before-tab violations while using minimal read-only permissions.