### PR TITLE
chore(static-analysis): increase PHPStan level from 1 to 2

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,12 +1,12 @@
 parameters:
-    level: 1 # TODO: raise level incrementally as codebase is cleaned up
-    
+    level: 2 # TODO: raise level incrementally as codebase is cleaned up
+
     # Target PHP 7.4 specifically to match the plugin's platform requirement
     phpVersion: 70400
-    
+
     # Store the result cache inside the project folder for easy CI cache restoration
     tmpDir: tmp/phpstan
-    
+
     # Force evaluation of actual runtime types over potentially outdated PHPDoc types
     treatPhpDocTypesAsCertain: false
 


### PR DESCRIPTION
## Description
Resolves #87 by upgrading the PHPStan analysis level from `1` to `2`. 

This change introduces stricter type safety, checks for unknown methods on all expressions, and enforces basic PHPDoc validation across the active codebase.

## Changes Made
* **Upgraded Level:** Bumped `level` to `2` in `phpstan.neon`.

## Verification Results
* [x] Local PHPStan execution passes successfully with Level 2 rules applied.
* [x] CI/CD workflow passes.

---

- Fixes: #87

## Summary by Sourcery

Build:
- Update PHPStan configuration to run analysis at level 2 instead of level 1.