### PR TITLE
fix(ci): restore inline PHPStan annotations on PRs

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -39,7 +39,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      pull-requests: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -50,11 +49,6 @@ jobs:
           php-version: '7.4'
           coverage: none
           tools: composer
-
-      - name: Setup Reviewdog
-        uses: reviewdog/action-setup@v1
-        with:
-          reviewdog_version: latest
 
       - name: Restore PHPStan Result Cache
         id: phpstan-cache-restore
@@ -70,11 +64,8 @@ jobs:
         with:
           composer-options: '--prefer-dist --optimize-autoloader --no-scripts'
 
-      - name: Run PHPStan with Reviewdog Comments
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |
-          vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-check -level=error -fail-level=error
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --error-format=github
 
       - name: Save PHPStan Result Cache
         uses: actions/cache/save@v5

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run PHPStan with Reviewdog Comments
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-review -level=error
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,7 +3,7 @@ name: Run PHPStan
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:  # Changed from pull_request
     branches: [ main ]
 
 concurrency:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -47,7 +48,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
-          tools: composer, cs2pr
+          tools: composer
 
       - name: Restore PHPStan Result Cache
         id: phpstan-cache-restore
@@ -64,10 +65,7 @@ jobs:
           composer-options: '--prefer-dist --optimize-autoloader --no-scripts'
 
       - name: Run PHPStan Analysis
-        shell: bash
-        run: |
-          set -o pipefail
-          composer phpstan -- --error-format=checkstyle | cs2pr
+        run: composer phpstan -- --error-format=github
 
       - name: Save PHPStan Result Cache
         uses: actions/cache/save@v5

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-review -level=error
+          vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-check -level=error
 
       - name: Save PHPStan Result Cache
         uses: actions/cache/save@v5

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-check -level=error -fail-on-error
+          vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-check -level=error -fail-level=error
 
       - name: Save PHPStan Result Cache
         uses: actions/cache/save@v5

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,7 +3,7 @@ name: Run PHPStan
 on:
   push:
     branches: [ main ]
-  pull_request_target:  # Changed from pull_request
+  pull_request:
     branches: [ main ]
 
 concurrency:
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run PHPStan with Reviewdog Comments
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_TOKEN }}
         run: |
           vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-review -level=error
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -49,6 +50,11 @@ jobs:
           php-version: '7.4'
           coverage: none
           tools: composer
+
+      - name: Setup Reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
 
       - name: Restore PHPStan Result Cache
         id: phpstan-cache-restore
@@ -64,8 +70,11 @@ jobs:
         with:
           composer-options: '--prefer-dist --optimize-autoloader --no-scripts'
 
-      - name: Run PHPStan Analysis
-        run: composer phpstan -- --error-format=github
+      - name: Run PHPStan with Reviewdog Comments
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-review -level=error
 
       - name: Save PHPStan Result Cache
         uses: actions/cache/save@v5

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-check -level=error
+          vendor/bin/phpstan analyse --error-format=checkstyle | reviewdog -f=checkstyle -name="phpstan" -reporter=github-pr-check -level=error -fail-on-error
 
       - name: Save PHPStan Result Cache
         uses: actions/cache/save@v5

--- a/includes/class-wpfaevent-i18n.php
+++ b/includes/class-wpfaevent-i18n.php
@@ -30,16 +30,4 @@ class Wpfaevent_I18n {
 			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
 		);
 	}
-
-	/**
-	 * Intentional Level 3 failure to test GitHub Actions annotations.
-	 *
-	 * @since    1.0.0
-	 * @param    string $input Dummy input parameter.
-	 * @return   int This says it must return an integer, but it returns a string.
-	 */
-	public function test_phpstan_annotations( string $input ) {
-		// Level 3 validates PHPDocs. It will catch this type mismatch.
-		return 'Testing GitHub Actions inline annotations.';
-	}
 }

--- a/includes/class-wpfaevent-i18n.php
+++ b/includes/class-wpfaevent-i18n.php
@@ -30,4 +30,16 @@ class Wpfaevent_I18n {
 			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
 		);
 	}
+
+	/**
+	 * Intentional Level 3 failure to test GitHub Actions annotations.
+	 *
+	 * @since    1.0.0
+	 * @param    string $input Dummy input parameter.
+	 * @return   int This says it must return an integer, but it returns a string.
+	 */
+	public function test_phpstan_annotations( string $input ) {
+		// Level 3 validates PHPDocs. It will catch this type mismatch.
+		return 'Testing GitHub Actions inline annotations.';
+	}
 }


### PR DESCRIPTION
## Problem

PHPStan static analysis errors are not showing up as inline code annotations on Pull Request diffs.

## Cause

1. The workflow lacked the explicit `checks: write` permission required by GitHub to write inline annotations.
2. Relying on `cs2pr` with piped checkstyle logs added unnecessary complexity and risked swallowing logs.

## Solution

* Added `checks: write` to the `phpstan-analysis` job permissions.
* Dropped `cs2pr` and switched to PHPStan's native `--error-format=github`.
* Bypassed the custom composer wrapper script to run the binary directly, avoiding shell pipe issues.

## Screenshot

<img width="1366" height="768" alt="Screenshot from 2026-06-14 12-31-53" src="https://github.com/user-attachments/assets/3d7fbeaf-ff79-4dd3-bcf1-1ff3e51bf27d" />

## Related issue

- Fixes: #108

## Summary by Sourcery

Restore PHPStan static analysis inline annotations on pull requests by updating the CI workflow configuration.

CI:
- Grant the phpstan-analysis workflow job checks: write permission required for publishing annotations.
- Run PHPStan with the native --error-format=github output format instead of piping checkstyle output through cs2pr.
- Stop installing the cs2pr tool in the GitHub Actions PHP setup since it is no longer needed.