### PR TITLE
task: Increase PHPStan analysis level from 2 to 3

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 2 # TODO: raise level incrementally as codebase is cleaned up
+    level: 3 # TODO: raise level incrementally as codebase is cleaned up
 
     # Target PHP 7.4 specifically to match the plugin's platform requirement
     phpVersion: 70400


### PR DESCRIPTION
## Description
This PR bumps the PHPStan static analysis level from **2** to **3** as part of our ongoing effort to improve type safety and code quality. 

Level 3 introduces stricter validation for:
* **Return types** (ensuring functions/methods return what they claim).
* **Property assignments** (preventing type mismatches when assigning values to class properties).

## Changes
* Updated `phpstan.neon` (or configuration file) to `level: 3`.

## Benefits
* Stronger static analysis and type safety.
* Catching type-related bugs earlier in the development lifecycle.
* Incremental progress toward higher PHPStan strictness levels.

## Related Issues
- Fixes: #102

## Summary by Sourcery

Build:
- Increase PHPStan configuration level from 2 to 3 for stricter static analysis.