### PR TITLE
Split #81: Frontend display for imported Eventyay data

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ This plugin is maintained by [FOSSASIA](https://fossasia.org) and is compatible 
 2. Activate **Event Plugin** in your WordPress Admin under
    `Plugins → Installed Plugins → Event Plugin → Activate`.
 
-3. Configure your API endpoints:
+3. Configure Eventyay import:
 
-   * Go to **Settings → Event Plugin** in the WordPress Admin.
-   * Enter the URLs of your Eventyay API endpoints for **Speakers**, **Sessions**, and **Schedule**.
-   * Optionally adjust the **cache time (TTL)** in seconds.
+   * Go to **Events → Import Events** in the WordPress Admin.
+   * Enter the Eventyay base URL, organizer slug, optional event slug, and API token.
+   * Choose the imported event post status, then run the import.
 
 4. Add WPFA template shortcodes to your pages or posts, for example:
 
@@ -134,33 +134,68 @@ Speaker profiles use the `wpfa_speaker` custom post type, registered speaker met
 
 See [`docs/speaker-data-model.md`](docs/speaker-data-model.md) for the speaker fields, REST-exposed metadata, relationship sync behavior, and the interim session metadata approach.
 
-## Settings Page
+## Roles And Permissions
 
-Navigate to **Settings → Event Plugin** to configure:
+WPFAevent uses three access levels. WordPress user roles stay unchanged.
 
-* **Speakers Endpoint:** `https://example.org/api/v1/events/{id}/speakers`
-* **Sessions Endpoint:** `https://example.org/api/v1/events/{id}/sessions`
-* **Schedule Endpoint:** `https://example.org/api/v1/events/{id}/schedule`
-* **Cache TTL (seconds):** Duration for transient caching of API results
-* **Test Buttons:** Verify that endpoints respond with valid JSON data
+| Access level | Publish events & speakers | Import/update from Eventyay | Edit existing content | Delete content |
+| --- | --- | --- | --- | --- |
+| **Administrator** | Yes | Yes | Yes | Yes |
+| **Event Organizer** | Yes | Yes | Yes | Yes |
+| **Event Contributor** | No | No | Yes | No |
 
-If the fields are left empty, the plugin falls back to placeholder content for development.
+Site administrators assign access under **WPFAEvent → Settings → Event Plugin Access**.
+
+* **Administrator** — full WordPress site control.
+* **Event Organizer** — run Eventyay import/update, publish new events and speakers, and access **WPFAEvent → Settings**.
+* **Event Contributor** — maintain existing event and speaker details from wp-admin and the frontend dashboard, without import, publish, or delete access.
+
+Site-wide footer branding remains administrator-only.
+
+## Event Attendee Information
+
+Each `wpfa_event` post includes an **Attendee Information** meta box. Use the main editor for general venue and travel notes, then add extra information sections for focused topics such as accommodation options, accessibility notes, or attendee resources.
+
+Extra sections are stored in the `wpfa_event_custom_tabs` post meta field and render on that event's single event page as separate sections. They are also added to the event section navigation with anchors such as `#custom-section-accommodation`.
+
+## Settings And Import Pages
+
+Navigate to **WPFAEvent → Settings** for plugin-level settings and the future admin dashboard placeholder. Eventyay event imports are configured under **Events → Import Events**.
+
+The Eventyay import page accepts:
+
+* **Eventyay base URL:** The Eventyay site root, for example `https://eventyay.com`
+* **Organizer slug:** The organizer path segment
+* **Event slug:** Optional single-event filter
+* **API token:** Optional private token for authenticated Eventyay endpoints
+* **Imported post status:** Draft, published, pending review, or private
+
+## Eventyay Event Import
+
+Users with the **Event Organizer** role or **Administrator** role can import Eventyay events from **Events → Import Events**. The importer uses the configured Eventyay base URL, organizer slug, optional event slug, and API token to create or update WordPress content.
+
+Imported data is stored and displayed in these places:
+
+| Eventyay data | WordPress destination |
+| ------------- | --------------------- |
+| Event title, dates, times, timezone, location, URL, and description | `wpfa_event` posts and event post meta such as `wpfa_event_start_date`, `wpfa_event_start_time`, `wpfa_event_timezone`, `wpfa_event_location`, and `_wpfa_eventyay_event_slug` |
+| Speakers | `wpfa_speaker` posts linked to the imported event through `wpfa_event_speakers` and `wpfa_speaker_events` |
+| Event-specific speaker dashboard data | `wp-content/uploads/fossasia-data/speakers-{event_id}.json` |
+| Event schedule rows | `wp-content/uploads/fossasia-data/schedule-{event_id}.json` |
+| About text, registration button, and visibility settings | `wp-content/uploads/fossasia-data/site-settings-{event_id}.json` |
+
+On the frontend, imported data appears on the single event page and on the event-filtered speaker list, for example `/speakers/?event={event-slug}`. The default speakers archive does not mix all event speakers together; select an event to view that event's own speaker list.
 
 ## Calendar Export And Timezones
 
-The schedule page exposes an **Add to calendar** link when an event has a valid start date. The link opens a Google Calendar event template. Individual events can also be downloaded as `.ics` files from `/wp-json/wpfaevent/v1/events/{event_id}/ics`.
+Single event pages expose an **Add to calendar** link when the event has a valid start date. The primary link opens a Google Calendar event template, and the fallback `.ics` download is available from `/wp-json/wpfaevent/v1/events/{event_id}/ics`.
 
 Event timezone behavior is deterministic:
 
 * Each event can save an explicit timezone. If it is empty, WPFAevent falls back to the WordPress site timezone.
 * All-day events export date-only `DTSTART` and exclusive date-only `DTEND` values.
 * Timed events are interpreted in the event timezone and exported as UTC `DTSTART`/`DTEND` values.
-
-Run the calendar export checks with:
-
-```bash
-php tests/calendar-test.php
-```
+* Eventyay imports save the Eventyay `timezone` field when present and preserve normalized source datetime values for calendar rendering/export.
 
 ## Development Notes
 

--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -40,7 +40,7 @@ class Wpfaevent_Admin {
 	private $version;
 
 	/**
-	 * Eventyay import service.
+	 * Eventyay import and dashboard sync service.
 	 *
 	 * @since 1.0.0
 	 * @access private
@@ -141,11 +141,12 @@ class Wpfaevent_Admin {
 		);
 
 		array_unshift( $links, $settings_link, $import_link );
+
 		return $links;
 	}
 
 	/**
-	 * Register the settings page in WordPress admin.
+	 * Register the plugin settings menu and Eventyay import page.
 	 *
 	 * @since    1.0.0
 	 */
@@ -155,7 +156,7 @@ class Wpfaevent_Admin {
 			esc_html__( 'WPFAEvent', 'wpfaevent' ),
 			Wpfaevent_Roles::CAP_MANAGE_SETTINGS,
 			'wpfaevent-settings',
-			array( $this, 'render_settings_page' ),
+			array( $this, 'render_plugin_settings_page' ),
 			'dashicons-calendar-alt',
 			30
 		);
@@ -166,7 +167,7 @@ class Wpfaevent_Admin {
 			esc_html__( 'Settings', 'wpfaevent' ),
 			Wpfaevent_Roles::CAP_MANAGE_SETTINGS,
 			'wpfaevent-settings',
-			array( $this, 'render_settings_page' )
+			array( $this, 'render_plugin_settings_page' )
 		);
 
 		add_submenu_page(
@@ -175,7 +176,7 @@ class Wpfaevent_Admin {
 			esc_html__( 'Import Events', 'wpfaevent' ),
 			Wpfaevent_Roles::CAP_IMPORT_EVENTYAY,
 			'wpfaevent-import-events',
-			array( $this, 'render_eventyay_import_page' )
+			array( $this, 'render_settings_page' )
 		);
 
 		add_submenu_page(
@@ -184,17 +185,25 @@ class Wpfaevent_Admin {
 			esc_html__( 'Update Events', 'wpfaevent' ),
 			Wpfaevent_Roles::CAP_IMPORT_EVENTYAY,
 			'wpfaevent-update-events',
-			array( $this, 'render_eventyay_update_page' )
+			array( $this, 'render_update_events_page' )
+		);
+
+		add_submenu_page(
+			'edit.php?post_type=wpfa_speaker',
+			esc_html__( 'Event Speaker Lists', 'wpfaevent' ),
+			esc_html__( 'Events', 'wpfaevent' ),
+			'edit_posts',
+			'wpfaevent-speaker-events',
+			array( $this, 'render_speaker_events_page' )
 		);
 	}
 
 	/**
-	 * Render the settings page placeholder.
+	 * Render the plugin settings placeholder page.
 	 *
-	 * @since    1.0.0
+	 * @since 1.0.0
 	 */
-	public function render_settings_page() {
-		// Check user capabilities.
+	public function render_plugin_settings_page() {
 		if ( ! Wpfaevent_Roles::current_user_can_manage_settings() ) {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wpfaevent' ) );
 		}
@@ -221,8 +230,8 @@ class Wpfaevent_Admin {
 				</div>
 			<?php endif; ?>
 
-			<div class="card">
-				<h2><?php esc_html_e( 'Plugin Information', 'wpfaevent' ); ?></h2>
+			<div class="card" style="max-width: 960px;">
+				<h2><?php esc_html_e( 'WPFAEvent Settings', 'wpfaevent' ); ?></h2>
 				<p><?php esc_html_e( 'This page is reserved for the future WPFAEvent admin dashboard and shared plugin settings.', 'wpfaevent' ); ?></p>
 				<?php if ( Wpfaevent_Roles::current_user_can_import_eventyay() ) : ?>
 					<p>
@@ -231,38 +240,125 @@ class Wpfaevent_Admin {
 						</a>
 					</p>
 				<?php endif; ?>
-				<table class="form-table">
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Version', 'wpfaevent' ); ?></th>
-						<td><?php echo esc_html( $this->version ); ?></td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Plugin Name', 'wpfaevent' ); ?></th>
-						<td><code><?php echo esc_html( $this->plugin_name ); ?></code></td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Text Domain', 'wpfaevent' ); ?></th>
-						<td><code>wpfaevent</code></td>
-					</tr>
-				</table>
 			</div>
 
-			<div class="card" style="margin-top: 20px;">
-				<h2><?php esc_html_e( 'Documentation', 'wpfaevent' ); ?></h2>
-				<p>
-					<?php
-					printf(
-						/* translators: %s: GitHub repository link */
-						esc_html__( 'For setup instructions and documentation, visit the %s.', 'wpfaevent' ),
-						sprintf(
-							'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
-							esc_url( 'https://github.com/fossasia/WPFAevent' ),
-							esc_html__( 'GitHub repository', 'wpfaevent' )
-						)
-					);
-					?>
-				</p>
+			<div class="card" style="max-width: 960px;">
+				<h2><?php esc_html_e( 'Where Imported Eventyay Data Appears', 'wpfaevent' ); ?></h2>
+				<table class="widefat striped">
+					<tbody>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'Events', 'wpfaevent' ); ?></th>
+							<td><?php esc_html_e( 'Created or updated as Events posts, with date, location, Eventyay URL, and Eventyay source metadata saved as post meta.', 'wpfaevent' ); ?></td>
+						</tr>
+							<tr>
+								<th scope="row"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></th>
+								<td><?php esc_html_e( 'Created or updated as Speaker posts and linked to the imported event through event-specific relationship meta.', 'wpfaevent' ); ?></td>
+							</tr>
+							<tr>
+								<th scope="row"><?php esc_html_e( 'Dashboard files', 'wpfaevent' ); ?></th>
+								<td><?php esc_html_e( 'Event dashboard data is written under uploads/fossasia-data using event-specific files such as speakers-{event_id}.json, schedule-{event_id}.json, sponsors-{event_id}.json, exhibitors-{event_id}.json, and site-settings-{event_id}.json.', 'wpfaevent' ); ?></td>
+							</tr>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'Frontend', 'wpfaevent' ); ?></th>
+							<td><?php esc_html_e( 'Imported data appears on the event detail page and on the event-filtered speakers page, for example /speakers/?event={event-slug}.', 'wpfaevent' ); ?></td>
+						</tr>
+					</tbody>
+				</table>
 			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render an event chooser under the Speakers admin menu.
+	 *
+	 * @since 1.0.0
+	 */
+	public function render_speaker_events_page() {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to view event speaker lists.', 'wpfaevent' ) );
+		}
+
+		$events = get_posts(
+			array(
+				'post_type'      => 'wpfa_event',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+				'no_found_rows'  => true,
+			)
+		);
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Event Speaker Lists', 'wpfaevent' ); ?></h1>
+			<p><?php esc_html_e( 'Choose an event to view the speakers linked only to that event.', 'wpfaevent' ); ?></p>
+
+			<?php if ( empty( $events ) ) : ?>
+				<div class="notice notice-info">
+					<p><?php esc_html_e( 'No events found yet.', 'wpfaevent' ); ?></p>
+				</div>
+			<?php else : ?>
+				<table class="widefat striped">
+					<thead>
+						<tr>
+							<th scope="col"><?php esc_html_e( 'Event', 'wpfaevent' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'Status', 'wpfaevent' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'Actions', 'wpfaevent' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $events as $event ) : ?>
+							<?php
+							$speaker_ids    = $this->get_admin_event_speaker_ids( $event->ID );
+							$speaker_count  = count( $speaker_ids );
+							$speakers_url   = add_query_arg(
+								array(
+									'post_type'          => 'wpfa_speaker',
+									'wpfa_speaker_event' => absint( $event->ID ),
+								),
+								admin_url( 'edit.php' )
+							);
+							$edit_event_url = get_edit_post_link( $event->ID, '' );
+							$status_object  = get_post_status_object( get_post_status( $event ) );
+							$status_label   = $status_object ? $status_object->label : get_post_status( $event );
+							?>
+							<tr>
+								<td>
+									<strong>
+										<a href="<?php echo esc_url( $speakers_url ); ?>">
+											<?php echo esc_html( get_the_title( $event ) ); ?>
+										</a>
+									</strong>
+								</td>
+								<td><?php echo esc_html( $status_label ); ?></td>
+								<td>
+									<?php
+									echo esc_html(
+										sprintf(
+											/* translators: %s: Speaker count. */
+											_n( '%s speaker', '%s speakers', $speaker_count, 'wpfaevent' ),
+											number_format_i18n( $speaker_count )
+										)
+									);
+									?>
+								</td>
+								<td>
+									<a class="button button-small" href="<?php echo esc_url( $speakers_url ); ?>">
+										<?php esc_html_e( 'View Speakers', 'wpfaevent' ); ?>
+									</a>
+									<?php if ( $edit_event_url ) : ?>
+										<a class="button button-small" href="<?php echo esc_url( $edit_event_url ); ?>">
+											<?php esc_html_e( 'Edit Event', 'wpfaevent' ); ?>
+										</a>
+									<?php endif; ?>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			<?php endif; ?>
 		</div>
 		<?php
 	}
@@ -294,7 +390,6 @@ class Wpfaevent_Admin {
 		$assigned_levels = Wpfaevent_Roles::get_user_access_levels();
 		$users           = get_users(
 			array(
-				'fields'  => 'all',
 				'orderby' => 'display_name',
 				'order'   => 'ASC',
 			)
@@ -307,7 +402,7 @@ class Wpfaevent_Admin {
 
 		$this->render_user_access_level_guide();
 		?>
-		<table class="widefat striped">
+		<table class="widefat striped" style="max-width: 960px;">
 			<thead>
 				<tr>
 					<th scope="col"><?php esc_html_e( 'User', 'wpfaevent' ); ?></th>
@@ -320,17 +415,18 @@ class Wpfaevent_Admin {
 				<?php foreach ( $users as $user ) : ?>
 					<?php
 					$user_id        = absint( $user->ID );
+					$is_admin       = Wpfaevent_Roles::user_is_site_administrator( $user );
 					$role_names     = array_map( 'translate_user_role', array_filter( (array) $user->roles ) );
 					$wordpress_role = ! empty( $role_names ) ? implode( ', ', $role_names ) : __( 'No role', 'wpfaevent' );
-					$assigned_level = isset( $assigned_levels[ $user_id ] ) ? $assigned_levels[ $user_id ] : '';
 					$field_name     = Wpfaevent_Roles::ACCESS_LEVELS_OPTION . '[' . $user_id . ']';
+					$current_level  = $is_admin ? '' : ( $assigned_levels[ $user_id ] ?? '' );
 					?>
 					<tr>
-						<td><?php echo esc_html( $user->display_name ? $user->display_name : $user->user_login ); ?></td>
+						<td><strong><?php echo esc_html( $user->display_name ); ?></strong></td>
 						<td><?php echo esc_html( $user->user_email ); ?></td>
 						<td><?php echo esc_html( $wordpress_role ); ?></td>
 						<td>
-							<?php if ( Wpfaevent_Roles::user_is_site_administrator( $user ) ) : ?>
+							<?php if ( $is_admin ) : ?>
 								<em><?php esc_html_e( 'Full access (Administrator)', 'wpfaevent' ); ?></em>
 							<?php else : ?>
 								<label class="screen-reader-text" for="<?php echo esc_attr( 'wpfaevent-access-' . $user_id ); ?>">
@@ -344,7 +440,7 @@ class Wpfaevent_Admin {
 								</label>
 								<select id="<?php echo esc_attr( 'wpfaevent-access-' . $user_id ); ?>" name="<?php echo esc_attr( $field_name ); ?>">
 									<?php foreach ( $access_labels as $level => $label ) : ?>
-										<option value="<?php echo esc_attr( $level ); ?>" <?php selected( $assigned_level, $level ); ?>>
+										<option value="<?php echo esc_attr( $level ); ?>" <?php selected( $current_level, $level ); ?>>
 											<?php echo esc_html( $label ); ?>
 										</option>
 									<?php endforeach; ?>
@@ -366,7 +462,7 @@ class Wpfaevent_Admin {
 	private function render_user_access_level_guide() {
 		?>
 		<h3 class="title" style="margin-top: 1.5em;"><?php esc_html_e( 'Access level guide', 'wpfaevent' ); ?></h3>
-		<table class="widefat striped" style="margin-bottom: 1em;">
+		<table class="widefat striped" style="max-width: 960px; margin-bottom: 1.5em;">
 			<thead>
 				<tr>
 					<th scope="col" style="width: 28%;"><?php esc_html_e( 'Access level', 'wpfaevent' ); ?></th>
@@ -413,6 +509,259 @@ class Wpfaevent_Admin {
 	}
 
 	/**
+	 * Render the event filter on the speaker admin list.
+	 *
+	 * Event-owned speakers are hidden from the default speaker list. This filter
+	 * gives admins an event-scoped way to inspect those records when needed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $post_type Current list-table post type.
+	 * @return void
+	 */
+	public function render_speaker_event_filter( $post_type ) {
+		if ( 'wpfa_speaker' !== $post_type ) {
+			return;
+		}
+
+		$events = get_posts(
+			array(
+				'post_type'      => 'wpfa_event',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+				'no_found_rows'  => true,
+			)
+		);
+
+		if ( empty( $events ) ) {
+			return;
+		}
+
+		$selected_event_id = $this->get_selected_speaker_admin_event_id();
+		?>
+		<label class="screen-reader-text" for="wpfa_speaker_event">
+			<?php esc_html_e( 'Filter speakers by event', 'wpfaevent' ); ?>
+		</label>
+		<select name="wpfa_speaker_event" id="wpfa_speaker_event">
+			<option value=""><?php esc_html_e( 'Site speakers', 'wpfaevent' ); ?></option>
+			<?php foreach ( $events as $event ) : ?>
+				<option value="<?php echo esc_attr( $event->ID ); ?>" <?php selected( $selected_event_id, $event->ID ); ?>>
+					<?php echo esc_html( sprintf( /* translators: %s: Event title. */ __( 'Event: %s', 'wpfaevent' ), get_the_title( $event ) ) ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Scope the speaker admin list to site speakers or one selected event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Query $query Admin list-table query.
+	 * @return void
+	 */
+	public function filter_speaker_admin_list( $query ) {
+		if ( ! is_admin() || ! $query->is_main_query() ) {
+			return;
+		}
+
+		$post_type = $query->get( 'post_type' );
+		if ( is_array( $post_type ) || 'wpfa_speaker' !== $post_type ) {
+			return;
+		}
+
+		$selected_event_id = $this->get_selected_speaker_admin_event_id();
+
+		if ( $selected_event_id ) {
+			$speaker_ids = $this->get_admin_event_speaker_ids( $selected_event_id );
+			$query->set( 'post__in', ! empty( $speaker_ids ) ? $speaker_ids : array( 0 ) );
+			return;
+		}
+
+		$event_owned_speaker_ids = $this->get_all_event_owned_speaker_ids();
+		if ( ! empty( $event_owned_speaker_ids ) ) {
+			$current_exclusions = $query->get( 'post__not_in' );
+			$current_exclusions = is_array( $current_exclusions ) ? $current_exclusions : array();
+			$query->set( 'post__not_in', Wpfaevent_Meta_Event::sanitize_post_id_list( array_merge( $current_exclusions, $event_owned_speaker_ids ) ) );
+		}
+
+		$existing_meta_query = $query->get( 'meta_query' );
+		$meta_query          = array(
+			'relation' => 'AND',
+			array(
+				'key'     => 'wpfa_speaker_events',
+				'compare' => 'NOT EXISTS',
+			),
+			array(
+				'key'     => '_wpfa_eventyay_speaker_id',
+				'compare' => 'NOT EXISTS',
+			),
+		);
+
+		if ( ! empty( $existing_meta_query ) ) {
+			$meta_query[] = $existing_meta_query;
+		}
+
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Admin list filtering is intentionally based on speaker ownership meta.
+		$query->set( 'meta_query', $meta_query );
+	}
+
+	/**
+	 * Replace raw speaker CPT status tabs with scoped counts.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $views Existing list-table view links.
+	 * @return array Scoped view links.
+	 */
+	public function filter_speaker_admin_views( $views ) {
+		$selected_event_id = $this->get_selected_speaker_admin_event_id();
+		$current_status    = filter_input( INPUT_GET, 'post_status', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$current_status    = $current_status ? sanitize_key( $current_status ) : '';
+		$base_args         = array(
+			'post_type' => 'wpfa_speaker',
+		);
+
+		if ( $selected_event_id ) {
+			$base_args['wpfa_speaker_event'] = $selected_event_id;
+		}
+
+		$scoped_views = array();
+		$view_items   = array(
+			'all'     => array(
+				'label'  => $selected_event_id ? __( 'Event speakers', 'wpfaevent' ) : __( 'Site speakers', 'wpfaevent' ),
+				'status' => '',
+			),
+			'publish' => array(
+				'label'  => __( 'Published', 'wpfaevent' ),
+				'status' => 'publish',
+			),
+			'trash'   => array(
+				'label'  => __( 'Trash', 'wpfaevent' ),
+				'status' => 'trash',
+			),
+		);
+
+		foreach ( $view_items as $view_key => $view_item ) {
+			$count = $this->count_scoped_speaker_admin_posts( $selected_event_id, $view_item['status'] );
+
+			if ( 'trash' === $view_key && 0 === $count && empty( $views['trash'] ) ) {
+				continue;
+			}
+
+			$url_args = $base_args;
+			if ( $view_item['status'] ) {
+				$url_args['post_status'] = $view_item['status'];
+			}
+
+			$is_current = $view_item['status'] === $current_status || ( '' === $view_item['status'] && '' === $current_status );
+
+			$scoped_views[ $view_key ] = sprintf(
+				'<a href="%1$s"%2$s>%3$s <span class="count">(%4$s)</span></a>',
+				esc_url( add_query_arg( $url_args, admin_url( 'edit.php' ) ) ),
+				$is_current ? ' class="current" aria-current="page"' : '',
+				esc_html( $view_item['label'] ),
+				esc_html( number_format_i18n( $count ) )
+			);
+		}
+
+		return $scoped_views;
+	}
+
+	/**
+	 * Read the selected event filter from the speaker admin list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int Event post ID, or 0 for site speakers.
+	 */
+	private function get_selected_speaker_admin_event_id() {
+		$event_id = filter_input( INPUT_GET, 'wpfa_speaker_event', FILTER_VALIDATE_INT );
+
+		return absint( $event_id );
+	}
+
+	/**
+	 * Get speakers assigned to one event for the admin list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int> Speaker post IDs.
+	 */
+	private function get_admin_event_speaker_ids( $event_id ) {
+		return Wpfaevent_Meta_Event::get_admin_event_speaker_ids( $event_id );
+	}
+
+	/**
+	 * Get every speaker owned by any event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int> Speaker post IDs.
+	 */
+	private function get_all_event_owned_speaker_ids() {
+		return Wpfaevent_Meta_Event::get_all_event_owned_speaker_ids();
+	}
+
+	/**
+	 * Count speaker admin rows in the current scoped list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $event_id    Selected event ID, or 0 for site speakers.
+	 * @param string $post_status Optional post status.
+	 * @return int
+	 */
+	private function count_scoped_speaker_admin_posts( $event_id, $post_status = '' ) {
+		$event_id    = absint( $event_id );
+		$post_status = sanitize_key( $post_status );
+		$query_args  = array(
+			'post_type'      => 'wpfa_speaker',
+			'post_status'    => $post_status ? $post_status : 'any',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		);
+
+		if ( $event_id ) {
+			$speaker_ids = $this->get_admin_event_speaker_ids( $event_id );
+
+			if ( empty( $speaker_ids ) ) {
+				return 0;
+			}
+
+			$query_args['post__in'] = $speaker_ids;
+		} else {
+			$event_owned_speaker_ids = $this->get_all_event_owned_speaker_ids();
+
+			if ( ! empty( $event_owned_speaker_ids ) ) {
+				$query_args['post__not_in'] = $event_owned_speaker_ids;
+			}
+
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Admin list counts mirror the scoped speaker ownership query.
+			$query_args['meta_query'] = array(
+				'relation' => 'AND',
+				array(
+					'key'     => 'wpfa_speaker_events',
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key'     => '_wpfa_eventyay_speaker_id',
+					'compare' => 'NOT EXISTS',
+				),
+			);
+		}
+
+		$speaker_ids = get_posts( $query_args );
+
+		return count( $speaker_ids );
+	}
+
+	/**
 	 * Sanitize Eventyay import options.
 	 *
 	 * @since 1.0.0
@@ -428,8 +777,9 @@ class Wpfaevent_Admin {
 	 * Render the Eventyay import page.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
-	public function render_eventyay_import_page() {
+	public function render_settings_page() {
 		$this->get_eventyay_importer()->render_settings_page();
 	}
 
@@ -437,8 +787,9 @@ class Wpfaevent_Admin {
 	 * Render the Eventyay update page.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
-	public function render_eventyay_update_page() {
+	public function render_update_events_page() {
 		$this->get_eventyay_importer()->render_update_events_page();
 	}
 
@@ -446,806 +797,472 @@ class Wpfaevent_Admin {
 	 * Handle Eventyay import form submissions.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function handle_eventyay_events_import() {
 		$this->get_eventyay_importer()->handle_eventyay_events_import();
 	}
 
-	// ========================================
-	// META BOXES
-	// ========================================
-
 	/**
-	 * Register meta boxes for Event and Speaker CPTs.
+	 * Show notice when block themes are active.
 	 *
 	 * @since 1.0.0
 	 */
-	public function add_meta_boxes() {
-		// Event meta boxes.
-		add_meta_box(
-			'wpfa_event_details',
-			__( 'Event Details', 'wpfaevent' ),
-			array( $this, 'render_event_meta_box' ),
-			'wpfa_event',
-			'normal',
-			'high'
-		);
-
-		// Speaker meta boxes.
-		add_meta_box(
-			'wpfa_speaker_details',
-			__( 'Speaker Details', 'wpfaevent' ),
-			array( $this, 'render_speaker_meta_box' ),
-			'wpfa_speaker',
-			'normal',
-			'high'
-		);
-
-		// Remove the default Custom Fields meta box to avoid UI clutter.
-		// since we have enabled 'custom-fields' support for REST API visibility.
-		remove_meta_box( 'postcustom', 'wpfa_event', 'normal' );
-		remove_meta_box( 'postcustom', 'wpfa_speaker', 'normal' );
-	}
-
-	/**
-	 * Render Event meta box.
-	 *
-	 * @since 1.0.0
-	 * @param WP_Post $post The post object.
-	 */
-	public function render_event_meta_box( $post ) {
-		wp_nonce_field( 'wpfa_event_meta_nonce', 'wpfa_event_meta_nonce' );
-
-		$start_date = get_post_meta( $post->ID, 'wpfa_event_start_date', true );
-		$end_date   = get_post_meta( $post->ID, 'wpfa_event_end_date', true );
-		$start_time = get_post_meta( $post->ID, 'wpfa_event_start_time', true );
-		$end_time   = get_post_meta( $post->ID, 'wpfa_event_end_time', true );
-
-		if ( '' === $start_time ) {
-			$start_time = get_post_meta( $post->ID, 'wpfa_event_time', true );
-		}
-
-		$timezone  = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_timezone( $post->ID ) : wp_timezone_string();
-		$all_day   = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_all_day( $post->ID ) : false;
-		$location  = get_post_meta( $post->ID, 'wpfa_event_location', true );
-		$url       = get_post_meta( $post->ID, 'wpfa_event_url', true );
-		$lead_text = get_post_meta( $post->ID, 'wpfa_event_lead_text', true );
-		$reg_link  = get_post_meta( $post->ID, 'wpfa_event_registration_link', true );
-		$cfs_link  = get_post_meta( $post->ID, 'wpfa_event_cfs_link', true );
-		$speakers  = $this->get_event_speaker_ids( $post->ID );
-
-		?>
-		<table class="form-table">
-			<tr>
-				<th><label for="wpfa_event_start_date"><?php esc_html_e( 'Start Date', 'wpfaevent' ); ?></label></th>
-				<td><input type="date" id="wpfa_event_start_date" name="wpfa_event_start_date" value="<?php echo esc_attr( $start_date ); ?>" class="regular-text"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_end_date"><?php esc_html_e( 'End Date', 'wpfaevent' ); ?></label></th>
-				<td><input type="date" id="wpfa_event_end_date" name="wpfa_event_end_date" value="<?php echo esc_attr( $end_date ); ?>" class="regular-text"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_timezone"><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></label></th>
-				<td>
-					<select id="wpfa_event_timezone" name="wpfa_event_timezone" class="regular-text">
-						<?php echo wp_timezone_choice( $timezone ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes timezone option markup. ?>
-					</select>
-					<p class="description"><?php esc_html_e( 'Used to interpret timed events and calendar exports. Leave as the site timezone when the event does not need a separate timezone.', 'wpfaevent' ); ?></p>
-				</td>
-			</tr>
-			<tr>
-				<th><?php esc_html_e( 'Time Format', 'wpfaevent' ); ?></th>
-				<td>
-					<label for="wpfa_event_all_day">
-						<input type="checkbox" id="wpfa_event_all_day" name="wpfa_event_all_day" value="1" <?php checked( $all_day ); ?>>
-						<?php esc_html_e( 'All-day event', 'wpfaevent' ); ?>
-					</label>
-					<p class="description"><?php esc_html_e( 'All-day events export as date-only calendar entries. Timed events use the event timezone.', 'wpfaevent' ); ?></p>
-				</td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_start_time"><?php esc_html_e( 'Start Time', 'wpfaevent' ); ?></label></th>
-				<td><input type="time" id="wpfa_event_start_time" name="wpfa_event_start_time" value="<?php echo esc_attr( $start_time ); ?>" class="regular-text"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_end_time"><?php esc_html_e( 'End Time', 'wpfaevent' ); ?></label></th>
-				<td><input type="time" id="wpfa_event_end_time" name="wpfa_event_end_time" value="<?php echo esc_attr( $end_time ); ?>" class="regular-text"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_location"><?php esc_html_e( 'Location', 'wpfaevent' ); ?></label></th>
-				<td><input type="text" id="wpfa_event_location" name="wpfa_event_location" value="<?php echo esc_attr( $location ); ?>" class="regular-text"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_lead_text"><?php esc_html_e( 'Lead Text', 'wpfaevent' ); ?></label></th>
-				<td><input type="text" id="wpfa_event_lead_text" name="wpfa_event_lead_text" value="<?php echo esc_attr( $lead_text ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Short description for hero section', 'wpfaevent' ); ?>"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_url"><?php esc_html_e( 'Event URL', 'wpfaevent' ); ?></label></th>
-				<td><input type="url" id="wpfa_event_url" name="wpfa_event_url" value="<?php echo esc_attr( $url ); ?>" class="regular-text" placeholder="https://"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_registration_link"><?php esc_html_e( 'Registration Link', 'wpfaevent' ); ?></label></th>
-				<td><input type="url" id="wpfa_event_registration_link" name="wpfa_event_registration_link" value="<?php echo esc_attr( $reg_link ); ?>" class="regular-text" placeholder="https://eventyay.com/e/..."></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_cfs_link"><?php esc_html_e( 'Call for Speakers Link', 'wpfaevent' ); ?></label></th>
-				<td><input type="url" id="wpfa_event_cfs_link" name="wpfa_event_cfs_link" value="<?php echo esc_attr( $cfs_link ); ?>" class="regular-text" placeholder="https://eventyay.com/e/.../cfs"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_event_speakers"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></label></th>
-				<td>
-					<?php
-					$speaker_ids = get_posts(
-						array(
-							'post_type'      => 'wpfa_speaker',
-							'post_status'    => 'any',
-							'posts_per_page' => -1,
-							'orderby'        => 'title',
-							'order'          => 'ASC',
-							'fields'         => 'ids',
-							'no_found_rows'  => true,
-						)
-					);
-					if ( $speaker_ids ) :
-						?>
-						<select name="wpfa_event_speakers[]" id="wpfa_event_speakers" multiple class="wpfaevent-relationship-select wpfaevent-speakers-select">
-							<?php foreach ( $speaker_ids as $speaker_id ) : ?>
-								<?php $is_selected = is_array( $speakers ) && in_array( $speaker_id, $speakers, true ); ?>
-									<option value="<?php echo esc_attr( $speaker_id ); ?>"
-										<?php selected( $is_selected, true ); ?>>
-									<?php echo esc_html( get_the_title( $speaker_id ) ); ?>
-								</option>
-							<?php endforeach; ?>
-						</select>
-						<p class="description">
-							<?php esc_html_e( 'Hold Ctrl (Cmd on Mac) to select multiple speakers.', 'wpfaevent' ); ?>
-						</p>
-					<?php else : ?>
-						<p><?php esc_html_e( 'No speakers found. Create speakers first.', 'wpfaevent' ); ?></p>
-					<?php endif; ?>
-				</td>
-			</tr>
-		</table>
-		<?php
-	}
-
-	/**
-	 * Render Speaker meta box.
-	 *
-	 * @since 1.0.0
-	 * @param WP_Post $post The post object.
-	 */
-	public function render_speaker_meta_box( $post ) {
-		wp_nonce_field( 'wpfa_speaker_meta_nonce', 'wpfa_speaker_meta_nonce' );
-
-		$position     = get_post_meta( $post->ID, 'wpfa_speaker_position', true );
-		$organization = get_post_meta( $post->ID, 'wpfa_speaker_organization', true );
-		$bio          = get_post_meta( $post->ID, 'wpfa_speaker_bio', true );
-		$headshot_url = get_post_meta( $post->ID, 'wpfa_speaker_headshot_url', true );
-		$events       = $this->sanitize_post_id_list(
-			array_merge(
-				$this->get_speaker_event_ids( $post->ID ),
-				$this->get_events_linked_to_speaker( $post->ID )
-			)
-		);
-		?>
-		<table class="form-table">
-			<tr>
-				<th><label for="wpfa_speaker_position"><?php esc_html_e( 'Position/Title', 'wpfaevent' ); ?></label></th>
-				<td><input type="text" id="wpfa_speaker_position" name="wpfa_speaker_position" value="<?php echo esc_attr( $position ); ?>" class="regular-text"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_speaker_organization"><?php esc_html_e( 'Organization', 'wpfaevent' ); ?></label></th>
-				<td><input type="text" id="wpfa_speaker_organization" name="wpfa_speaker_organization" value="<?php echo esc_attr( $organization ); ?>" class="regular-text"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_speaker_bio"><?php esc_html_e( 'Biography', 'wpfaevent' ); ?></label></th>
-				<td>
-					<?php
-					wp_editor(
-						$bio,
-						'wpfa_speaker_bio',
-						array(
-							'textarea_name' => 'wpfa_speaker_bio',
-							'textarea_rows' => 10,
-							'media_buttons' => false,
-						)
-					);
-					?>
-				</td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_speaker_headshot_url"><?php esc_html_e( 'Headshot URL', 'wpfaevent' ); ?></label></th>
-				<td><input type="url" id="wpfa_speaker_headshot_url" name="wpfa_speaker_headshot_url" value="<?php echo esc_attr( $headshot_url ); ?>" class="regular-text" placeholder="https://"></td>
-			</tr>
-			<tr>
-				<th><label for="wpfa_speaker_events"><?php esc_html_e( 'Related Events', 'wpfaevent' ); ?></label></th>
-				<td>
-					<?php
-					$event_ids = get_posts(
-						array(
-							'post_type'      => 'wpfa_event',
-							'post_status'    => 'any',
-							'posts_per_page' => -1,
-							'orderby'        => 'title',
-							'order'          => 'ASC',
-							'fields'         => 'ids',
-							'no_found_rows'  => true,
-						)
-					);
-					if ( $event_ids ) :
-						?>
-						<select name="wpfa_speaker_events[]" id="wpfa_speaker_events" multiple class="wpfaevent-relationship-select wpfaevent-events-select">
-							<?php foreach ( $event_ids as $event_id ) : ?>
-								<?php $is_selected = in_array( $event_id, $events, true ); ?>
-								<option value="<?php echo esc_attr( $event_id ); ?>" <?php selected( $is_selected, true ); ?>>
-									<?php echo esc_html( get_the_title( $event_id ) ); ?>
-								</option>
-							<?php endforeach; ?>
-						</select>
-						<p class="description">
-							<?php esc_html_e( 'Hold Ctrl (Cmd on Mac) to select multiple events.', 'wpfaevent' ); ?>
-						</p>
-					<?php else : ?>
-						<p><?php esc_html_e( 'No events found. Create events first.', 'wpfaevent' ); ?></p>
-					<?php endif; ?>
-				</td>
-			</tr>
-		</table>
-		<?php
-	}
-
-	/**
-	 * Save Event meta box data.
-	 *
-	 * @since 1.0.0
-	 * @param int $post_id The post ID.
-	 */
-	public function save_event_meta( $post_id ) {
-		$event_nonce = isset( $_POST['wpfa_event_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_meta_nonce'] ) ) : '';
-
-		if ( ! $event_nonce || ! wp_verify_nonce( $event_nonce, 'wpfa_event_meta_nonce' ) ) {
+	public function maybe_show_block_theme_notice() {
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
 			return;
 		}
 
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
-
-		$posted_start_date = isset( $_POST['wpfa_event_start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_start_date'] ) ) : '';
-		$posted_end_date   = isset( $_POST['wpfa_event_end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_end_date'] ) ) : '';
-		$posted_timezone   = isset( $_POST['wpfa_event_timezone'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_timezone'] ) ) : '';
-		$start_date        = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_date_value( $posted_start_date ) : $posted_start_date;
-		$end_date          = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_date_value( $posted_end_date ) : $posted_end_date;
-		$timezone          = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_timezone( $posted_timezone ) : $posted_timezone;
-
-		if ( isset( $_POST['wpfa_event_start_date'] ) ) {
-			$this->update_or_delete_post_meta( $post_id, 'wpfa_event_start_date', $start_date );
-		}
-
-		if ( isset( $_POST['wpfa_event_end_date'] ) ) {
-			$this->update_or_delete_post_meta( $post_id, 'wpfa_event_end_date', $end_date );
-		}
-
-		if ( '' !== $timezone ) {
-			update_post_meta( $post_id, 'wpfa_event_timezone', $timezone );
-		} else {
-			delete_post_meta( $post_id, 'wpfa_event_timezone' );
-		}
-
-		$all_day = isset( $_POST['wpfa_event_all_day'] );
-		update_post_meta( $post_id, 'wpfa_event_all_day', $all_day ? '1' : '0' );
-
-		$posted_start_time = isset( $_POST['wpfa_event_start_time'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_start_time'] ) ) : '';
-		$posted_end_time   = isset( $_POST['wpfa_event_end_time'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_end_time'] ) ) : '';
-		$start_time        = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_time_value( $posted_start_time ) : $posted_start_time;
-		$end_time          = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_time_value( $posted_end_time ) : $posted_end_time;
-
-		if ( $all_day ) {
-			delete_post_meta( $post_id, 'wpfa_event_start_time' );
-			delete_post_meta( $post_id, 'wpfa_event_time' );
-			delete_post_meta( $post_id, 'wpfa_event_end_time' );
-			delete_post_meta( $post_id, 'wpfa_event_starts_at' );
-			delete_post_meta( $post_id, 'wpfa_event_ends_at' );
-		} else {
-			$end_date_for_datetime = '' !== $end_date ? $end_date : $start_date;
-
-			$this->update_or_delete_post_meta( $post_id, 'wpfa_event_start_time', $start_time );
-			$this->update_or_delete_post_meta( $post_id, 'wpfa_event_time', $start_time );
-			$this->update_or_delete_post_meta( $post_id, 'wpfa_event_end_time', $end_time );
-			$this->update_or_delete_post_meta(
-				$post_id,
-				'wpfa_event_starts_at',
-				class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::build_datetime_value( $start_date, $start_time, $timezone ) : ''
-			);
-			$this->update_or_delete_post_meta(
-				$post_id,
-				'wpfa_event_ends_at',
-				class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::build_datetime_value( $end_date_for_datetime, $end_time, $timezone ) : ''
-			);
-		}
-
-		$meta_fields = array(
-			'wpfa_event_location',
-			'wpfa_event_lead_text',
-			'wpfa_event_url',
-			'wpfa_event_registration_link',
-			'wpfa_event_cfs_link',
+		echo '<div class="notice notice-warning is-dismissible"><p>';
+		echo esc_html__(
+			'WPFA Event page templates require a classic theme. Block themes (e.g., Twenty Twenty-Five) do not support PHP page templates.',
+			'wpfaevent'
 		);
-
-		foreach ( $meta_fields as $field ) {
-			if ( isset( $_POST[ $field ] ) ) {
-				$raw_value = sanitize_text_field( wp_unslash( $_POST[ $field ] ) );
-
-				if ( in_array( $field, array( 'wpfa_event_url', 'wpfa_event_registration_link', 'wpfa_event_cfs_link' ), true ) ) {
-					$value = esc_url_raw( $raw_value );
-				} else {
-					$value = $raw_value;
-				}
-
-				update_post_meta( $post_id, $field, $value );
-			}
-		}
-
-		$previous_speakers = $this->get_event_speaker_ids( $post_id );
-		$speakers          = array();
-
-		// Handle speakers array.
-		if ( isset( $_POST['wpfa_event_speakers'] ) && is_array( $_POST['wpfa_event_speakers'] ) ) {
-			$speakers = $this->sanitize_post_id_list(
-				array_map(
-					'sanitize_text_field',
-					wp_unslash( $_POST['wpfa_event_speakers'] )
-				)
-			);
-		}
-
-		$this->update_post_id_list_meta( $post_id, 'wpfa_event_speakers', $speakers );
-
-		$this->sync_event_speaker_relationships( $post_id, $previous_speakers, $speakers );
+		echo '</p></div>';
 	}
 
 	/**
-	 * Get normalized speaker IDs assigned to an event.
+	 * Handle AJAX request to get speaker data.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param int $event_id Event post ID.
-	 * @return array<int> Speaker post IDs.
 	 */
-	private function get_event_speaker_ids( $event_id ) {
-		$speaker_ids = get_post_meta( $event_id, 'wpfa_event_speakers', true );
-
-		return $this->sanitize_post_id_list( $speaker_ids );
-	}
-
-	/**
-	 * Get normalized event IDs assigned to a speaker.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $speaker_id Speaker post ID.
-	 * @return array<int> Event post IDs.
-	 */
-	private function get_speaker_event_ids( $speaker_id ) {
-		$event_ids = get_post_meta( $speaker_id, 'wpfa_speaker_events', true );
-
-		return $this->sanitize_post_id_list( $event_ids );
-	}
-
-	/**
-	 * Sanitize, deduplicate, and reindex a list of post IDs.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param mixed $post_ids Raw post IDs.
-	 * @return array<int> Sanitized post IDs.
-	 */
-	private function sanitize_post_id_list( $post_ids ) {
-		if ( ! is_array( $post_ids ) ) {
-			$post_ids = array( $post_ids );
-		}
-
-		$post_ids = array_map( 'absint', $post_ids );
-		$post_ids = array_filter( $post_ids );
-
-		return array_values( array_unique( $post_ids ) );
-	}
-
-	/**
-	 * Save a normalized post ID list as post meta.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int        $post_id  Post ID.
-	 * @param string     $meta_key Meta key.
-	 * @param array<int> $post_ids Post IDs to save.
-	 * @return void
-	 */
-	private function update_post_id_list_meta( $post_id, $meta_key, $post_ids ) {
-		$post_ids = $this->sanitize_post_id_list( $post_ids );
-
-		if ( empty( $post_ids ) ) {
-			delete_post_meta( $post_id, $meta_key );
-			return;
-		}
-
-		update_post_meta( $post_id, $meta_key, $post_ids );
-	}
-
-	/**
-	 * Sync speaker-side event relationship meta after an event is saved.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int        $event_id          Event post ID.
-	 * @param array<int> $previous_speakers Speaker IDs before save.
-	 * @param array<int> $current_speakers  Speaker IDs after save.
-	 * @return void
-	 */
-	private function sync_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers ) {
-		$event_id          = absint( $event_id );
-		$previous_speakers = $this->sanitize_post_id_list( $previous_speakers );
-		$current_speakers  = $this->sanitize_post_id_list( $current_speakers );
-
-		if ( ! $event_id ) {
-			return;
-		}
-
-		$previous_speakers = array_values(
-			array_unique(
-				array_merge(
-					$previous_speakers,
-					$this->get_speakers_linked_to_event( $event_id )
-				)
-			)
-		);
-
-		$removed_speakers = array_diff( $previous_speakers, $current_speakers );
-
-		foreach ( $removed_speakers as $speaker_id ) {
-			$this->remove_event_from_speaker( $speaker_id, $event_id );
-		}
-
-		foreach ( $current_speakers as $speaker_id ) {
-			$this->add_event_to_speaker( $speaker_id, $event_id );
-		}
-	}
-
-	/**
-	 * Find speakers whose speaker-side event meta includes an event.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $event_id Event post ID.
-	 * @return array<int> Speaker post IDs.
-	 */
-	private function get_speakers_linked_to_event( $event_id ) {
-		$event_id = absint( $event_id );
-
-		if ( ! $event_id ) {
-			return array();
-		}
-
-		$batch_size   = 100;
-		$current_page = 1;
-		$speaker_ids  = array();
-
-		do {
-			$batch_ids = get_posts(
+	public function ajax_get_speaker() {
+		// Verify nonce.
+		if ( ! check_ajax_referer( 'wpfa_speakers_ajax', 'nonce', false ) ) {
+			wp_send_json_error(
 				array(
-					'post_type'              => 'wpfa_speaker',
-					'post_status'            => 'any',
-					'posts_per_page'         => $batch_size,
-					'paged'                  => $current_page,
-					'fields'                 => 'ids',
-					'no_found_rows'          => true,
-					'orderby'                => 'ID',
-					'order'                  => 'ASC',
-					'update_post_meta_cache' => false,
-					'update_post_term_cache' => false,
-				)
-			);
-
-			if ( empty( $batch_ids ) ) {
-				break;
-			}
-
-			$batch_count = count( $batch_ids );
-			update_meta_cache( 'post', $batch_ids );
-
-			foreach ( $batch_ids as $speaker_id ) {
-				if ( in_array( $event_id, $this->get_speaker_event_ids( $speaker_id ), true ) ) {
-					$speaker_ids[] = $speaker_id;
-				}
-			}
-
-			++$current_page;
-		} while ( $batch_count === $batch_size );
-
-		return $this->sanitize_post_id_list( $speaker_ids );
-	}
-
-	/**
-	 * Add an event ID to a speaker's related events.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $speaker_id Speaker post ID.
-	 * @param int $event_id Event post ID.
-	 * @return void
-	 */
-	private function add_event_to_speaker( $speaker_id, $event_id ) {
-		$speaker_id = absint( $speaker_id );
-		$event_id   = absint( $event_id );
-
-		if ( ! $speaker_id || ! $event_id ) {
-			return;
-		}
-
-		if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
-			return;
-		}
-
-		$event_ids   = $this->get_speaker_event_ids( $speaker_id );
-		$event_ids[] = $event_id;
-
-		$this->update_post_id_list_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
-	}
-
-	/**
-	 * Remove an event ID from a speaker's related events.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $speaker_id Speaker post ID.
-	 * @param int $event_id Event post ID.
-	 * @return void
-	 */
-	private function remove_event_from_speaker( $speaker_id, $event_id ) {
-		$speaker_id = absint( $speaker_id );
-		$event_id   = absint( $event_id );
-
-		if ( ! $speaker_id || ! $event_id ) {
-			return;
-		}
-
-		if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
-			return;
-		}
-
-		$event_ids = array_diff( $this->get_speaker_event_ids( $speaker_id ), array( $event_id ) );
-
-		$this->update_post_id_list_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
-	}
-
-	/**
-	 * Update a meta key when it has content, otherwise delete it.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int    $post_id Post ID.
-	 * @param string $key     Meta key.
-	 * @param string $value   Meta value.
-	 * @return void
-	 */
-	private function update_or_delete_post_meta( $post_id, $key, $value ) {
-		if ( '' === $value ) {
-			delete_post_meta( $post_id, $key );
-			return;
-		}
-
-		update_post_meta( $post_id, $key, $value );
-	}
-
-	/**
-	 * Save Speaker meta box data.
-	 *
-	 * @since 1.0.0
-	 * @param int $post_id The post ID.
-	 */
-	public function save_speaker_meta( $post_id ) {
-		$speaker_nonce = isset( $_POST['wpfa_speaker_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_speaker_meta_nonce'] ) ) : '';
-
-		if ( ! $speaker_nonce || ! wp_verify_nonce( $speaker_nonce, 'wpfa_speaker_meta_nonce' ) ) {
-			return;
-		}
-
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
-
-		if ( isset( $_POST['wpfa_speaker_position'] ) ) {
-			update_post_meta( $post_id, 'wpfa_speaker_position', sanitize_text_field( wp_unslash( $_POST['wpfa_speaker_position'] ) ) );
-		}
-
-		if ( isset( $_POST['wpfa_speaker_organization'] ) ) {
-			update_post_meta( $post_id, 'wpfa_speaker_organization', sanitize_text_field( wp_unslash( $_POST['wpfa_speaker_organization'] ) ) );
-		}
-
-		if ( isset( $_POST['wpfa_speaker_bio'] ) ) {
-			update_post_meta( $post_id, 'wpfa_speaker_bio', wp_kses_post( wp_unslash( $_POST['wpfa_speaker_bio'] ) ) );
-		}
-
-		if ( isset( $_POST['wpfa_speaker_headshot_url'] ) ) {
-			update_post_meta( $post_id, 'wpfa_speaker_headshot_url', esc_url_raw( wp_unslash( $_POST['wpfa_speaker_headshot_url'] ) ) );
-		}
-
-		$previous_events = $this->get_speaker_event_ids( $post_id );
-		$events          = array();
-
-		if ( isset( $_POST['wpfa_speaker_events'] ) && is_array( $_POST['wpfa_speaker_events'] ) ) {
-			$events = $this->sanitize_post_id_list(
-				array_map(
-					'sanitize_text_field',
-					wp_unslash( $_POST['wpfa_speaker_events'] )
-				)
+					'message' => esc_html__( 'Invalid nonce', 'wpfaevent' ),
+				),
+				403
 			);
 		}
 
-		$this->update_post_id_list_meta( $post_id, 'wpfa_speaker_events', $events );
-		$this->sync_speaker_event_relationships( $post_id, $previous_events, $events );
-	}
-
-	/**
-	 * Sync event-side speaker relationship meta after a speaker is saved.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int        $speaker_id      Speaker post ID.
-	 * @param array<int> $previous_events Event IDs before save.
-	 * @param array<int> $current_events  Event IDs after save.
-	 * @return void
-	 */
-	private function sync_speaker_event_relationships( $speaker_id, $previous_events, $current_events ) {
-		$speaker_id      = absint( $speaker_id );
-		$previous_events = $this->sanitize_post_id_list( $previous_events );
-		$current_events  = $this->sanitize_post_id_list( $current_events );
-
-		if ( ! $speaker_id || 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
-			return;
-		}
-
-		$previous_events = array_values(
-			array_unique(
-				array_merge(
-					$previous_events,
-					$this->get_events_linked_to_speaker( $speaker_id )
-				)
-			)
-		);
-
-		$removed_events = array_diff( $previous_events, $current_events );
-
-		foreach ( $removed_events as $event_id ) {
-			$this->remove_speaker_from_event( $event_id, $speaker_id );
-		}
-
-		foreach ( $current_events as $event_id ) {
-			$this->add_speaker_to_event( $event_id, $speaker_id );
-		}
-	}
-
-	/**
-	 * Find events whose event-side speaker meta includes a speaker.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $speaker_id Speaker post ID.
-	 * @return array<int> Event post IDs.
-	 */
-	private function get_events_linked_to_speaker( $speaker_id ) {
-		$speaker_id = absint( $speaker_id );
+		$speaker_id = isset( $_POST['speaker_id'] ) ? absint( $_POST['speaker_id'] ) : 0;
 
 		if ( ! $speaker_id ) {
-			return array();
+			wp_send_json_error( esc_html__( 'Invalid speaker ID', 'wpfaevent' ) );
 		}
 
-		$batch_size   = 100;
-		$current_page = 1;
-		$event_ids    = array();
+		$speaker = get_post( $speaker_id );
 
-		do {
-			$batch_ids = get_posts(
+		if ( ! $speaker || 'wpfa_speaker' !== $speaker->post_type || ! current_user_can( 'edit_post', $speaker_id ) ) {
+			wp_send_json_error( esc_html__( 'Speaker not found', 'wpfaevent' ) );
+		}
+
+		// Get category term.
+		$category      = '';
+		$category_slug = '';
+		$terms         = wp_get_object_terms( $speaker_id, 'wpfa_speaker_category' );
+		if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+			$category      = $terms[0]->name;
+			$category_slug = $terms[0]->slug;
+		}
+
+		$data = array(
+			'id'            => $speaker_id,
+			'name'          => $speaker->post_title,
+			'position'      => get_post_meta( $speaker_id, 'wpfa_speaker_position', true ),
+			'organization'  => get_post_meta( $speaker_id, 'wpfa_speaker_organization', true ),
+			'bio'           => get_post_meta( $speaker_id, 'wpfa_speaker_bio', true ),
+			'headshot_url'  => get_post_meta( $speaker_id, 'wpfa_speaker_headshot_url', true ),
+			'linkedin'      => get_post_meta( $speaker_id, 'wpfa_speaker_linkedin', true ),
+			'twitter'       => get_post_meta( $speaker_id, 'wpfa_speaker_twitter', true ),
+			'github'        => get_post_meta( $speaker_id, 'wpfa_speaker_github', true ),
+			'website'       => get_post_meta( $speaker_id, 'wpfa_speaker_website', true ),
+			'category'      => $category,
+			'category_slug' => $category_slug,
+			'talk_title'    => get_post_meta( $speaker_id, 'wpfa_speaker_talk_title', true ),
+			'talk_date'     => get_post_meta( $speaker_id, 'wpfa_speaker_talk_date', true ),
+			'talk_time'     => get_post_meta( $speaker_id, 'wpfa_speaker_talk_time', true ),
+			'talk_end_time' => get_post_meta( $speaker_id, 'wpfa_speaker_talk_end_time', true ),
+			'talk_abstract' => get_post_meta( $speaker_id, 'wpfa_speaker_talk_abstract', true ),
+		);
+
+		wp_send_json_success( $data );
+	}
+
+	/**
+	 * Handle AJAX request to add a new speaker.
+	 *
+	 * @since 1.0.0
+	 */
+	public function ajax_add_speaker() {
+		// Verify nonce.
+		if ( ! check_ajax_referer( 'wpfa_speakers_ajax', 'nonce', false ) ) {
+			wp_send_json_error(
 				array(
-					'post_type'              => 'wpfa_event',
-					'post_status'            => 'any',
-					'posts_per_page'         => $batch_size,
-					'paged'                  => $current_page,
-					'fields'                 => 'ids',
-					'no_found_rows'          => true,
-					'orderby'                => 'ID',
-					'order'                  => 'ASC',
-					'update_post_meta_cache' => false,
-					'update_post_term_cache' => false,
-				)
+					'message' => esc_html__( 'Invalid nonce', 'wpfaevent' ),
+				),
+				403
 			);
+		}
 
-			if ( empty( $batch_ids ) ) {
-				break;
+		if ( ! current_user_can( 'publish_speakers' ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Unauthorized', 'wpfaevent' ),
+				),
+				403
+			);
+		}
+
+		// Validate required fields.
+		$required_fields = array( 'name', 'position', 'bio', 'talk_title', 'talk_date', 'talk_time', 'talk_end_time' );
+		foreach ( $required_fields as $field ) {
+			if ( empty( $_POST[ $field ] ) ) {
+				/* translators: %s: Required field key. */
+				wp_send_json_error( sprintf( esc_html__( 'Missing required field: %s', 'wpfaevent' ), $field ) );
+			}
+		}
+
+		// Create speaker post.
+		$speaker_name = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+		$speaker_data = array(
+			'post_title'   => $speaker_name,
+			'post_type'    => 'wpfa_speaker',
+			'post_status'  => 'publish',
+			'post_content' => '',
+		);
+
+		$speaker_id = wp_insert_post( $speaker_data );
+
+		if ( is_wp_error( $speaker_id ) ) {
+			wp_send_json_error( $speaker_id->get_error_message() );
+		}
+
+		// Handle image upload.
+		$image_url = '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- media_handle_upload() requires the raw $_FILES payload.
+		$uploaded_file = ( isset( $_FILES['image_upload'] ) && is_array( $_FILES['image_upload'] ) ) ? $_FILES['image_upload'] : array();
+		if ( ! empty( $uploaded_file['name'] ) ) {
+			// Validate file type.
+			$allowed_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp' );
+			$file_type     = isset( $uploaded_file['type'] ) ? sanitize_mime_type( wp_unslash( $uploaded_file['type'] ) ) : '';
+
+			if ( ! in_array( $file_type, $allowed_types, true ) ) {
+				wp_send_json_error( esc_html__( 'Invalid file type. Only JPG, PNG, GIF, and WebP are allowed.', 'wpfaevent' ) );
 			}
 
-			$batch_count = count( $batch_ids );
-			update_meta_cache( 'post', $batch_ids );
+			// Validate file size (2MB max).
+			$max_size  = 2 * 1024 * 1024; // 2MB in bytes.
+			$file_size = isset( $uploaded_file['size'] ) ? absint( $uploaded_file['size'] ) : 0;
+			if ( $file_size > $max_size ) {
+				wp_send_json_error( esc_html__( 'File size exceeds 2MB limit.', 'wpfaevent' ) );
+			}
 
-			foreach ( $batch_ids as $event_id ) {
-				if ( in_array( $speaker_id, $this->get_event_speaker_ids( $event_id ), true ) ) {
-					$event_ids[] = $event_id;
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+
+			// Upload and create attachment.
+			$attachment_id = media_handle_upload( 'image_upload', 0 );
+
+			if ( is_wp_error( $attachment_id ) ) {
+				/* translators: %s: Upload error message. */
+				wp_send_json_error( sprintf( esc_html__( 'Image upload failed: %s', 'wpfaevent' ), $attachment_id->get_error_message() ) );
+			}
+
+			$image_url = wp_get_attachment_url( $attachment_id );
+		} elseif ( ! empty( $_POST['image_url'] ) ) {
+			$image_url = esc_url_raw( wp_unslash( $_POST['image_url'] ) );
+		}
+
+		// Save meta fields.
+		$meta_fields = array(
+			'wpfa_speaker_position'     => 'position',
+			'wpfa_speaker_organization' => 'organization',
+			'wpfa_speaker_bio'          => 'bio',
+			'wpfa_speaker_headshot_url' => 'image_url',
+			'wpfa_speaker_linkedin'     => 'linkedin',
+			'wpfa_speaker_twitter'      => 'twitter',
+			'wpfa_speaker_github'       => 'github',
+			'wpfa_speaker_website'      => 'website',
+		);
+
+		foreach ( $meta_fields as $meta_key => $post_key ) {
+			if ( 'image_url' === $post_key && ! empty( $image_url ) ) {
+				// Use uploaded image URL or provided URL.
+				update_post_meta( $speaker_id, $meta_key, $image_url );
+			} elseif ( isset( $_POST[ $post_key ] ) ) {
+				$value = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+
+				if ( 'bio' === $post_key ) {
+					$value = wp_kses_post( wp_unslash( $_POST[ $post_key ] ) );
+				} elseif ( in_array( $post_key, array( 'linkedin', 'twitter', 'github', 'website' ), true ) ) {
+					$value = esc_url_raw( wp_unslash( $_POST[ $post_key ] ) );
+				} else {
+					$value = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+				}
+
+				if ( strlen( $value ) === 0 ) {
+					delete_post_meta( $speaker_id, $meta_key );
+				} else {
+					update_post_meta( $speaker_id, $meta_key, $value );
 				}
 			}
+		}
 
-			++$current_page;
-		} while ( $batch_count === $batch_size );
+		$session_fields = array(
+			'wpfa_speaker_talk_title'    => 'talk_title',
+			'wpfa_speaker_talk_date'     => 'talk_date',
+			'wpfa_speaker_talk_time'     => 'talk_time',
+			'wpfa_speaker_talk_end_time' => 'talk_end_time',
+			'wpfa_speaker_talk_abstract' => 'talk_abstract',
+		);
 
-		return $this->sanitize_post_id_list( $event_ids );
+		foreach ( $session_fields as $meta_key => $post_key ) {
+			if ( isset( $_POST[ $post_key ] ) ) {
+
+				if ( 'talk_abstract' === $post_key ) {
+					$value = wp_kses_post( wp_unslash( $_POST[ $post_key ] ) );
+				} else {
+					$value = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+				}
+
+				if ( strlen( $value ) === 0 ) {
+					delete_post_meta( $speaker_id, $meta_key );
+				} else {
+					update_post_meta( $speaker_id, $meta_key, $value );
+				}
+			}
+		}
+
+		if ( isset( $_POST['category'] ) ) {
+			$category = sanitize_text_field( wp_unslash( $_POST['category'] ) );
+
+			// If it's numeric, it's a term ID.
+			if ( is_numeric( $category ) ) {
+				$term_id = (int) $category;
+				wp_set_object_terms( $speaker_id, $term_id, 'wpfa_speaker_category' );
+			} elseif ( '_custom' === $category && isset( $_POST['category_custom'] ) && ! empty( $_POST['category_custom'] ) ) {
+				// If it's "_custom" with custom value.
+				$category_name = sanitize_text_field( wp_unslash( $_POST['category_custom'] ) );
+				wp_set_object_terms( $speaker_id, $category_name, 'wpfa_speaker_category' );
+			} elseif ( ! empty( $category ) && '_custom' !== $category ) {
+				// If it's a slug or name.
+				wp_set_object_terms( $speaker_id, $category, 'wpfa_speaker_category' );
+			} else {
+				// Empty value.
+				wp_set_object_terms( $speaker_id, array(), 'wpfa_speaker_category' );
+			}
+		}
+
+		wp_send_json_success( array( 'speaker_id' => $speaker_id ) );
 	}
 
 	/**
-	 * Add a speaker ID to an event's related speakers.
+	 * Handle AJAX request to update a speaker.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param int $event_id   Event post ID.
-	 * @param int $speaker_id Speaker post ID.
-	 * @return void
 	 */
-	private function add_speaker_to_event( $event_id, $speaker_id ) {
-		$event_id   = absint( $event_id );
-		$speaker_id = absint( $speaker_id );
-
-		if ( ! $event_id || ! $speaker_id ) {
-			return;
+	public function ajax_update_speaker() {
+		// Verify nonce.
+		if ( ! check_ajax_referer( 'wpfa_speakers_ajax', 'nonce', false ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Invalid nonce', 'wpfaevent' ),
+				),
+				403
+			);
 		}
 
-		if ( 'wpfa_event' !== get_post_type( $event_id ) ) {
-			return;
+		$speaker_id = isset( $_POST['speaker_id'] ) ? absint( $_POST['speaker_id'] ) : 0;
+
+		if ( ! $speaker_id ) {
+			wp_send_json_error( __( 'Invalid speaker ID', 'wpfaevent' ) );
 		}
 
-		if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
-			return;
+		// Verify the speaker exists and the user can edit it.
+		$speaker = get_post( $speaker_id );
+		if ( ! $speaker || 'wpfa_speaker' !== $speaker->post_type || ! current_user_can( 'edit_post', $speaker_id ) ) {
+			wp_send_json_error( __( 'Cannot edit this speaker', 'wpfaevent' ) );
 		}
 
-		$speaker_ids   = $this->get_event_speaker_ids( $event_id );
-		$speaker_ids[] = $speaker_id;
+		// Validate required fields.
+		$required_fields = array( 'name', 'position', 'bio', 'talk_title', 'talk_date', 'talk_time', 'talk_end_time' );
+		foreach ( $required_fields as $field ) {
+			if ( empty( $_POST[ $field ] ) ) {
+				/* translators: %s: Required field key. */
+				wp_send_json_error( sprintf( esc_html__( 'Missing required field: %s', 'wpfaevent' ), $field ) );
+			}
+		}
 
-		$this->update_post_id_list_meta( $event_id, 'wpfa_event_speakers', $speaker_ids );
+		// Update post title if the name changed.
+		$speaker_name = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+		if ( ! empty( $speaker_name ) ) {
+			wp_update_post(
+				array(
+					'ID'         => $speaker_id,
+					'post_title' => $speaker_name,
+				)
+			);
+		}
+
+		// Handle image upload.
+		$image_url = '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- media_handle_upload() requires the raw $_FILES payload.
+		$uploaded_file = ( isset( $_FILES['image_upload'] ) && is_array( $_FILES['image_upload'] ) ) ? $_FILES['image_upload'] : array();
+		if ( ! empty( $uploaded_file['name'] ) ) {
+			// Validate file type.
+			$allowed_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp' );
+			$file_type     = isset( $uploaded_file['type'] ) ? sanitize_mime_type( wp_unslash( $uploaded_file['type'] ) ) : '';
+
+			if ( ! in_array( $file_type, $allowed_types, true ) ) {
+				wp_send_json_error( esc_html__( 'Invalid file type. Only JPG, PNG, GIF, and WebP are allowed.', 'wpfaevent' ) );
+			}
+
+			// Validate file size (2MB max).
+			$max_size  = 2 * 1024 * 1024; // 2MB in bytes.
+			$file_size = isset( $uploaded_file['size'] ) ? absint( $uploaded_file['size'] ) : 0;
+			if ( $file_size > $max_size ) {
+				wp_send_json_error( esc_html__( 'File size exceeds 2MB limit.', 'wpfaevent' ) );
+			}
+
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+
+			// Upload and create attachment.
+			$attachment_id = media_handle_upload( 'image_upload', $speaker_id );
+
+			if ( is_wp_error( $attachment_id ) ) {
+				/* translators: %s: Upload error message. */
+				wp_send_json_error( sprintf( esc_html__( 'Image upload failed: %s', 'wpfaevent' ), $attachment_id->get_error_message() ) );
+			}
+
+			$image_url = wp_get_attachment_url( $attachment_id );
+		} elseif ( ! empty( $_POST['image_url'] ) ) {
+			$image_url = esc_url_raw( wp_unslash( $_POST['image_url'] ) );
+		}
+
+		// Save meta fields.
+		$meta_fields = array(
+			'wpfa_speaker_position'     => 'position',
+			'wpfa_speaker_organization' => 'organization',
+			'wpfa_speaker_bio'          => 'bio',
+			'wpfa_speaker_headshot_url' => 'image_url',
+			'wpfa_speaker_linkedin'     => 'linkedin',
+			'wpfa_speaker_twitter'      => 'twitter',
+			'wpfa_speaker_github'       => 'github',
+			'wpfa_speaker_website'      => 'website',
+		);
+
+		foreach ( $meta_fields as $meta_key => $post_key ) {
+			if ( 'image_url' === $post_key && ! empty( $image_url ) ) {
+				// Use uploaded image URL or provided URL.
+				update_post_meta( $speaker_id, $meta_key, $image_url );
+			} elseif ( isset( $_POST[ $post_key ] ) ) {
+
+				if ( 'bio' === $post_key ) {
+					$value = wp_kses_post( wp_unslash( $_POST[ $post_key ] ) );
+				} elseif ( in_array( $post_key, array( 'linkedin', 'twitter', 'github', 'website' ), true ) ) {
+					$value = esc_url_raw( wp_unslash( $_POST[ $post_key ] ) );
+				} else {
+					$value = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+				}
+
+				// Delete meta when the field is intentionally cleared to avoid storing empty values.
+				if ( strlen( $value ) === 0 ) {
+					delete_post_meta( $speaker_id, $meta_key );
+				} else {
+					update_post_meta( $speaker_id, $meta_key, $value );
+				}
+			}
+		}
+
+		$session_fields = array(
+			'wpfa_speaker_talk_title'    => 'talk_title',
+			'wpfa_speaker_talk_date'     => 'talk_date',
+			'wpfa_speaker_talk_time'     => 'talk_time',
+			'wpfa_speaker_talk_end_time' => 'talk_end_time',
+			'wpfa_speaker_talk_abstract' => 'talk_abstract',
+		);
+
+		foreach ( $session_fields as $meta_key => $post_key ) {
+			if ( isset( $_POST[ $post_key ] ) ) {
+
+				if ( 'talk_abstract' === $post_key ) {
+					$value = wp_kses_post( wp_unslash( $_POST[ $post_key ] ) );
+				} else {
+					$value = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+				}
+
+				if ( strlen( $value ) === 0 ) {
+					delete_post_meta( $speaker_id, $meta_key );
+				} else {
+					update_post_meta( $speaker_id, $meta_key, $value );
+				}
+			}
+		}
+
+		if ( isset( $_POST['category'] ) ) {
+			$category = sanitize_text_field( wp_unslash( $_POST['category'] ) );
+
+			// If it's numeric, it's a term ID.
+			if ( is_numeric( $category ) ) {
+				$term_id = (int) $category;
+				wp_set_object_terms( $speaker_id, $term_id, 'wpfa_speaker_category' );
+			} elseif ( '_custom' === $category && isset( $_POST['category_custom'] ) && ! empty( $_POST['category_custom'] ) ) {
+				// If it's "_custom" with a custom value.
+				$category_name = sanitize_text_field( wp_unslash( $_POST['category_custom'] ) );
+				wp_set_object_terms( $speaker_id, $category_name, 'wpfa_speaker_category' );
+			} elseif ( ! empty( $category ) && '_custom' !== $category ) {
+				// If it's a slug or name.
+				wp_set_object_terms( $speaker_id, $category, 'wpfa_speaker_category' );
+			} else {
+				// Empty value.
+				wp_set_object_terms( $speaker_id, array(), 'wpfa_speaker_category' );
+			}
+		}
+
+		wp_send_json_success();
 	}
 
 	/**
-	 * Remove a speaker ID from an event's related speakers.
+	 * Handle AJAX request to delete a speaker.
 	 *
 	 * @since 1.0.0
+	 */
+	public function ajax_delete_speaker() {
+		// Verify nonce.
+		if ( ! check_ajax_referer( 'wpfa_speakers_ajax', 'nonce', false ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Invalid nonce', 'wpfaevent' ),
+				),
+				403
+			);
+		}
+
+		$speaker_id = isset( $_POST['speaker_id'] ) ? absint( $_POST['speaker_id'] ) : 0;
+
+		if ( ! $speaker_id ) {
+			wp_send_json_error( __( 'Invalid speaker ID', 'wpfaevent' ) );
+		}
+
+		// Verify the speaker exists and the user can delete it.
+		$speaker = get_post( $speaker_id );
+		if ( ! $speaker || 'wpfa_speaker' !== $speaker->post_type || ! current_user_can( 'delete_post', $speaker_id ) ) {
+			wp_send_json_error( __( 'Cannot delete this speaker', 'wpfaevent' ) );
+		}
+
+		// Delete the speaker.
+		$result = wp_delete_post( $speaker_id, true );
+
+		if ( ! $result ) {
+			wp_send_json_error( __( 'Failed to delete speaker', 'wpfaevent' ) );
+		}
+
+		wp_send_json_success();
+	}
+
+	/**
+	 * Handle Eventyay JSON:API speaker sync for the admin dashboard.
 	 *
-	 * @param int $event_id   Event post ID.
-	 * @param int $speaker_id Speaker post ID.
+	 * @since 1.0.0
 	 * @return void
 	 */
-	private function remove_speaker_from_event( $event_id, $speaker_id ) {
-		$event_id   = absint( $event_id );
-		$speaker_id = absint( $speaker_id );
-
-		if ( ! $event_id || ! $speaker_id ) {
-			return;
-		}
-
-		if ( 'wpfa_event' !== get_post_type( $event_id ) ) {
-			return;
-		}
-
-		if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
-			return;
-		}
-
-		$speaker_ids = array_diff( $this->get_event_speaker_ids( $event_id ), array( $speaker_id ) );
-
-		$this->update_post_id_list_meta( $event_id, 'wpfa_event_speakers', $speaker_ids );
+	public function ajax_sync_eventyay() {
+		$this->get_eventyay_importer()->ajax_sync_eventyay();
 	}
 }

--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -4267,6 +4267,43 @@ class Wpfaevent_Eventyay_Importer {
 	}
 
 	/**
+	 * Ensure a dashboard sync URL targets the configured Eventyay host and API path.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $api_url Raw API URL.
+	 * @return true|WP_Error
+	 */
+	private function validate_eventyay_sync_url( $api_url ) {
+		$settings        = $this->get_eventyay_import_settings();
+		$configured_host = wp_parse_url( $settings['base_url'], PHP_URL_HOST );
+		$sync_host       = wp_parse_url( $api_url, PHP_URL_HOST );
+
+		if (
+			empty( $configured_host ) ||
+			empty( $sync_host ) ||
+			strtolower( (string) $configured_host ) !== strtolower( (string) $sync_host )
+		) {
+			return new WP_Error(
+				'wpfaevent_eventyay_sync_host_not_allowed',
+				esc_html__( 'The Eventyay sync URL must use the configured Eventyay host.', 'wpfaevent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$path = wp_parse_url( $api_url, PHP_URL_PATH );
+		if ( false === strpos( (string) $path, '/api/' ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_sync_path_not_allowed',
+				esc_html__( 'The Eventyay sync URL must point to an Eventyay API endpoint.', 'wpfaevent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Validate and complete a dashboard Eventyay API URL.
 	 *
 	 * @since 1.0.0
@@ -4294,6 +4331,11 @@ class Wpfaevent_Eventyay_Importer {
 				esc_html__( 'The Eventyay API URL must use HTTP or HTTPS.', 'wpfaevent' ),
 				array( 'status' => 400 )
 			);
+		}
+
+		$host_validation = $this->validate_eventyay_sync_url( $api_url );
+		if ( is_wp_error( $host_validation ) ) {
+			return $host_validation;
 		}
 
 		$path = isset( $parts['path'] ) ? $parts['path'] : '';

--- a/admin/js/wpfaevent-admin.js
+++ b/admin/js/wpfaevent-admin.js
@@ -1,32 +1,47 @@
 (function( $ ) {
 	'use strict';
 
-	/**
-	 * All of the code for your admin-facing JavaScript source
-	 * should reside in this file.
-	 *
-	 * Note: It has been assumed you will write jQuery code here, so the
-	 * $ function reference has been prepared for usage within the scope
-	 * of this function.
-	 *
-	 * This enables you to define handlers, for when the DOM is ready:
-	 *
-	 * $(function() {
-	 *
-	 * });
-	 *
-	 * When the window is loaded:
-	 *
-	 * $( window ).load(function() {
-	 *
-	 * });
-	 *
-	 * ...and/or other possibilities.
-	 *
-	 * Ideally, it is not considered best practise to attach more than a
-	 * single DOM-ready or window-load handler for a particular page.
-	 * Although scripts in the WordPress core, Plugins and Themes may be
-	 * practising this, we should strive to set a better example in our own work.
-	 */
+	$( function() {
+		$( '.wpfaevent-custom-tabs' ).each( function() {
+			var $box = $( this );
+			var $list = $box.find( '.wpfaevent-custom-tabs-list' );
+			var $empty = $box.find( '.wpfaevent-custom-tabs-empty' );
+			var $template = $box.find( '.wpfaevent-custom-tab-template' );
+			var toggleEmptyState = function() {
+				$empty.prop( 'hidden', $list.find( '.wpfaevent-custom-tab-row' ).length > 0 );
+			};
+
+			$box.on( 'click', '.wpfaevent-add-custom-tab', function( event ) {
+				var nextIndex = parseInt( $box.attr( 'data-next-index' ), 10 );
+				var templateHtml = $template.html();
+				var $newRow;
+
+				event.preventDefault();
+
+				if ( isNaN( nextIndex ) ) {
+					nextIndex = $list.find( '.wpfaevent-custom-tab-row' ).length;
+				}
+
+				if ( ! templateHtml ) {
+					return;
+				}
+
+				$list.append( templateHtml.replace( /\{\{INDEX\}\}/g, nextIndex ) );
+				$box.attr( 'data-next-index', nextIndex + 1 );
+				toggleEmptyState();
+
+				$newRow = $list.find( '.wpfaevent-custom-tab-row' ).last();
+				$newRow.find( 'input[type="text"]' ).trigger( 'focus' );
+			} );
+
+			$box.on( 'click', '.wpfaevent-remove-custom-tab', function( event ) {
+				event.preventDefault();
+				$( this ).closest( '.wpfaevent-custom-tab-row' ).remove();
+				toggleEmptyState();
+			} );
+
+			toggleEmptyState();
+		} );
+	} );
 
 })( jQuery );

--- a/admin/partials/admin-dashboard.php
+++ b/admin/partials/admin-dashboard.php
@@ -3,7 +3,7 @@
  * Template Name: FOSSASIA Admin Dashboard (Plugin)
  * Description: A template for the admin dashboard to manage speaker submissions.
  */
-if ( ! current_user_can( 'manage_options' ) ) {
+if ( ! Wpfaevent_Roles::current_user_can_manage_settings() ) {
     wp_die( 'You do not have sufficient permissions to access this page.', 'Access Denied', [ 'response' => 403 ] );
 }
 
@@ -15,6 +15,7 @@ $data_dir = $upload_dir['basedir'] . '/fossasia-data';
 
 // Define file paths based on event ID
 $sponsors_file = $event_id ? $data_dir . '/sponsors-' . $event_id . '.json' : '';
+$exhibitors_file = $event_id ? $data_dir . '/exhibitors-' . $event_id . '.json' : '';
 $settings_file = $event_id ? $data_dir . '/site-settings-' . $event_id . '.json' : '';
 $speakers_file = $event_id ? $data_dir . '/speakers-' . $event_id . '.json' : '';
 $schedule_file = $event_id ? $data_dir . '/schedule-' . $event_id . '.json' : '';
@@ -33,7 +34,8 @@ $coc_content_file = $data_dir . '/coc-content.json';
 // Ensure files exist
 if ($event_id) {
     if (!file_exists($sponsors_file)) { file_put_contents($sponsors_file, '[]'); }
-    if (!file_exists($settings_file)) { file_put_contents($settings_file, '{"about_section_content": "", "section_visibility": {"about": true, "speakers": true, "schedule": true, "sponsors": true}}'); }
+    if (!file_exists($exhibitors_file)) { file_put_contents($exhibitors_file, '[]'); }
+    if (!file_exists($settings_file)) { file_put_contents($settings_file, '{"about_section_content": "", "section_visibility": {"about": true, "speakers": true, "schedule": true, "sponsors": true, "exhibitors": true}}'); }
     if (!file_exists($speakers_file)) { file_put_contents($speakers_file, '[]'); }
     if (!file_exists($schedule_file)) { file_put_contents($schedule_file, '{}'); }
     if (!file_exists($theme_settings_file)) { file_put_contents($theme_settings_file, '{"brand_color": "#D51007", "background_color": "#f8f9fa", "text_color": "#0b0b0b"}'); }
@@ -46,6 +48,7 @@ if (!file_exists($coc_content_file)) { file_put_contents($coc_content_file, '{"c
 // Speaker data is needed for the new "Manage Speakers" tab
 $speakers_data = $event_id && file_exists($speakers_file) ? json_decode(file_get_contents($speakers_file), true) : [];
 $sponsors_data = $event_id && file_exists($sponsors_file) ? json_decode(file_get_contents($sponsors_file), true) : [];
+$exhibitors_data = $event_id && file_exists($exhibitors_file) ? json_decode(file_get_contents($exhibitors_file), true) : [];
 $site_settings_data = $event_id && file_exists($settings_file) ? json_decode(file_get_contents($settings_file), true) : [];
 $custom_sections_data = json_decode(file_get_contents($sections_file), true);
 $schedule_data = $event_id && file_exists($schedule_file) ? json_decode(file_get_contents($schedule_file), true) : [];
@@ -739,6 +742,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const store = {
         speakers: <?php echo json_encode($speakers_data); ?>,
         sponsors: <?php echo json_encode($sponsors_data); ?>,
+        exhibitors: <?php echo json_encode($exhibitors_data); ?>,
         settings: <?php echo json_encode($site_settings_data); ?>,
         sections: <?php echo json_encode($custom_sections_data); ?>,
         navigation: <?php echo json_encode($navigation_data); ?>,
@@ -961,7 +965,8 @@ document.addEventListener('DOMContentLoaded', function() {
             { id: 'about', name: 'About Section' },
             { id: 'speakers', name: 'Speakers Section' },
             { id: 'schedule', name: 'Schedule Overview' },
-            { id: 'sponsors', name: 'Sponsors Section' }
+            { id: 'sponsors', name: 'Sponsors Section' },
+            { id: 'exhibitors', name: 'Exhibitors Section' }
         ];
 
         const render = () => {
@@ -1262,8 +1267,9 @@ document.addEventListener('DOMContentLoaded', function() {
             formData.append('action', 'fossasia_sync_eventyay');
             formData.append('nonce', adminNonce);
             formData.append('event_id', eventId);
+            formData.append('eventyay_api_url', apiUrlInput.value.trim());
 
-            // The PHP backend will now read the saved URL
+            // Send the current URL so sync does not depend on the legacy settings AJAX bridge.
             try {
                 const response = await fetch(ajaxUrl, { method: 'POST', body: formData });
                 const data = await response.json();
@@ -1294,11 +1300,17 @@ document.addEventListener('DOMContentLoaded', function() {
         });
 
         syncBtn.addEventListener('click', async () => {
-            if (await saveUrl()) {
-                runSync();
-            } else {
-                customAlert.alert('Could not save the URL. Please try again.', 'Error');
+            if (!apiUrlInput.value.trim()) {
+                customAlert.alert('Please enter an Eventyay API URL before syncing.', 'Error');
+                return;
             }
+
+            const saved = await saveUrl();
+            if (saved) {
+                store.settings.eventyay_api_url = apiUrlInput.value.trim();
+            }
+
+            runSync();
         });
     })();
 
@@ -2116,6 +2128,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const defaultTargets = [
                 { value: '#about', label: 'About Section' }, { value: '#speakers', label: 'Speakers Section' },
                 { value: '#schedule-overview', label: 'Schedule Overview Section' }, { value: '#sponsors', label: 'Sponsors Section' },
+                { value: '#exhibitors', label: 'Exhibitors Section' },
                 { value: '#venue', label: 'Venue Section' }
             ];
             const customTargets = (store.sections || [])

--- a/admin/partials/ajax-handlers/class-wpfaevent-event-handler.php
+++ b/admin/partials/ajax-handlers/class-wpfaevent-event-handler.php
@@ -19,14 +19,6 @@
 class Wpfaevent_Event_Handler {
 
 	/**
-	 * Initialize the class.
-	 *
-	 * @since    1.0.0
-	 */
-	public function __construct() {
-	}
-
-	/**
 	 * Handle AJAX request to get event data.
 	 *
 	 * @since    1.0.0
@@ -42,14 +34,6 @@ class Wpfaevent_Event_Handler {
 			);
 		}
 
-		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error(
-				array( 'message' => __( 'Unauthorized', 'wpfaevent' ) ),
-				403
-			);
-		}
-
 		$event_id = isset( $_POST['event_id'] ) ? absint( $_POST['event_id'] ) : 0;
 
 		if ( ! $event_id ) {
@@ -58,14 +42,8 @@ class Wpfaevent_Event_Handler {
 
 		$event = get_post( $event_id );
 
-		if ( ! $event || 'wpfa_event' !== $event->post_type ) {
+		if ( ! $event || 'wpfa_event' !== $event->post_type || ! current_user_can( 'edit_post', $event_id ) ) {
 			wp_send_json_error( esc_html__( 'Event not found', 'wpfaevent' ) );
-		}
-
-		$start_time = get_post_meta( $event_id, 'wpfa_event_start_time', true );
-
-		if ( '' === $start_time ) {
-			$start_time = get_post_meta( $event_id, 'wpfa_event_time', true );
 		}
 
 		$data = array(
@@ -75,11 +53,6 @@ class Wpfaevent_Event_Handler {
 			'excerpt'           => $event->post_excerpt,
 			'start_date'        => get_post_meta( $event_id, 'wpfa_event_start_date', true ),
 			'end_date'          => get_post_meta( $event_id, 'wpfa_event_end_date', true ),
-			'start_time'        => $start_time,
-			'end_time'          => get_post_meta( $event_id, 'wpfa_event_end_time', true ),
-			'time'              => $start_time,
-			'timezone'          => class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_timezone( $event_id ) : wp_timezone_string(),
-			'all_day'           => class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_all_day( $event_id ) : false,
 			'location'          => get_post_meta( $event_id, 'wpfa_event_location', true ),
 			'event_url'         => get_post_meta( $event_id, 'wpfa_event_url', true ),
 			'registration_link' => get_post_meta( $event_id, 'wpfa_event_registration_link', true ),
@@ -106,8 +79,7 @@ class Wpfaevent_Event_Handler {
 			);
 		}
 
-		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'publish_events' ) ) {
 			wp_send_json_error(
 				array(
 					'message' => __( 'Unauthorized', 'wpfaevent' ),
@@ -119,6 +91,7 @@ class Wpfaevent_Event_Handler {
 		$title             = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
 		$excerpt           = isset( $_POST['excerpt'] ) ? sanitize_text_field( wp_unslash( $_POST['excerpt'] ) ) : '';
 		$start_date        = isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : '';
+		$time              = isset( $_POST['time'] ) ? sanitize_text_field( wp_unslash( $_POST['time'] ) ) : '';
 		$location          = isset( $_POST['location'] ) ? sanitize_text_field( wp_unslash( $_POST['location'] ) ) : '';
 		$lead_text         = isset( $_POST['lead_text'] ) ? sanitize_text_field( wp_unslash( $_POST['lead_text'] ) ) : '';
 		$registration_link = isset( $_POST['registration_link'] ) ? esc_url_raw( wp_unslash( $_POST['registration_link'] ) ) : '';
@@ -128,6 +101,7 @@ class Wpfaevent_Event_Handler {
 			'title'             => $title,
 			'excerpt'           => $excerpt,
 			'start_date'        => $start_date,
+			'time'              => $time,
 			'location'          => $location,
 			'lead_text'         => $lead_text,
 			'registration_link' => $registration_link,
@@ -173,16 +147,17 @@ class Wpfaevent_Event_Handler {
 			'post_status'  => 'publish',
 		);
 
-		$event_id = wp_insert_post( $event_data, true );
+		$event_id = wp_insert_post( $event_data );
 
-		if ( is_wp_error( $event_id ) ) {
-			wp_send_json_error( $event_id->get_error_message() );
+		if ( 0 === $event_id ) {
+			wp_send_json_error( esc_html__( 'Failed to create event.', 'wpfaevent' ) );
 		}
 
 		// Save meta fields - using CORRECT form field names.
 		$meta_fields = array(
 			'wpfa_event_start_date'        => 'start_date',
 			'wpfa_event_end_date'          => 'end_date',
+			'wpfa_event_time'              => 'time',
 			'wpfa_event_location'          => 'location',
 			'wpfa_event_lead_text'         => 'lead_text',
 			'wpfa_event_registration_link' => 'registration_link',
@@ -203,8 +178,6 @@ class Wpfaevent_Event_Handler {
 				}
 			}
 		}
-
-		$this->save_event_timing_meta( $event_id, $_POST );
 
 		// Handle featured image upload - now safe since validation passed.
 		require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -247,14 +220,6 @@ class Wpfaevent_Event_Handler {
 			);
 		}
 
-		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error(
-				array( 'message' => __( 'Unauthorized', 'wpfaevent' ) ),
-				403
-			);
-		}
-
 		$event_id = isset( $_POST['event_id'] ) ? absint( $_POST['event_id'] ) : 0;
 
 		if ( ! $event_id ) {
@@ -268,7 +233,7 @@ class Wpfaevent_Event_Handler {
 		}
 
 		// Validate required fields - must match UI requirements.
-		$required_fields = array( 'title', 'excerpt', 'start_date', 'location', 'lead_text', 'registration_link' );
+		$required_fields = array( 'title', 'excerpt', 'start_date', 'time', 'location', 'lead_text', 'registration_link' );
 		foreach ( $required_fields as $field ) {
 			if ( empty( $_POST[ $field ] ) ) {
 				/* translators: %s: Field name */
@@ -325,6 +290,7 @@ class Wpfaevent_Event_Handler {
 		$meta_fields = array(
 			'wpfa_event_start_date'        => 'start_date',
 			'wpfa_event_end_date'          => 'end_date',
+			'wpfa_event_time'              => 'time',
 			'wpfa_event_location'          => 'location',
 			'wpfa_event_lead_text'         => 'lead_text',
 			'wpfa_event_url'               => 'event_url',
@@ -347,8 +313,6 @@ class Wpfaevent_Event_Handler {
 				}
 			}
 		}
-
-		$this->save_event_timing_meta( $event_id, $_POST );
 
 		// Handle featured image upload - now safe since validation passed.
 		if ( ! empty( $_FILES['featured_image']['name'] ) ) {
@@ -375,127 +339,6 @@ class Wpfaevent_Event_Handler {
 	}
 
 	/**
-	 * Save front-end event timing fields into calendar-aware event meta.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int   $event_id Event post ID.
-	 * @param array $request  Request data.
-	 * @return void
-	 */
-	private function save_event_timing_meta( $event_id, $request ) {
-		$event_id = absint( $event_id );
-
-		if ( ! $event_id || ! is_array( $request ) ) {
-			return;
-		}
-
-		$has_timing_payload = isset( $request['timezone'] )
-			|| isset( $request['all_day'] )
-			|| isset( $request['start_time'] )
-			|| isset( $request['end_time'] )
-			|| isset( $request['time'] );
-
-		if ( ! $has_timing_payload ) {
-			$this->sync_event_datetime_meta( $event_id );
-			return;
-		}
-
-		if ( isset( $request['timezone'] ) ) {
-			$posted_timezone = sanitize_text_field( wp_unslash( $request['timezone'] ) );
-			$timezone        = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_timezone( $posted_timezone ) : $posted_timezone;
-
-			$this->update_or_delete_post_meta( $event_id, 'wpfa_event_timezone', $timezone );
-		}
-
-		$all_day = isset( $request['all_day'] ) && rest_sanitize_boolean( wp_unslash( $request['all_day'] ) );
-		update_post_meta( $event_id, 'wpfa_event_all_day', $all_day ? '1' : '0' );
-
-		$posted_start_time = isset( $request['start_time'] ) ? sanitize_text_field( wp_unslash( $request['start_time'] ) ) : '';
-		$posted_end_time   = isset( $request['end_time'] ) ? sanitize_text_field( wp_unslash( $request['end_time'] ) ) : '';
-
-		if ( '' === $posted_start_time && isset( $request['time'] ) ) {
-			$posted_start_time = sanitize_text_field( wp_unslash( $request['time'] ) );
-		}
-
-		$start_time = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_time_value( $posted_start_time ) : $posted_start_time;
-		$end_time   = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_time_value( $posted_end_time ) : $posted_end_time;
-
-		if ( $all_day ) {
-			delete_post_meta( $event_id, 'wpfa_event_start_time' );
-			delete_post_meta( $event_id, 'wpfa_event_time' );
-			delete_post_meta( $event_id, 'wpfa_event_end_time' );
-			delete_post_meta( $event_id, 'wpfa_event_starts_at' );
-			delete_post_meta( $event_id, 'wpfa_event_ends_at' );
-			return;
-		}
-
-		$this->update_or_delete_post_meta( $event_id, 'wpfa_event_start_time', $start_time );
-		$this->update_or_delete_post_meta( $event_id, 'wpfa_event_time', $start_time );
-		$this->update_or_delete_post_meta( $event_id, 'wpfa_event_end_time', $end_time );
-		$this->sync_event_datetime_meta( $event_id );
-	}
-
-	/**
-	 * Keep calendar-aware datetime meta in sync after front-end AJAX saves.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $event_id Event post ID.
-	 * @return void
-	 */
-	private function sync_event_datetime_meta( $event_id ) {
-		$event_id = absint( $event_id );
-
-		if ( ! $event_id || ! class_exists( 'Wpfaevent_Meta_Event' ) ) {
-			return;
-		}
-
-		if ( Wpfaevent_Meta_Event::get_event_all_day( $event_id ) ) {
-			delete_post_meta( $event_id, 'wpfa_event_starts_at' );
-			delete_post_meta( $event_id, 'wpfa_event_ends_at' );
-			return;
-		}
-
-		$start_date = Wpfaevent_Meta_Event::sanitize_date_value( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
-		$end_date   = Wpfaevent_Meta_Event::sanitize_date_value( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
-		$start_time = Wpfaevent_Meta_Event::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_start_time', true ) );
-		$end_time   = Wpfaevent_Meta_Event::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_end_time', true ) );
-		$timezone   = Wpfaevent_Meta_Event::get_event_timezone( $event_id );
-
-		if ( '' === $start_time ) {
-			$start_time = Wpfaevent_Meta_Event::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_time', true ) );
-
-			if ( '' !== $start_time ) {
-				update_post_meta( $event_id, 'wpfa_event_start_time', $start_time );
-			}
-		}
-
-		$this->update_or_delete_post_meta( $event_id, 'wpfa_event_time', $start_time );
-		$this->update_or_delete_post_meta( $event_id, 'wpfa_event_starts_at', Wpfaevent_Meta_Event::build_datetime_value( $start_date, $start_time, $timezone ) );
-		$this->update_or_delete_post_meta( $event_id, 'wpfa_event_ends_at', Wpfaevent_Meta_Event::build_datetime_value( '' !== $end_date ? $end_date : $start_date, $end_time, $timezone ) );
-	}
-
-	/**
-	 * Update a meta value or delete it when empty.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int    $post_id Post ID.
-	 * @param string $key     Meta key.
-	 * @param string $value   Meta value.
-	 * @return void
-	 */
-	private function update_or_delete_post_meta( $post_id, $key, $value ) {
-		if ( '' === $value ) {
-			delete_post_meta( $post_id, $key );
-			return;
-		}
-
-		update_post_meta( $post_id, $key, $value );
-	}
-
-	/**
 	 * Handle AJAX request to delete an event.
 	 *
 	 * @since    1.0.0
@@ -507,14 +350,6 @@ class Wpfaevent_Event_Handler {
 				array(
 					'message' => esc_html__( 'Invalid nonce', 'wpfaevent' ),
 				),
-				403
-			);
-		}
-
-		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error(
-				array( 'message' => __( 'Unauthorized', 'wpfaevent' ) ),
 				403
 			);
 		}

--- a/admin/partials/ajax-handlers/class-wpfaevent-footer-handler.php
+++ b/admin/partials/ajax-handlers/class-wpfaevent-footer-handler.php
@@ -19,14 +19,6 @@
 class Wpfaevent_Footer_Handler {
 
 	/**
-	 * Initialize the class.
-	 *
-	 * @since    1.0.0
-	 */
-	public function __construct() {
-	}
-
-	/**
 	 * Handle AJAX request to update footer text.
 	 *
 	 * @since    1.0.0
@@ -39,7 +31,7 @@ class Wpfaevent_Footer_Handler {
 		}
 
 		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! Wpfaevent_Roles::current_user_can_manage_site_branding() ) {
 			wp_send_json_error( esc_html__( 'Unauthorized', 'wpfaevent' ), 403 );
 		}
 

--- a/admin/partials/ajax-handlers/class-wpfaevent-speakers-handler.php
+++ b/admin/partials/ajax-handlers/class-wpfaevent-speakers-handler.php
@@ -19,14 +19,6 @@
 class Wpfaevent_Speakers_Handler {
 
 	/**
-	 * Initialize the class.
-	 *
-	 * @since    1.0.0
-	 */
-	public function __construct() {
-	}
-
-	/**
 	 * Handle AJAX request to get speaker data.
 	 *
 	 * @since    1.0.0
@@ -42,14 +34,6 @@ class Wpfaevent_Speakers_Handler {
 			);
 		}
 
-		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error(
-				array( 'message' => __( 'Unauthorized', 'wpfaevent' ) ),
-				403
-			);
-		}
-
 		$speaker_id = isset( $_POST['speaker_id'] ) ? absint( $_POST['speaker_id'] ) : 0;
 
 		if ( ! $speaker_id ) {
@@ -58,7 +42,7 @@ class Wpfaevent_Speakers_Handler {
 
 		$speaker = get_post( $speaker_id );
 
-		if ( ! $speaker || 'wpfa_speaker' !== $speaker->post_type ) {
+		if ( ! $speaker || 'wpfa_speaker' !== $speaker->post_type || ! current_user_can( 'edit_post', $speaker_id ) ) {
 			wp_send_json_error( esc_html__( 'Speaker not found', 'wpfaevent' ) );
 		}
 
@@ -110,8 +94,7 @@ class Wpfaevent_Speakers_Handler {
 			);
 		}
 
-		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'publish_speakers' ) ) {
 			wp_send_json_error(
 				array(
 					'message' => __( 'Unauthorized', 'wpfaevent' ),
@@ -275,14 +258,6 @@ class Wpfaevent_Speakers_Handler {
 			);
 		}
 
-		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error(
-				array( 'message' => __( 'Unauthorized', 'wpfaevent' ) ),
-				403
-			);
-		}
-
 		$speaker_id = isset( $_POST['speaker_id'] ) ? absint( $_POST['speaker_id'] ) : 0;
 
 		if ( ! $speaker_id ) {
@@ -441,14 +416,6 @@ class Wpfaevent_Speakers_Handler {
 				array(
 					'message' => esc_html__( 'Invalid nonce', 'wpfaevent' ),
 				),
-				403
-			);
-		}
-
-		// Check permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error(
-				array( 'message' => __( 'Unauthorized', 'wpfaevent' ) ),
 				403
 			);
 		}

--- a/assets/demo/minimal.json
+++ b/assets/demo/minimal.json
@@ -6,7 +6,7 @@
       "slug": "alex-example",
       "org": "FOSSASIA",
       "position": "Developer Advocate",
-      "photo": "https://via.placeholder.com/300x300.png?text=Alex"
+      "photo": ""
     },
     {
       "title": "Bao Nguyen",
@@ -14,7 +14,7 @@
       "slug": "bao-nguyen",
       "org": "Eventyay",
       "position": "Software Engineer",
-      "photo": "https://via.placeholder.com/300x300.png?text=Bao"
+      "photo": ""
     }
   ],
   "events": [

--- a/includes/class-wpfaevent-activator.php
+++ b/includes/class-wpfaevent-activator.php
@@ -31,6 +31,9 @@ class Wpfaevent_Activator {
 		require_once plugin_dir_path( __FILE__ ) . 'cpt/class-wpfaevent-cpt-event.php';
 		require_once plugin_dir_path( __FILE__ ) . 'cpt/class-wpfaevent-cpt-speaker.php';
 		require_once plugin_dir_path( __FILE__ ) . 'taxonomies/class-wpfaevent-taxonomies.php';
+		require_once plugin_dir_path( __FILE__ ) . 'helpers/class-wpfaevent-additional-information-helper.php';
+		require_once plugin_dir_path( __FILE__ ) . 'helpers/class-wpfaevent-schedule-helper.php';
+		require_once plugin_dir_path( __FILE__ ) . 'helpers/class-wpfaevent-partner-helper.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-wpfaevent-roles.php';
 
 		// Register CPTs and taxonomies.
@@ -38,74 +41,16 @@ class Wpfaevent_Activator {
 		Wpfaevent_CPT_Speaker::register();
 		Wpfaevent_Taxonomies::register();
 
+		// Create the public schedule page used by event detail links.
+		Wpfaevent_Schedule_Helper::ensure_schedule_page( false );
+		Wpfaevent_Additional_Information_Helper::ensure_additional_information_page( false );
+		Wpfaevent_Partner_Helper::ensure_partner_page( false );
+
 		// Flush rewrite rules so CPT permalinks work.
 		flush_rewrite_rules();
 
-		// Grant custom capabilities to administrators.
-		self::add_capabilities();
+		// Register plugin roles and grant capabilities.
 		Wpfaevent_Roles::register_roles_and_capabilities();
 		update_option( Wpfaevent_Roles::ROLES_VERSION_OPTION, Wpfaevent_Roles::ROLES_VERSION, false );
-	}
-
-	/**
-	 * Grant custom capabilities to administrator role.
-	 *
-	 * @since 1.0.0
-	 */
-	private static function add_capabilities() {
-		$role = get_role( 'administrator' );
-
-		if ( ! $role ) {
-			return;
-		}
-
-		// Event capabilities.
-		// TODO: Future PR - Review capability list alignment with CPT registration.
-		// Currently granting extended capabilities (delete_*, edit_private_*, etc.).
-		// These are auto-derived by map_meta_cap. Consider either:
-		// 1. Explicitly defining all capabilities in CPT registration, OR
-		// 2. Only granting base capabilities defined in the CPT.
-		// Reference: https://developer.wordpress.org/plugins/users/roles-and-capabilities/.
-		$event_caps = array(
-			'edit_event',
-			'read_event',
-			'delete_event',
-			'edit_events',
-			'edit_others_events',
-			'publish_events',
-			'read_private_events',
-			'delete_events',
-			'delete_private_events',
-			'delete_published_events',
-			'delete_others_events',
-			'edit_private_events',
-			'edit_published_events',
-		);
-
-		foreach ( $event_caps as $cap ) {
-			$role->add_cap( $cap );
-		}
-
-		// Speaker capabilities.
-		// TODO: Same capability review needed for speakers (see event_caps above).
-		$speaker_caps = array(
-			'edit_speaker',
-			'read_speaker',
-			'delete_speaker',
-			'edit_speakers',
-			'edit_others_speakers',
-			'publish_speakers',
-			'read_private_speakers',
-			'delete_speakers',
-			'delete_private_speakers',
-			'delete_published_speakers',
-			'delete_others_speakers',
-			'edit_private_speakers',
-			'edit_published_speakers',
-		);
-
-		foreach ( $speaker_caps as $cap ) {
-			$role->add_cap( $cap );
-		}
 	}
 }

--- a/includes/class-wpfaevent-templates.php
+++ b/includes/class-wpfaevent-templates.php
@@ -71,12 +71,26 @@ class Wpfaevent_Templates {
 			'block'     => 'schedule',
 			'title'     => 'WPFA Schedule',
 		),
+		'additional_info' => array(
+			'file'      => 'page-additional-information.php',
+			'label'     => 'WPFA - Additional Information',
+			'shortcode' => 'wpfaevent_additional_information',
+			'block'     => 'additional-information',
+			'title'     => 'WPFA Additional Information',
+		),
 		'code_of_conduct' => array(
 			'file'      => 'page-code-of-conduct.php',
 			'label'     => 'WPFA - Code of Conduct',
 			'shortcode' => 'wpfaevent_code_of_conduct',
 			'block'     => 'code-of-conduct',
 			'title'     => 'WPFA Code of Conduct',
+		),
+		'partner'         => array(
+			'file'      => 'page-partner.php',
+			'label'     => 'WPFA - Partner',
+			'shortcode' => 'wpfaevent_partner',
+			'block'     => 'partner',
+			'title'     => 'WPFA Partner',
 		),
 	);
 
@@ -156,6 +170,22 @@ class Wpfaevent_Templates {
 
 		if ( is_singular( 'wpfa_event' ) ) {
 			$candidate = WPFAEVENT_PATH . 'public/templates/single-wpfa-event.php';
+
+			if ( file_exists( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		if ( is_post_type_archive( 'wpfa_speaker' ) ) {
+			$candidate = WPFAEVENT_PATH . 'public/templates/page-speakers.php';
+
+			if ( file_exists( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		if ( is_post_type_archive( 'wpfa_event' ) ) {
+			$candidate = WPFAEVENT_PATH . 'public/templates/archive-wpfa-event.php';
 
 			if ( file_exists( $candidate ) ) {
 				return $candidate;
@@ -566,8 +596,12 @@ class Wpfaevent_Templates {
 				return __( 'WPFA - Past Events', 'wpfaevent' );
 			case 'schedule':
 				return __( 'WPFA - Schedule', 'wpfaevent' );
+			case 'additional_info':
+				return __( 'WPFA - Additional Information', 'wpfaevent' );
 			case 'code_of_conduct':
 				return __( 'WPFA - Code of Conduct', 'wpfaevent' );
+			case 'partner':
+				return __( 'WPFA - Partner', 'wpfaevent' );
 			default:
 				return '';
 		}
@@ -593,8 +627,12 @@ class Wpfaevent_Templates {
 				return __( 'WPFA Past Events', 'wpfaevent' );
 			case 'schedule':
 				return __( 'WPFA Schedule', 'wpfaevent' );
+			case 'additional_info':
+				return __( 'WPFA Additional Information', 'wpfaevent' );
 			case 'code_of_conduct':
 				return __( 'WPFA Code of Conduct', 'wpfaevent' );
+			case 'partner':
+				return __( 'WPFA Partner', 'wpfaevent' );
 			default:
 				return '';
 		}
@@ -663,6 +701,14 @@ class Wpfaevent_Templates {
 			WPFAEVENT_VERSION,
 			'all'
 		);
+
+		wp_register_style(
+			'wpfaevent-event',
+			WPFAEVENT_URL . 'public/css/templates/event.css',
+			array( 'wpfaevent', 'wpfaevent-navigation' ),
+			WPFAEVENT_VERSION,
+			'all'
+		);
 	}
 
 	/**
@@ -678,7 +724,10 @@ class Wpfaevent_Templates {
 			'events'          => 'wpfaevent-events',
 			'speakers'        => 'wpfaevent-speakers',
 			'past_events'     => 'wpfaevent-past-events',
+			'schedule'        => 'wpfaevent-event',
+			'additional_info' => 'wpfaevent-event',
 			'code_of_conduct' => 'wpfaevent-code-of-conduct',
+			'partner'         => 'wpfaevent-event',
 		);
 
 		return isset( $handles[ $key ] ) ? $handles[ $key ] : 'wpfaevent';
@@ -697,7 +746,7 @@ class Wpfaevent_Templates {
 			wp_enqueue_style( 'wpfaevent' );
 		}
 
-		if ( in_array( $key, array( 'speakers', 'past_events', 'code_of_conduct' ), true ) && ! wp_style_is( 'wpfaevent-navigation', 'enqueued' ) ) {
+		if ( in_array( $key, array( 'speakers', 'past_events', 'schedule', 'additional_info', 'code_of_conduct', 'partner' ), true ) && ! wp_style_is( 'wpfaevent-navigation', 'enqueued' ) ) {
 			wp_enqueue_style( 'wpfaevent-navigation' );
 		}
 
@@ -716,6 +765,10 @@ class Wpfaevent_Templates {
 
 		if ( 'events' === $key ) {
 			wp_enqueue_style( 'wpfaevent-events' );
+		}
+
+		if ( in_array( $key, array( 'schedule', 'additional_info', 'partner' ), true ) ) {
+			wp_enqueue_style( 'wpfaevent-event' );
 		}
 
 		if ( 'code_of_conduct' === $key ) {

--- a/includes/class-wpfaevent.php
+++ b/includes/class-wpfaevent.php
@@ -84,6 +84,7 @@ class Wpfaevent {
 		$this->define_cpt_hooks();
 		$this->define_taxonomy_hooks();
 		$this->define_meta_hooks();
+		$this->define_page_hooks();
 		$this->define_admin_hooks();
 		$this->define_public_hooks();
 	}
@@ -126,7 +127,12 @@ class Wpfaevent {
 
 		// Calendar export support.
 		require_once plugin_dir_path( __FILE__ ) . 'class-wpfaevent-calendar.php';
+
+		// Shared frontend helpers.
+		require_once plugin_dir_path( __FILE__ ) . 'helpers/class-wpfaevent-event-navigation-helper.php';
+		require_once plugin_dir_path( __FILE__ ) . 'helpers/class-wpfaevent-additional-information-helper.php';
 		require_once plugin_dir_path( __FILE__ ) . 'helpers/class-wpfaevent-schedule-helper.php';
+		require_once plugin_dir_path( __FILE__ ) . 'helpers/class-wpfaevent-partner-helper.php';
 
 		// Admin and Public classes.
 		require_once plugin_dir_path( __DIR__ ) . 'admin/class-wpfaevent-eventyay-importer.php';
@@ -186,6 +192,19 @@ class Wpfaevent {
 	}
 
 	/**
+	 * Register hooks for plugin-managed pages.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function define_page_hooks() {
+		// Repair the schedule page for existing installs before WordPress resolves the request.
+		$this->loader->add_action( 'init', 'Wpfaevent_Schedule_Helper', 'ensure_schedule_page', 20 );
+		$this->loader->add_action( 'init', 'Wpfaevent_Additional_Information_Helper', 'ensure_additional_information_page', 21 );
+		$this->loader->add_action( 'init', 'Wpfaevent_Partner_Helper', 'ensure_partner_page', 22 );
+	}
+
+	/**
 	 * Register all of the hooks related to the admin area functionality
 	 * of the plugin.
 	 *
@@ -198,6 +217,7 @@ class Wpfaevent {
 
 		// Register admin-specific stylesheet.
 		$this->loader->add_action( 'admin_enqueue_scripts', $this->plugin_admin, 'enqueue_styles' );
+		$this->loader->add_action( 'admin_enqueue_scripts', $this->plugin_admin, 'enqueue_scripts' );
 
 		// Register settings page.
 		$this->loader->add_action( 'admin_menu', $this->plugin_admin, 'register_settings_page' );
@@ -208,21 +228,27 @@ class Wpfaevent {
 		$plugin_basename = plugin_basename( dirname( __DIR__ ) . '/wpfaevent.php' );
 		$this->loader->add_filter( 'plugin_action_links_' . $plugin_basename, $this->plugin_admin, 'add_settings_link' );
 
-		// Add meta boxes to CPTs.
-		$this->loader->add_action( 'add_meta_boxes', $this->plugin_admin, 'add_meta_boxes' );
+		// Add meta boxes to CPTs from the meta classes.
+		$this->loader->add_action( 'add_meta_boxes', 'Wpfaevent_Meta_Event', 'add_meta_boxes' );
+		$this->loader->add_action( 'add_meta_boxes', 'Wpfaevent_Meta_Speaker', 'add_meta_boxes' );
 
 		// Save meta box data.
-		$this->loader->add_action( 'save_post_wpfa_event', $this->plugin_admin, 'save_event_meta' );
-		$this->loader->add_action( 'save_post_wpfa_speaker', $this->plugin_admin, 'save_speaker_meta' );
+		$this->loader->add_action( 'save_post_wpfa_event', 'Wpfaevent_Meta_Event', 'save_meta' );
+		$this->loader->add_action( 'save_post_wpfa_speaker', 'Wpfaevent_Meta_Speaker', 'save_meta' );
 
-		// Register AJAX handlers for speakers page.
+		// Keep event-owned speakers out of the global speaker admin list.
+		$this->loader->add_action( 'restrict_manage_posts', $this->plugin_admin, 'render_speaker_event_filter' );
+		$this->loader->add_action( 'pre_get_posts', $this->plugin_admin, 'filter_speaker_admin_list' );
+		$this->loader->add_filter( 'views_edit-wpfa_speaker', $this->plugin_admin, 'filter_speaker_admin_views' );
+
+		// Register AJAX handlers for the speakers page.
 		$plugin_speakers_handler = new Wpfaevent_Speakers_Handler();
 		$this->loader->add_action( 'wp_ajax_wpfa_get_speaker', $plugin_speakers_handler, 'ajax_get_speaker' );
 		$this->loader->add_action( 'wp_ajax_wpfa_add_speaker', $plugin_speakers_handler, 'ajax_add_speaker' );
 		$this->loader->add_action( 'wp_ajax_wpfa_update_speaker', $plugin_speakers_handler, 'ajax_update_speaker' );
 		$this->loader->add_action( 'wp_ajax_wpfa_delete_speaker', $plugin_speakers_handler, 'ajax_delete_speaker' );
 
-		// Register AJAX handlers for events page.
+		// Register AJAX handlers for the events page.
 		$plugin_event_handler = new Wpfaevent_Event_Handler();
 		$this->loader->add_action( 'wp_ajax_wpfa_get_event', $plugin_event_handler, 'ajax_get_event' );
 		$this->loader->add_action( 'wp_ajax_wpfa_add_event', $plugin_event_handler, 'ajax_add_event' );
@@ -233,7 +259,8 @@ class Wpfaevent {
 		$plugin_footer_handler = new Wpfaevent_Footer_Handler();
 		$this->loader->add_action( 'wp_ajax_wpfa_update_footer_text', $plugin_footer_handler, 'ajax_update_footer_text' );
 
-		// Register Eventyay import form handler.
+		// Register Eventyay sync on the maintained admin path.
+		$this->loader->add_action( 'wp_ajax_fossasia_sync_eventyay', $this->plugin_admin, 'ajax_sync_eventyay' );
 		$this->loader->add_action( 'admin_post_wpfaevent_import_eventyay_events', $this->plugin_admin, 'handle_eventyay_events_import' );
 	}
 
@@ -250,6 +277,7 @@ class Wpfaevent {
 
 		// Register public-specific stylesheet.
 		$this->loader->add_action( 'wp_enqueue_scripts', $this->plugin_public, 'enqueue_styles' );
+		$this->loader->add_action( 'wp_enqueue_scripts', $this->plugin_public, 'enqueue_scripts' );
 
 		// Cache invalidation hooks (static method calls).
 		$this->loader->add_action( 'save_post', 'Wpfaevent_Cache', 'clear_page_cache' );

--- a/includes/cli/class-wpfa-cli.php
+++ b/includes/cli/class-wpfa-cli.php
@@ -56,7 +56,7 @@ class WPFA_CLI {
 	 * Minimal hardcoded seed (2 speakers, 1 event).
 	 */
 	private static function seed_minimal() {
-		$placeholder = 'https://via.placeholder.com/300x300.png?text=Speaker';
+		$placeholder = WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
 
 		$speakers = array(
 			array(
@@ -174,7 +174,7 @@ class WPFA_CLI {
 				$meta = array(
 					'wpfa_speaker_organization' => isset( $s['org'] ) ? sanitize_text_field( $s['org'] ) : '',
 					'wpfa_speaker_position'     => isset( $s['position'] ) ? sanitize_text_field( $s['position'] ) : '',
-					'wpfa_speaker_headshot_url' => isset( $s['photo'] ) ? esc_url_raw( $s['photo'] ) : 'https://via.placeholder.com/300x300.png?text=Speaker',
+					'wpfa_speaker_headshot_url' => isset( $s['photo'] ) ? esc_url_raw( $s['photo'] ) : WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg',
 				);
 
 				$id                  = self::upsert_post_by_slug(

--- a/includes/helpers/class-wpfaevent-additional-information-helper.php
+++ b/includes/helpers/class-wpfaevent-additional-information-helper.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Additional information page helpers.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/includes/helpers
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manage the public Additional Information page.
+ */
+class Wpfaevent_Additional_Information_Helper {
+
+	/**
+	 * Get the public additional information page URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_additional_information_page_url() {
+		$page = get_page_by_path( 'additional-information' );
+
+		if ( $page instanceof WP_Post ) {
+			return get_permalink( $page );
+		}
+
+		$pages = get_pages(
+			array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Managed page lookup by assigned template.
+				'meta_key'    => '_wp_page_template',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Managed page lookup by assigned template.
+				'meta_value'  => 'page-additional-information.php',
+				'number'      => 1,
+				'post_status' => 'publish',
+			)
+		);
+
+		if ( empty( $pages ) ) {
+			$pages = get_pages(
+				array(
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Back-compat managed page lookup by assigned template.
+					'meta_key'    => '_wp_page_template',
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Back-compat managed page lookup by assigned template.
+					'meta_value'  => 'public/partials/additional-information-page.php',
+					'number'      => 1,
+					'post_status' => 'publish',
+				)
+			);
+		}
+
+		$url = ! empty( $pages[0] ) ? get_permalink( $pages[0] ) : home_url( '/additional-information/' );
+
+		return apply_filters( 'wpfaevent_additional_information_page_url', $url );
+	}
+
+	/**
+	 * Get an event-specific additional information URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return string
+	 */
+	public static function get_event_additional_information_url( $event_id ) {
+		$event_id = absint( $event_id );
+
+		if ( ! $event_id ) {
+			return self::get_additional_information_page_url();
+		}
+
+		return add_query_arg( 'event', get_post_field( 'post_name', $event_id ), self::get_additional_information_page_url() );
+	}
+
+	/**
+	 * Ensure the public additional information page exists.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool $check_capability Whether to require plugin settings access before creating the page.
+	 * @return int Page ID, or 0 when the page could not be ensured.
+	 */
+	public static function ensure_additional_information_page( $check_capability = true ) {
+		if ( $check_capability && ! Wpfaevent_Roles::current_user_can_manage_settings() ) {
+			return 0;
+		}
+
+		$page_id = absint( get_option( 'wpfaevent_additional_information_page_id', 0 ) );
+		if ( $page_id && 'page' === get_post_type( $page_id ) && 'trash' !== get_post_status( $page_id ) ) {
+			self::ensure_additional_information_page_template( $page_id );
+
+			return $page_id;
+		}
+
+		$page = get_page_by_path( 'additional-information' );
+		if ( $page instanceof WP_Post ) {
+			$page_id = absint( $page->ID );
+			self::ensure_additional_information_page_template( $page_id );
+			update_option( 'wpfaevent_additional_information_page_id', $page_id, false );
+
+			return $page_id;
+		}
+
+		$page_id = wp_insert_post(
+			array(
+				'post_title'     => __( 'Additional Information', 'wpfaevent' ),
+				'post_name'      => 'additional-information',
+				'post_type'      => 'page',
+				'post_status'    => 'publish',
+				'post_content'   => '',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			),
+			true
+		);
+
+		if ( is_wp_error( $page_id ) || ! $page_id ) {
+			return 0;
+		}
+
+		$page_id = absint( $page_id );
+		update_post_meta( $page_id, '_wp_page_template', 'page-additional-information.php' );
+		update_post_meta( $page_id, '_wpfaevent_managed_page', 'additional_information' );
+		update_option( 'wpfaevent_additional_information_page_id', $page_id, false );
+
+		return $page_id;
+	}
+
+	/**
+	 * Ensure the page uses the plugin additional information template.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $page_id Page ID.
+	 * @return void
+	 */
+	private static function ensure_additional_information_page_template( $page_id ) {
+		$page_id = absint( $page_id );
+
+		if ( ! $page_id ) {
+			return;
+		}
+
+		$template = get_page_template_slug( $page_id );
+		if ( 'page-additional-information.php' === $template ) {
+			return;
+		}
+
+		update_post_meta( $page_id, '_wp_page_template', 'page-additional-information.php' );
+	}
+}

--- a/includes/helpers/class-wpfaevent-event-navigation-helper.php
+++ b/includes/helpers/class-wpfaevent-event-navigation-helper.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Event section navigation helpers.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/includes/helpers
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Build and filter event section navigation items.
+ */
+class Wpfaevent_Event_Navigation_Helper {
+
+	/**
+	 * Return the dashboard data directory path.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_data_dir() {
+		$upload_dir = wp_upload_dir();
+
+		return trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data';
+	}
+
+	/**
+	 * Read configured navigation items from dashboard JSON.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function read_navigation_items() {
+		$file = self::get_data_dir() . '/navigation.json';
+
+		if ( ! file_exists( $file ) ) {
+			return array();
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local dashboard JSON.
+		$data = json_decode( file_get_contents( $file ), true );
+
+		return is_array( $data ) ? $data : array();
+	}
+
+	/**
+	 * Map legacy section anchors to dashboard navigation targets.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $href Navigation href.
+	 * @return string
+	 */
+	public static function normalize_href( $href ) {
+		$href = trim( (string) $href );
+
+		$legacy_map = array(
+			'#wpfa-event-about-title'    => '#about',
+			'#wpfa-event-speakers-title' => '#speakers',
+			'#wpfa-event-schedule-title' => '#schedule-overview',
+		);
+
+		return isset( $legacy_map[ $href ] ) ? $legacy_map[ $href ] : $href;
+	}
+
+	/**
+	 * Determine whether a navigation target should be shown.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $href    Navigation href.
+	 * @param array<string, mixed> $context Section availability context.
+	 * @return bool
+	 */
+	public static function section_is_visible( $href, $context ) {
+		$href = self::normalize_href( $href );
+
+		switch ( $href ) {
+			case '#about':
+				return ! empty( $context['show_about'] ) && ! empty( $context['has_about'] );
+			case '#speakers':
+				return ! empty( $context['show_speakers'] ) && ! empty( $context['has_speakers'] );
+			case '#schedule-overview':
+				return ! empty( $context['show_schedule'] ) && ! empty( $context['has_schedule'] );
+			case '#sponsors':
+				return ! empty( $context['show_sponsors'] ) && ! empty( $context['has_sponsors'] );
+			case '#exhibitors':
+				return ! empty( $context['show_exhibitors'] ) && ! empty( $context['has_exhibitors'] );
+			case '#venue':
+				return ! empty( $context['has_venue'] );
+		}
+
+		if ( 0 === strpos( $href, '#custom-section-' ) ) {
+			$section_id = sanitize_title( substr( $href, strlen( '#custom-section-' ) ) );
+
+			return ! empty( $context['custom_sections'] ) && ! empty( $context['custom_sections'][ $section_id ] );
+		}
+
+		return '' !== $href;
+	}
+
+	/**
+	 * Build navigation items for an event page.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, mixed>   $context           Section availability context.
+	 * @param array<int, array>|null $navigation_items  Optional preloaded navigation items.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function build_nav_items( $context, $navigation_items = null ) {
+		if ( null === $navigation_items ) {
+			$navigation_items = self::read_navigation_items();
+		}
+
+		$items = array();
+
+		foreach ( $navigation_items as $item ) {
+			if ( ! is_array( $item ) || empty( $item['text'] ) ) {
+				continue;
+			}
+
+			$type = isset( $item['type'] ) ? (string) $item['type'] : 'link';
+
+			if ( 'dropdown' === $type && ! empty( $item['items'] ) && is_array( $item['items'] ) ) {
+				$sub_items = array();
+
+				foreach ( $item['items'] as $sub_item ) {
+					if ( ! is_array( $sub_item ) || empty( $sub_item['text'] ) || empty( $sub_item['href'] ) ) {
+						continue;
+					}
+
+					$href = self::normalize_href( $sub_item['href'] );
+
+					if ( ! self::section_is_visible( $href, $context ) ) {
+						continue;
+					}
+
+					$sub_items[] = array(
+						'text' => sanitize_text_field( $sub_item['text'] ),
+						'href' => $href,
+					);
+				}
+
+				if ( ! empty( $sub_items ) ) {
+					$items[] = array(
+						'text'  => sanitize_text_field( $item['text'] ),
+						'type'  => 'dropdown',
+						'items' => $sub_items,
+					);
+				}
+
+				continue;
+			}
+
+			if ( 'link' !== $type || empty( $item['href'] ) ) {
+				continue;
+			}
+
+			$href = self::normalize_href( $item['href'] );
+
+			if ( ! self::section_is_visible( $href, $context ) ) {
+				continue;
+			}
+
+			$items[] = array(
+				'text' => sanitize_text_field( $item['text'] ),
+				'type' => 'link',
+				'href' => $href,
+			);
+		}
+
+		if ( ! empty( $items ) ) {
+			return $items;
+		}
+
+		$defaults = array(
+			array(
+				'href' => '#about',
+				'text' => __( 'Overview', 'wpfaevent' ),
+			),
+			array(
+				'href' => '#speakers',
+				'text' => __( 'Speakers', 'wpfaevent' ),
+			),
+			array(
+				'href' => '#schedule-overview',
+				'text' => __( 'Schedule', 'wpfaevent' ),
+			),
+			array(
+				'href' => '#venue',
+				'text' => __( 'Additional Info', 'wpfaevent' ),
+			),
+		);
+
+		if ( ! empty( $context['custom_sections'] ) && is_array( $context['custom_sections'] ) ) {
+			foreach ( $context['custom_sections'] as $section_id => $section_label ) {
+				$section_id = sanitize_title( $section_id );
+				if ( '' === $section_id ) {
+					continue;
+				}
+
+				$defaults[] = array(
+					'href' => '#custom-section-' . $section_id,
+					'text' => is_scalar( $section_label ) ? sanitize_text_field( $section_label ) : __( 'Event Info', 'wpfaevent' ),
+				);
+			}
+		}
+
+		$defaults[] = array(
+			'href' => '#sponsors',
+			'text' => __( 'Sponsors', 'wpfaevent' ),
+		);
+		$defaults[] = array(
+			'href' => '#exhibitors',
+			'text' => __( 'Exhibitors', 'wpfaevent' ),
+		);
+
+		foreach ( $defaults as $default_item ) {
+			if ( self::section_is_visible( $default_item['href'], $context ) ) {
+				$items[] = array(
+					'text' => $default_item['text'],
+					'type' => 'link',
+					'href' => $default_item['href'],
+				);
+			}
+		}
+
+		return $items;
+	}
+}

--- a/includes/helpers/class-wpfaevent-partner-helper.php
+++ b/includes/helpers/class-wpfaevent-partner-helper.php
@@ -1,0 +1,388 @@
+<?php
+/**
+ * Sponsor and exhibitor detail page helpers.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/includes/helpers
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manage public sponsor/exhibitor detail pages.
+ */
+class Wpfaevent_Partner_Helper {
+
+	/**
+	 * Supported partner types.
+	 *
+	 * @since 1.0.0
+	 * @var array<int, string>
+	 */
+	private static $partner_types = array( 'exhibitor', 'sponsor' );
+
+	/**
+	 * Get the public partner detail page URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_partner_page_url() {
+		$page = get_page_by_path( 'partner' );
+
+		if ( $page instanceof WP_Post ) {
+			return get_permalink( $page );
+		}
+
+		$pages = get_pages(
+			array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Managed page lookup by assigned template.
+				'meta_key'    => '_wp_page_template',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Managed page lookup by assigned template.
+				'meta_value'  => 'page-partner.php',
+				'number'      => 1,
+				'post_status' => 'publish',
+			)
+		);
+
+		$url = ! empty( $pages[0] ) ? get_permalink( $pages[0] ) : home_url( '/partner/' );
+
+		return apply_filters( 'wpfaevent_partner_page_url', $url );
+	}
+
+	/**
+	 * Build a stable partner key for URLs.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $partner Partner record.
+	 * @return string
+	 */
+	public static function get_partner_key( $partner ) {
+		if ( ! is_array( $partner ) ) {
+			return '';
+		}
+
+		if ( ! empty( $partner['id'] ) ) {
+			return sanitize_key( $partner['id'] );
+		}
+
+		if ( ! empty( $partner['name'] ) ) {
+			return sanitize_title( $partner['name'] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build a partner detail URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $event_id Event post ID.
+	 * @param string $type     Partner type. Accepts exhibitor or sponsor.
+	 * @param array  $partner  Partner record.
+	 * @return string
+	 */
+	public static function get_partner_detail_url( $event_id, $type, $partner ) {
+		$event_id = absint( $event_id );
+		$type     = sanitize_key( $type );
+		$key      = self::get_partner_key( $partner );
+
+		if ( ! $event_id || ! in_array( $type, self::$partner_types, true ) || '' === $key ) {
+			return self::get_partner_page_url();
+		}
+
+		return add_query_arg(
+			array(
+				'event'   => get_post_field( 'post_name', $event_id ),
+				'type'    => $type,
+				'partner' => $key,
+			),
+			self::get_partner_page_url()
+		);
+	}
+
+	/**
+	 * Resolve the current partner detail request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function resolve_partner_request() {
+		$read_filter_value = static function ( $key ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page filters.
+			if ( ! isset( $_GET[ $key ] ) ) {
+				return '';
+			}
+
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized below.
+			$value = wp_unslash( $_GET[ $key ] );
+
+			if ( is_array( $value ) ) {
+				return '';
+			}
+
+			return sanitize_text_field( $value );
+		};
+
+		$event_filter  = $read_filter_value( 'event' );
+		$partner_type  = sanitize_key( $read_filter_value( 'type' ) );
+		$partner_key   = sanitize_key( $read_filter_value( 'partner' ) );
+		$event_id      = self::resolve_event_id( $event_filter );
+		$partner       = array();
+		$group_name    = '';
+		$partner_label = '';
+
+		if ( $event_id && $partner_key && in_array( $partner_type, self::$partner_types, true ) ) {
+			if ( 'exhibitor' === $partner_type ) {
+				$partner       = self::find_exhibitor_by_key( $event_id, $partner_key );
+				$partner_label = __( 'Exhibitor', 'wpfaevent' );
+			} else {
+				$match = self::find_sponsor_by_key( $event_id, $partner_key );
+				if ( ! empty( $match['partner'] ) ) {
+					$partner    = $match['partner'];
+					$group_name = isset( $match['group_name'] ) ? $match['group_name'] : '';
+				}
+				$partner_label = __( 'Sponsor', 'wpfaevent' );
+			}
+		}
+
+		return array(
+			'event_id'      => $event_id,
+			'event_slug'    => $event_id ? get_post_field( 'post_name', $event_id ) : '',
+			'event_title'   => $event_id ? get_the_title( $event_id ) : '',
+			'event_url'     => $event_id ? get_permalink( $event_id ) : '',
+			'type'          => $partner_type,
+			'partner_key'   => $partner_key,
+			'partner'       => is_array( $partner ) ? $partner : array(),
+			'group_name'    => $group_name,
+			'partner_label' => $partner_label,
+		);
+	}
+
+	/**
+	 * Ensure the public partner detail page exists.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool $check_capability Whether to require plugin settings access before creating the page.
+	 * @return int Page ID, or 0 when the page could not be ensured.
+	 */
+	public static function ensure_partner_page( $check_capability = true ) {
+		if ( $check_capability && ! Wpfaevent_Roles::current_user_can_manage_settings() ) {
+			return 0;
+		}
+
+		$page_id = absint( get_option( 'wpfaevent_partner_page_id', 0 ) );
+		if ( $page_id && 'page' === get_post_type( $page_id ) && 'trash' !== get_post_status( $page_id ) ) {
+			self::ensure_partner_page_template( $page_id );
+
+			return $page_id;
+		}
+
+		$page = get_page_by_path( 'partner' );
+		if ( $page instanceof WP_Post ) {
+			$page_id = absint( $page->ID );
+			self::ensure_partner_page_template( $page_id );
+			update_option( 'wpfaevent_partner_page_id', $page_id, false );
+
+			return $page_id;
+		}
+
+		$page_id = wp_insert_post(
+			array(
+				'post_title'     => __( 'Partner', 'wpfaevent' ),
+				'post_name'      => 'partner',
+				'post_type'      => 'page',
+				'post_status'    => 'publish',
+				'post_content'   => '',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			),
+			true
+		);
+
+		if ( is_wp_error( $page_id ) || ! $page_id ) {
+			return 0;
+		}
+
+		$page_id = absint( $page_id );
+		update_post_meta( $page_id, '_wp_page_template', 'page-partner.php' );
+		update_post_meta( $page_id, '_wpfaevent_managed_page', 'partner' );
+		update_option( 'wpfaevent_partner_page_id', $page_id, false );
+
+		return $page_id;
+	}
+
+	/**
+	 * Resolve an event ID from a slug or numeric ID.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $event_filter Event slug or ID.
+	 * @return int
+	 */
+	private static function resolve_event_id( $event_filter ) {
+		$event_filter = trim( (string) $event_filter );
+
+		if ( '' === $event_filter ) {
+			return 0;
+		}
+
+		if ( is_numeric( $event_filter ) ) {
+			$event_id = absint( $event_filter );
+
+			return ( $event_id && 'wpfa_event' === get_post_type( $event_id ) && 'publish' === get_post_status( $event_id ) ) ? $event_id : 0;
+		}
+
+		$events = get_posts(
+			array(
+				'name'           => sanitize_title( $event_filter ),
+				'post_type'      => 'wpfa_event',
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		return ! empty( $events[0] ) ? absint( $events[0] ) : 0;
+	}
+
+	/**
+	 * Find an exhibitor record by key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $event_id    Event post ID.
+	 * @param string $partner_key Partner key.
+	 * @return array
+	 */
+	private static function find_exhibitor_by_key( $event_id, $partner_key ) {
+		$exhibitors = self::read_dashboard_json_file( 'exhibitors-' . absint( $event_id ) . '.json', array() );
+
+		foreach ( $exhibitors as $exhibitor ) {
+			if ( ! is_array( $exhibitor ) ) {
+				continue;
+			}
+
+			if ( self::get_partner_key( $exhibitor ) === $partner_key ) {
+				return $exhibitor;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Find a sponsor record by key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $event_id    Event post ID.
+	 * @param string $partner_key Partner key.
+	 * @return array<string, mixed>
+	 */
+	private static function find_sponsor_by_key( $event_id, $partner_key ) {
+		$sponsor_groups = self::read_dashboard_json_file( 'sponsors-' . absint( $event_id ) . '.json', array() );
+
+		foreach ( $sponsor_groups as $sponsor_group ) {
+			if ( ! is_array( $sponsor_group ) || empty( $sponsor_group['sponsors'] ) || ! is_array( $sponsor_group['sponsors'] ) ) {
+				continue;
+			}
+
+			$group_name = ! empty( $sponsor_group['group_name'] ) ? sanitize_text_field( $sponsor_group['group_name'] ) : __( 'Sponsors', 'wpfaevent' );
+
+			foreach ( $sponsor_group['sponsors'] as $sponsor ) {
+				if ( ! is_array( $sponsor ) ) {
+					continue;
+				}
+
+				if ( self::get_partner_key( $sponsor ) === $partner_key ) {
+					return array(
+						'partner'    => $sponsor,
+						'group_name' => $group_name,
+					);
+				}
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Read plugin-managed dashboard JSON.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $filename File name.
+	 * @param mixed  $fallback Fallback value.
+	 * @return mixed
+	 */
+	private static function read_dashboard_json_file( $filename, $fallback ) {
+		$upload_dir = wp_upload_dir();
+
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return $fallback;
+		}
+
+		$path = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/' . sanitize_file_name( $filename );
+
+		if ( ! file_exists( $path ) || ! is_readable( $path ) ) {
+			return $fallback;
+		}
+
+		if ( function_exists( 'wp_json_file_decode' ) ) {
+			$decoded = wp_json_file_decode( $path, array( 'associative' => true ) );
+
+			return is_array( $decoded ) ? $decoded : $fallback;
+		}
+
+		global $wp_filesystem;
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! WP_Filesystem() || ! $wp_filesystem ) {
+			return $fallback;
+		}
+
+		$contents = $wp_filesystem->get_contents( $path );
+		if ( false === $contents || '' === trim( $contents ) ) {
+			return $fallback;
+		}
+
+		$decoded = json_decode( $contents, true );
+
+		return ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) ? $decoded : $fallback;
+	}
+
+	/**
+	 * Ensure the page uses the plugin partner template.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $page_id Page ID.
+	 * @return void
+	 */
+	private static function ensure_partner_page_template( $page_id ) {
+		$page_id = absint( $page_id );
+
+		if ( ! $page_id ) {
+			return;
+		}
+
+		$template = get_page_template_slug( $page_id );
+		if ( 'page-partner.php' === $template ) {
+			return;
+		}
+
+		update_post_meta( $page_id, '_wp_page_template', 'page-partner.php' );
+	}
+}

--- a/includes/helpers/class-wpfaevent-schedule-helper.php
+++ b/includes/helpers/class-wpfaevent-schedule-helper.php
@@ -226,6 +226,195 @@ class Wpfaevent_Schedule_Helper {
 	}
 
 	/**
+	 * Get the public schedule page URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_schedule_page_url() {
+		$page = get_page_by_path( 'full-schedule' );
+
+		if ( $page instanceof WP_Post ) {
+			return get_permalink( $page );
+		}
+
+		$pages = get_pages(
+			array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Schedule page lookup by assigned template.
+				'meta_key'    => '_wp_page_template',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Schedule page lookup by assigned template.
+				'meta_value'  => 'page-schedule.php',
+				'number'      => 1,
+				'post_status' => 'publish',
+			)
+		);
+
+		$url = ! empty( $pages[0] ) ? get_permalink( $pages[0] ) : home_url( '/full-schedule/' );
+
+		return apply_filters( 'wpfaevent_schedule_page_url', $url );
+	}
+
+	/**
+	 * Ensure the public full schedule page exists.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool $check_capability Whether to require plugin settings access before creating the page.
+	 * @return int Page ID, or 0 when the page could not be ensured.
+	 */
+	public static function ensure_schedule_page( $check_capability = true ) {
+		if ( $check_capability && ! Wpfaevent_Roles::current_user_can_manage_settings() ) {
+			return 0;
+		}
+
+		$page_id = absint( get_option( 'wpfaevent_schedule_page_id', 0 ) );
+		if ( $page_id && 'page' === get_post_type( $page_id ) && 'trash' !== get_post_status( $page_id ) ) {
+			self::ensure_schedule_page_template( $page_id );
+
+			return $page_id;
+		}
+
+		$page = get_page_by_path( 'full-schedule' );
+		if ( $page instanceof WP_Post ) {
+			$page_id = absint( $page->ID );
+			self::ensure_schedule_page_template( $page_id );
+			update_option( 'wpfaevent_schedule_page_id', $page_id, false );
+
+			return $page_id;
+		}
+
+		$page_id = wp_insert_post(
+			array(
+				'post_title'     => __( 'Full Schedule', 'wpfaevent' ),
+				'post_name'      => 'full-schedule',
+				'post_type'      => 'page',
+				'post_status'    => 'publish',
+				'post_content'   => '',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			),
+			true
+		);
+
+		if ( is_wp_error( $page_id ) || ! $page_id ) {
+			return 0;
+		}
+
+		$page_id = absint( $page_id );
+		update_post_meta( $page_id, '_wp_page_template', 'page-schedule.php' );
+		update_post_meta( $page_id, '_wpfaevent_managed_page', 'schedule' );
+		update_option( 'wpfaevent_schedule_page_id', $page_id, false );
+
+		return $page_id;
+	}
+
+	/**
+	 * Ensure the schedule page uses the plugin schedule template.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $page_id Page ID.
+	 * @return void
+	 */
+	private static function ensure_schedule_page_template( $page_id ) {
+		$page_id = absint( $page_id );
+
+		if ( ! $page_id ) {
+			return;
+		}
+
+		$template = get_page_template_slug( $page_id );
+		if ( 'page-schedule.php' === $template ) {
+			return;
+		}
+
+		update_post_meta( $page_id, '_wp_page_template', 'page-schedule.php' );
+	}
+
+	/**
+	 * Build event-specific schedule session items from dashboard JSON.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int               $event_id         Event post ID.
+	 * @param DateTimeZone|null $display_timezone Target timezone.
+	 * @return array<string, mixed>
+	 */
+	public static function build_event_session_schedule( $event_id, $display_timezone = null ) {
+		$event_id = absint( $event_id );
+
+		if ( ! $event_id ) {
+			return array(
+				'items'  => array(),
+				'groups' => array(),
+			);
+		}
+
+		if ( ! $display_timezone instanceof DateTimeZone ) {
+			$display_timezone = wp_timezone();
+		}
+
+		$schedule_table = self::read_dashboard_json_file( 'schedule-' . $event_id . '.json', array() );
+		$schedule_rows  = isset( $schedule_table['data'] ) && is_array( $schedule_table['data'] ) ? $schedule_table['data'] : array();
+		$schedule_meta  = isset( $schedule_table['sessions'] ) && is_array( $schedule_table['sessions'] ) ? $schedule_table['sessions'] : array();
+		$schedule_head  = ! empty( $schedule_rows[0] ) && is_array( $schedule_rows[0] ) ? $schedule_rows[0] : array();
+		$schedule_body  = ! empty( $schedule_head ) ? array_slice( $schedule_rows, 1 ) : $schedule_rows;
+		$event_timezone = self::get_event_timezone_object( $event_id );
+		$items          = array();
+
+		foreach ( $schedule_body as $row_index => $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$row_meta       = isset( $schedule_meta[ $row_index ] ) && is_array( $schedule_meta[ $row_index ] ) ? $schedule_meta[ $row_index ] : array();
+			$start_datetime = isset( $row_meta['starts_at'] ) ? sanitize_text_field( $row_meta['starts_at'] ) : '';
+			$end_datetime   = isset( $row_meta['ends_at'] ) ? sanitize_text_field( $row_meta['ends_at'] ) : '';
+			$row_date       = isset( $row[0] ) ? sanitize_text_field( $row[0] ) : '';
+			$row_time       = isset( $row[1] ) ? sanitize_text_field( $row[1] ) : '';
+
+			$item = array(
+				'date'           => $row_date,
+				'date_label'     => self::format_schedule_session_date( $start_datetime, $row_date, $row_time, $display_timezone, $event_timezone ),
+				'time'           => $row_time,
+				'time_label'     => self::format_schedule_session_time( $start_datetime, $end_datetime, $row_date, $row_time, $display_timezone, $event_timezone ),
+				'title'          => ! empty( $row[2] ) ? sanitize_text_field( $row[2] ) : get_the_title( $event_id ),
+				'speakers'       => isset( $row[3] ) ? sanitize_text_field( $row[3] ) : '',
+				'track'          => isset( $row[4] ) ? sanitize_text_field( $row[4] ) : '',
+				'room'           => isset( $row[5] ) ? sanitize_text_field( $row[5] ) : '',
+				'start_datetime' => $start_datetime,
+				'end_datetime'   => $end_datetime,
+			);
+
+			$item['calendar_url'] = self::build_schedule_session_calendar_url( $event_id, $item, $event_timezone );
+
+			$time_parts         = preg_split( '/\s*-\s*/', $item['time_label'], 2 );
+			$item['time_start'] = isset( $time_parts[0] ) ? trim( $time_parts[0] ) : $item['time_label'];
+			$item['time_end']   = isset( $time_parts[1] ) ? trim( $time_parts[1] ) : '';
+
+			$items[] = $item;
+		}
+
+		$groups = array();
+
+		foreach ( $items as $item ) {
+			$day_key = ! empty( $item['date_label'] ) ? $item['date_label'] : __( 'TBD', 'wpfaevent' );
+
+			if ( ! isset( $groups[ $day_key ] ) ) {
+				$groups[ $day_key ] = array();
+			}
+
+			$groups[ $day_key ][] = $item;
+		}
+
+		return array(
+			'items'  => $items,
+			'groups' => $groups,
+		);
+	}
+
+	/**
 	 * Build a sortable schedule entry for an event.
 	 *
 	 * @since 1.0.0
@@ -245,36 +434,22 @@ class Wpfaevent_Schedule_Helper {
 			$display_timezone = wp_timezone();
 		}
 
-		$calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-		$calendar_data = is_wp_error( $calendar_data ) ? array() : $calendar_data;
-		$calendar_url  = ! empty( $calendar_data ) && class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::build_google_calendar_url( $calendar_data ) : '';
-		$all_day       = ! empty( $calendar_data['all_day'] );
-		$datetime      = self::get_event_start_datetime( $event_id );
+		$datetime = self::get_event_start_datetime( $event_id );
 
 		if ( $datetime ) {
 			$display_datetime = $datetime->setTimezone( $display_timezone );
-			$date_label       = $all_day && ! empty( $calendar_data['date_label'] )
-				? sanitize_text_field( $calendar_data['date_label'] )
-				: wp_date( get_option( 'date_format' ), $display_datetime->getTimestamp(), $display_timezone );
-			$group_key        = $all_day && ! empty( $calendar_data['start_date'] )
-				? sanitize_text_field( $calendar_data['start_date'] )
-				: $display_datetime->format( 'Y-m-d' );
-			$time_label       = $all_day ? __( 'All day', 'wpfaevent' ) : '';
-
-			if ( ! $all_day ) {
-				$time_label = self::format_event_time_label( $calendar_data, $event_id, $display_timezone );
-			}
 
 			return array(
 				'id'           => $event_id,
 				'sort_key'     => $display_datetime->getTimestamp(),
-				'date_label'   => $date_label,
-				'time_label'   => $time_label,
-				'group_key'    => $group_key,
+				'date_label'   => wp_date( get_option( 'date_format' ), $display_datetime->getTimestamp(), $display_timezone ),
+				'time_label'   => self::format_event_start_time( $event_id, $display_timezone ),
+				'group_key'    => $display_datetime->format( 'Y-m-d' ),
 				'location'     => sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) ),
 				'title'        => get_the_title( $event_id ),
 				'permalink'    => get_permalink( $event_id ),
-				'calendar_url' => $calendar_url,
+				'schedule_url' => add_query_arg( 'event', get_post_field( 'post_name', $event_id ), self::get_schedule_page_url() ),
+				'calendar_url' => class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_google_calendar_url( $event_id ) : '',
 			);
 		}
 
@@ -287,31 +462,294 @@ class Wpfaevent_Schedule_Helper {
 			'location'     => sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) ),
 			'title'        => get_the_title( $event_id ),
 			'permalink'    => get_permalink( $event_id ),
-			'calendar_url' => $calendar_url,
+			'schedule_url' => add_query_arg( 'event', get_post_field( 'post_name', $event_id ), self::get_schedule_page_url() ),
+			'calendar_url' => class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_google_calendar_url( $event_id ) : '',
 		);
 	}
 
 	/**
-	 * Format a timed event's start and end time for schedule display.
+	 * Read plugin-managed dashboard JSON.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array<string, mixed> $calendar_data     Normalized calendar data.
-	 * @param int                  $event_id          Event post ID.
-	 * @param DateTimeZone         $display_timezone  Target timezone.
-	 * @return string
+	 * @param string $filename File name.
+	 * @param mixed  $fallback Fallback value.
+	 * @return mixed
 	 */
-	private static function format_event_time_label( $calendar_data, $event_id, $display_timezone ) {
-		if ( ! empty( $calendar_data['start_datetime'] ) && $calendar_data['start_datetime'] instanceof DateTimeInterface ) {
-			$time_format = get_option( 'time_format' );
-			$start_label = wp_date( $time_format, $calendar_data['start_datetime']->getTimestamp(), $display_timezone );
-			$end_label   = ! empty( $calendar_data['end_datetime'] ) && $calendar_data['end_datetime'] instanceof DateTimeInterface
-				? wp_date( $time_format, $calendar_data['end_datetime']->getTimestamp(), $display_timezone )
-				: '';
+	private static function read_dashboard_json_file( $filename, $fallback ) {
+		$upload_dir = wp_upload_dir();
 
-			return $end_label && $end_label !== $start_label ? $start_label . ' - ' . $end_label : $start_label;
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return $fallback;
 		}
 
-		return self::format_event_start_time( $event_id, $display_timezone );
+		$path = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/' . sanitize_file_name( $filename );
+
+		if ( ! file_exists( $path ) || ! is_readable( $path ) ) {
+			return $fallback;
+		}
+
+		if ( function_exists( 'wp_json_file_decode' ) ) {
+			$decoded = wp_json_file_decode( $path, array( 'associative' => true ) );
+
+			return is_array( $decoded ) ? $decoded : $fallback;
+		}
+
+		global $wp_filesystem;
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! WP_Filesystem() || ! $wp_filesystem ) {
+			return $fallback;
+		}
+
+		$contents = $wp_filesystem->get_contents( $path );
+		if ( false === $contents || '' === trim( $contents ) ) {
+			return $fallback;
+		}
+
+		$decoded = json_decode( $contents, true );
+
+		return ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) ? $decoded : $fallback;
+	}
+
+	/**
+	 * Get an event timezone object.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return DateTimeZone
+	 */
+	private static function get_event_timezone_object( $event_id ) {
+		$timezone_string = class_exists( 'Wpfaevent_Calendar' )
+			? Wpfaevent_Calendar::get_event_timezone_string( $event_id )
+			: wp_timezone_string();
+
+		try {
+			return new DateTimeZone( $timezone_string );
+		} catch ( Exception $exception ) {
+			return wp_timezone();
+		}
+	}
+
+	/**
+	 * Parse an imported schedule date-time value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $datetime Date-time value.
+	 * @return DateTimeImmutable|null
+	 */
+	private static function parse_schedule_datetime( $datetime ) {
+		$datetime = trim( (string) $datetime );
+
+		if ( '' === $datetime ) {
+			return null;
+		}
+
+		try {
+			return new DateTimeImmutable( $datetime );
+		} catch ( Exception $exception ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Split a human-entered time range.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $time Time or time range.
+	 * @return array<int, string>
+	 */
+	private static function split_schedule_time_range( $time ) {
+		$parts = preg_split( '/\s*-\s*/', trim( (string) $time ), 2 );
+
+		return array_values( array_filter( array_map( 'trim', is_array( $parts ) ? $parts : array() ) ) );
+	}
+
+	/**
+	 * Build a schedule fallback date-time from separate date and time values.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string       $date            Date value.
+	 * @param string       $time            Time value.
+	 * @param DateTimeZone $source_timezone Source timezone.
+	 * @return DateTimeImmutable|null
+	 */
+	private static function build_schedule_fallback_datetime( $date, $time, $source_timezone ) {
+		$date = class_exists( 'Wpfaevent_Meta_Event' )
+			? Wpfaevent_Meta_Event::sanitize_date_value( $date )
+			: sanitize_text_field( $date );
+
+		$time_parts = self::split_schedule_time_range( $time );
+		$time       = isset( $time_parts[0] ) ? $time_parts[0] : '';
+
+		if ( '' === $date || '' === $time ) {
+			return null;
+		}
+
+		try {
+			return new DateTimeImmutable( trim( $date . ' ' . $time ), $source_timezone );
+		} catch ( Exception $exception ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Format an imported session date.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string       $start_datetime  Imported start date-time.
+	 * @param string       $fallback_date   Fallback date.
+	 * @param string       $fallback_time   Fallback time.
+	 * @param DateTimeZone $display_timezone Display timezone.
+	 * @param DateTimeZone $event_timezone   Event timezone.
+	 * @return string
+	 */
+	private static function format_schedule_session_date( $start_datetime, $fallback_date, $fallback_time, $display_timezone, $event_timezone ) {
+		$start = self::parse_schedule_datetime( $start_datetime );
+
+		if ( $start ) {
+			return wp_date( get_option( 'date_format' ), $start->getTimestamp(), $display_timezone );
+		}
+
+		$fallback = self::build_schedule_fallback_datetime( $fallback_date, $fallback_time, $event_timezone );
+
+		return $fallback ? wp_date( get_option( 'date_format' ), $fallback->getTimestamp(), $display_timezone ) : sanitize_text_field( $fallback_date );
+	}
+
+	/**
+	 * Format an imported session time.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string       $start_datetime  Imported start date-time.
+	 * @param string       $end_datetime    Imported end date-time.
+	 * @param string       $fallback_date   Fallback date.
+	 * @param string       $fallback_time   Fallback time.
+	 * @param DateTimeZone $display_timezone Display timezone.
+	 * @param DateTimeZone $event_timezone   Event timezone.
+	 * @return string
+	 */
+	private static function format_schedule_session_time( $start_datetime, $end_datetime, $fallback_date, $fallback_time, $display_timezone, $event_timezone ) {
+		$start       = self::parse_schedule_datetime( $start_datetime );
+		$end         = self::parse_schedule_datetime( $end_datetime );
+		$start_label = $start ? wp_date( get_option( 'time_format' ), $start->getTimestamp(), $display_timezone ) : '';
+		$end_label   = $end ? wp_date( get_option( 'time_format' ), $end->getTimestamp(), $display_timezone ) : '';
+
+		if ( ! $start_label ) {
+			$time_parts     = self::split_schedule_time_range( $fallback_time );
+			$fallback_start = self::build_schedule_fallback_datetime( $fallback_date, isset( $time_parts[0] ) ? $time_parts[0] : '', $event_timezone );
+			$fallback_end   = self::build_schedule_fallback_datetime( $fallback_date, isset( $time_parts[1] ) ? $time_parts[1] : '', $event_timezone );
+			$start_label    = $fallback_start ? wp_date( get_option( 'time_format' ), $fallback_start->getTimestamp(), $display_timezone ) : '';
+			$end_label      = $fallback_end ? wp_date( get_option( 'time_format' ), $fallback_end->getTimestamp(), $display_timezone ) : '';
+		}
+
+		if ( $start_label && $end_label && $start_label !== $end_label ) {
+			return $start_label . ' - ' . $end_label;
+		}
+
+		return $start_label ? $start_label : sanitize_text_field( $fallback_time );
+	}
+
+	/**
+	 * Build a Google Calendar URL for one imported session.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int          $event_id       Event post ID.
+	 * @param array        $item           Schedule item.
+	 * @param DateTimeZone $event_timezone Event timezone.
+	 * @return string
+	 */
+	private static function build_schedule_session_calendar_url( $event_id, $item, $event_timezone ) {
+		if ( ! class_exists( 'Wpfaevent_Calendar' ) ) {
+			return '';
+		}
+
+		$time_parts            = self::split_schedule_time_range( isset( $item['time'] ) ? $item['time'] : '' );
+		$start                 = self::parse_schedule_datetime( isset( $item['start_datetime'] ) ? $item['start_datetime'] : '' );
+		$end                   = self::parse_schedule_datetime( isset( $item['end_datetime'] ) ? $item['end_datetime'] : '' );
+		$event_title           = get_the_title( $event_id );
+		$event_url             = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_url', true ) );
+		$location              = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+		$event_timezone_string = Wpfaevent_Calendar::get_event_timezone_string( $event_id );
+		$all_day               = false;
+		$start_date            = '';
+		$end_date              = '';
+
+		if ( ! $start ) {
+			$start = self::build_schedule_fallback_datetime(
+				isset( $item['date'] ) ? $item['date'] : '',
+				isset( $time_parts[0] ) ? $time_parts[0] : '',
+				$event_timezone
+			);
+		}
+
+		if ( $start && ! $end && ! empty( $time_parts[1] ) ) {
+			$end = self::build_schedule_fallback_datetime( isset( $item['date'] ) ? $item['date'] : '', $time_parts[1], $event_timezone );
+		}
+
+		if ( $start && $end && $end <= $start ) {
+			$end = $end->modify( '+1 day' );
+		}
+
+		if ( ! $start && empty( $time_parts[0] ) ) {
+			$start_date = class_exists( 'Wpfaevent_Meta_Event' )
+				? Wpfaevent_Meta_Event::sanitize_date_value( isset( $item['date'] ) ? $item['date'] : '' )
+				: '';
+			$end_date   = $start_date;
+			$all_day    = '' !== $start_date;
+		}
+
+		if ( ! $start && ! $all_day ) {
+			return '';
+		}
+
+		$details = array_filter(
+			array(
+				$event_title ? sprintf(
+					/* translators: %s: event title. */
+					__( 'Event: %s', 'wpfaevent' ),
+					$event_title
+				) : '',
+				! empty( $item['speakers'] ) ? sprintf(
+					/* translators: %s: speaker names. */
+					__( 'Speakers: %s', 'wpfaevent' ),
+					$item['speakers']
+				) : '',
+				! empty( $item['track'] ) ? sprintf(
+					/* translators: %s: session track. */
+					__( 'Track: %s', 'wpfaevent' ),
+					$item['track']
+				) : '',
+				! empty( $item['room'] ) ? sprintf(
+					/* translators: %s: session room. */
+					__( 'Room: %s', 'wpfaevent' ),
+					$item['room']
+				) : '',
+			)
+		);
+
+		return Wpfaevent_Calendar::build_google_calendar_url(
+			array(
+				'title'           => ! empty( $item['title'] ) ? $item['title'] : $event_title,
+				'description'     => implode( "\n", $details ),
+				'location'        => ! empty( $item['room'] ) ? $item['room'] : $location,
+				'url'             => $event_url,
+				'timezone_string' => $event_timezone_string,
+				'all_day'         => $all_day,
+				'start_date'      => $start_date,
+				'end_date'        => $end_date,
+				'start_datetime'  => $all_day ? null : $start,
+				'end_datetime'    => $all_day ? null : $end,
+			)
+		);
 	}
 }

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -39,7 +39,7 @@ class Wpfaevent_Meta_Event {
 				'type'              => 'string',
 				'single'            => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => array( __CLASS__, 'sanitize_date_value' ),
+				'sanitize_callback' => 'sanitize_text_field',
 				'description'       => __( 'Event start date', 'wpfaevent' ),
 			)
 		);
@@ -51,7 +51,7 @@ class Wpfaevent_Meta_Event {
 				'type'              => 'string',
 				'single'            => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => array( __CLASS__, 'sanitize_date_value' ),
+				'sanitize_callback' => 'sanitize_text_field',
 				'description'       => __( 'Event end date', 'wpfaevent' ),
 			)
 		);
@@ -68,7 +68,7 @@ class Wpfaevent_Meta_Event {
 			)
 		);
 
-		// Legacy single event time used by the front-end event modal.
+		// Legacy single event time used by the event modal.
 		register_post_meta(
 			self::$post_type,
 			'wpfa_event_time',
@@ -151,6 +151,48 @@ class Wpfaevent_Meta_Event {
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
 				'description'       => __( 'Event venue/location', 'wpfaevent' ),
+			)
+		);
+
+		register_post_meta(
+			self::$post_type,
+			'wpfa_event_venue_information',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'wp_kses_post',
+				'description'       => __( 'Venue, hotel, and transportation information for attendees', 'wpfaevent' ),
+			)
+		);
+
+		register_post_meta(
+			self::$post_type,
+			'wpfa_event_custom_tabs',
+			array(
+				'type'              => 'array',
+				'single'            => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'title'   => array(
+									'type' => 'string',
+								),
+								'slug'    => array(
+									'type' => 'string',
+								),
+								'content' => array(
+									'type' => 'string',
+								),
+							),
+						),
+					),
+				),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_custom_tabs' ),
+				'description'       => __( 'Event-specific custom tab sections for attendee information', 'wpfaevent' ),
 			)
 		);
 
@@ -258,57 +300,667 @@ class Wpfaevent_Meta_Event {
 				'description'       => __( 'Related speaker post IDs', 'wpfaevent' ),
 			)
 		);
-	}
 
-	/**
-	 * Sanitizes an array of speaker IDs.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $speaker_ids Array of speaker post IDs.
-	 * @return array Sanitized array of integers.
-	 */
-	public static function sanitize_speaker_ids( $speaker_ids ) {
-		if ( ! is_array( $speaker_ids ) ) {
-			return array();
-		}
-
-		$speaker_ids = array_map( 'absint', $speaker_ids );
-		$speaker_ids = array_filter( $speaker_ids );
-
-		return array_values( array_unique( $speaker_ids ) );
-	}
-
-	/**
-	 * Sync speaker-side event relationship meta after an event is saved.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int        $event_id          Event post ID.
-	 * @param array<int> $previous_speakers Speaker IDs before save.
-	 * @param array<int> $current_speakers  Speaker IDs after save.
-	 */
-	private static function sync_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers ) {
-		$event_id          = absint( $event_id );
-		$previous_speakers = self::sanitize_post_id_list(
-			array_merge(
-				self::sanitize_post_id_list( $previous_speakers ),
-				Wpfaevent_Meta_Speaker::get_speakers_linked_to_event( $event_id )
+		register_post_meta(
+			self::$post_type,
+			'wpfa_event_featured_speakers',
+			array(
+				'type'              => 'array',
+				'single'            => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type' => 'integer',
+						),
+					),
+				),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_speaker_ids' ),
+				'description'       => __( 'Featured speaker post IDs for this event', 'wpfaevent' ),
 			)
 		);
-		$current_speakers  = self::sanitize_post_id_list( $current_speakers );
+	}
 
-		if ( ! $event_id ) {
+	/**
+	 * Register the Event Details meta box.
+	 *
+	 * @since 1.0.0
+	 */
+	public static function add_meta_boxes() {
+		add_meta_box(
+			'wpfa_event_details',
+			__( 'Event Details', 'wpfaevent' ),
+			array( __CLASS__, 'render_meta_box' ),
+			self::$post_type,
+			'normal',
+			'high'
+		);
+
+		add_meta_box(
+			'wpfa_event_additional_information',
+			__( 'Attendee Information', 'wpfaevent' ),
+			array( __CLASS__, 'render_additional_information_meta_box' ),
+			self::$post_type,
+			'normal',
+			'default'
+		);
+
+		remove_meta_box( 'postcustom', self::$post_type, 'normal' );
+	}
+
+	/**
+	 * Render the Event Details meta box.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Post $post Event post object.
+	 */
+	public static function render_meta_box( $post ) {
+		wp_nonce_field( 'wpfa_event_meta_nonce', 'wpfa_event_meta_nonce' );
+
+		$start_date = get_post_meta( $post->ID, 'wpfa_event_start_date', true );
+		$end_date   = get_post_meta( $post->ID, 'wpfa_event_end_date', true );
+		$start_time = get_post_meta( $post->ID, 'wpfa_event_start_time', true );
+		$end_time   = get_post_meta( $post->ID, 'wpfa_event_end_time', true );
+		$timezone   = self::get_event_timezone( $post->ID );
+		$all_day    = self::get_event_all_day( $post->ID );
+		$location   = get_post_meta( $post->ID, 'wpfa_event_location', true );
+		$url        = get_post_meta( $post->ID, 'wpfa_event_url', true );
+		$lead_text  = get_post_meta( $post->ID, 'wpfa_event_lead_text', true );
+		$reg_link   = get_post_meta( $post->ID, 'wpfa_event_registration_link', true );
+		$cfs_link   = get_post_meta( $post->ID, 'wpfa_event_cfs_link', true );
+		$languages  = self::sanitize_language_list( get_post_meta( $post->ID, 'wpfa_event_languages', true ) );
+		$colors     = self::get_event_colors( $post->ID );
+		$speakers   = self::get_admin_event_speaker_ids( $post->ID );
+		$featured   = array_values( array_intersect( self::get_event_featured_speaker_ids( $post->ID ), $speakers ) );
+		?>
+		<table class="form-table">
+			<tr>
+				<th><label for="wpfa_event_start_date"><?php esc_html_e( 'Start Date', 'wpfaevent' ); ?></label></th>
+				<td><input type="date" id="wpfa_event_start_date" name="wpfa_event_start_date" value="<?php echo esc_attr( $start_date ); ?>" class="regular-text"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_end_date"><?php esc_html_e( 'End Date', 'wpfaevent' ); ?></label></th>
+				<td><input type="date" id="wpfa_event_end_date" name="wpfa_event_end_date" value="<?php echo esc_attr( $end_date ); ?>" class="regular-text"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_timezone"><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></label></th>
+				<td>
+					<select id="wpfa_event_timezone" name="wpfa_event_timezone" class="regular-text">
+						<?php echo wp_timezone_choice( $timezone ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes timezone option markup. ?>
+					</select>
+					<p class="description"><?php esc_html_e( 'Used to interpret timed events and calendar exports. Leave as the site timezone when the event does not need a separate timezone.', 'wpfaevent' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Time Format', 'wpfaevent' ); ?></th>
+				<td>
+					<label for="wpfa_event_all_day">
+						<input type="checkbox" id="wpfa_event_all_day" name="wpfa_event_all_day" value="1" <?php checked( $all_day ); ?>>
+						<?php esc_html_e( 'All-day event', 'wpfaevent' ); ?>
+					</label>
+					<p class="description"><?php esc_html_e( 'All-day events export as date-only calendar entries. Timed events use the event timezone.', 'wpfaevent' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_start_time"><?php esc_html_e( 'Start Time', 'wpfaevent' ); ?></label></th>
+				<td><input type="time" id="wpfa_event_start_time" name="wpfa_event_start_time" value="<?php echo esc_attr( $start_time ); ?>" class="regular-text"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_end_time"><?php esc_html_e( 'End Time', 'wpfaevent' ); ?></label></th>
+				<td><input type="time" id="wpfa_event_end_time" name="wpfa_event_end_time" value="<?php echo esc_attr( $end_time ); ?>" class="regular-text"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_location"><?php esc_html_e( 'Location', 'wpfaevent' ); ?></label></th>
+				<td><input type="text" id="wpfa_event_location" name="wpfa_event_location" value="<?php echo esc_attr( $location ); ?>" class="regular-text"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_url"><?php esc_html_e( 'Event URL', 'wpfaevent' ); ?></label></th>
+				<td><input type="url" id="wpfa_event_url" name="wpfa_event_url" value="<?php echo esc_attr( $url ); ?>" class="regular-text" placeholder="https://"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_lead_text"><?php esc_html_e( 'Lead Text', 'wpfaevent' ); ?></label></th>
+				<td><input type="text" id="wpfa_event_lead_text" name="wpfa_event_lead_text" value="<?php echo esc_attr( $lead_text ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Short description for hero section', 'wpfaevent' ); ?>"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_registration_link"><?php esc_html_e( 'Registration Link', 'wpfaevent' ); ?></label></th>
+				<td><input type="url" id="wpfa_event_registration_link" name="wpfa_event_registration_link" value="<?php echo esc_attr( $reg_link ); ?>" class="regular-text" placeholder="https://eventyay.com/e/..."></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_cfs_link"><?php esc_html_e( 'Call for Speakers Link', 'wpfaevent' ); ?></label></th>
+				<td><input type="url" id="wpfa_event_cfs_link" name="wpfa_event_cfs_link" value="<?php echo esc_attr( $cfs_link ); ?>" class="regular-text" placeholder="https://eventyay.com/e/.../cfs"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_languages"><?php esc_html_e( 'Event Languages', 'wpfaevent' ); ?></label></th>
+				<td>
+					<input type="text" id="wpfa_event_languages" name="wpfa_event_languages" value="<?php echo esc_attr( implode( ', ', $languages ) ); ?>" class="regular-text">
+					<p class="description"><?php esc_html_e( 'Comma-separated language names or codes, e.g. English, Hindi, German.', 'wpfaevent' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Event Colors', 'wpfaevent' ); ?></th>
+				<td>
+					<fieldset>
+						<?php foreach ( self::get_event_color_meta_fields() as $meta_key => $label ) : ?>
+							<label style="display:block;margin-bottom:8px;" for="<?php echo esc_attr( $meta_key ); ?>">
+								<span style="display:inline-block;min-width:180px;"><?php echo esc_html( $label ); ?></span>
+								<input type="text" id="<?php echo esc_attr( $meta_key ); ?>" name="<?php echo esc_attr( $meta_key ); ?>" value="<?php echo esc_attr( isset( $colors[ $meta_key ] ) ? $colors[ $meta_key ] : '' ); ?>" class="regular-text" placeholder="#D51007">
+							</label>
+						<?php endforeach; ?>
+					</fieldset>
+					<p class="description"><?php esc_html_e( 'Imported from Eventyay settings when the API exposes event theme colors.', 'wpfaevent' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_speakers"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></label></th>
+				<td>
+					<?php
+						$all_speaker_ids     = get_posts(
+							array(
+								'post_type'      => 'wpfa_speaker',
+								'posts_per_page' => -1,
+								'orderby'        => 'title',
+								'order'          => 'ASC',
+								'fields'         => 'ids',
+								'no_found_rows'  => true,
+							)
+						);
+					$other_event_speaker_ids = array_diff( self::get_all_event_owned_speaker_ids(), $speakers );
+					$speaker_ids             = array_diff( $all_speaker_ids, $other_event_speaker_ids );
+					$speaker_ids             = self::sanitize_post_id_list( array_merge( $speakers, $speaker_ids ) );
+					usort(
+						$speaker_ids,
+						static function ( $speaker_a, $speaker_b ) {
+							return strcasecmp( get_the_title( $speaker_a ), get_the_title( $speaker_b ) );
+						}
+					);
+
+					if ( $speaker_ids ) :
+						?>
+						<select name="wpfa_event_speakers[]" id="wpfa_event_speakers" multiple class="wpfaevent-speakers-select">
+							<?php foreach ( $speaker_ids as $speaker_id ) : ?>
+								<option value="<?php echo esc_attr( $speaker_id ); ?>" <?php selected( in_array( $speaker_id, $speakers, true ) ); ?>>
+									<?php echo esc_html( get_the_title( $speaker_id ) ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+						<p class="description">
+							<?php esc_html_e( 'Only site speakers and speakers already linked to this event are shown.', 'wpfaevent' ); ?>
+						</p>
+					<?php else : ?>
+						<p><?php esc_html_e( 'No speakers found. Create speakers first.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_event_featured_speakers"><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></label></th>
+				<td>
+					<?php if ( ! empty( $speakers ) ) : ?>
+						<select name="wpfa_event_featured_speakers[]" id="wpfa_event_featured_speakers" multiple class="wpfaevent-speakers-select">
+							<?php foreach ( $speakers as $speaker_id ) : ?>
+								<option value="<?php echo esc_attr( $speaker_id ); ?>" <?php selected( in_array( $speaker_id, $featured, true ) ); ?>>
+									<?php echo esc_html( get_the_title( $speaker_id ) ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+						<p class="description">
+							<?php esc_html_e( 'Featured speakers are highlighted and listed first on this event only.', 'wpfaevent' ); ?>
+						</p>
+					<?php else : ?>
+						<p><?php esc_html_e( 'Add speakers to this event before selecting featured speakers.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</td>
+			</tr>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Render the Additional Information meta box.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Post $post Event post object.
+	 */
+	public static function render_additional_information_meta_box( $post ) {
+		$venue_info  = get_post_meta( $post->ID, 'wpfa_event_venue_information', true );
+		$custom_tabs = self::sanitize_custom_tabs( get_post_meta( $post->ID, 'wpfa_event_custom_tabs', true ) );
+		?>
+		<p class="description">
+			<?php esc_html_e( 'Use this area for attendee-facing information that appears on the event page. Keep the main section for general venue and travel notes, then add extra sections only for topics that need their own navigation item.', 'wpfaevent' ); ?>
+		</p>
+		<div class="wpfaevent-attendee-info">
+			<div class="wpfaevent-attendee-info-section">
+				<h3><?php esc_html_e( 'Main Additional Information', 'wpfaevent' ); ?></h3>
+				<p class="description">
+					<?php esc_html_e( 'Shown as the default Additional Info section. Best for venue notes, directions, parking, transport, and accessibility details.', 'wpfaevent' ); ?>
+				</p>
+				<?php
+				wp_editor(
+					$venue_info,
+					'wpfa_event_venue_information',
+					array(
+						'textarea_name' => 'wpfa_event_venue_information',
+						'textarea_rows' => 8,
+						'media_buttons' => false,
+					)
+				);
+				?>
+			</div>
+
+			<div class="wpfaevent-attendee-info-section">
+				<h3><?php esc_html_e( 'Extra Information Sections', 'wpfaevent' ); ?></h3>
+				<p class="description">
+					<?php esc_html_e( 'Add separate event page sections for focused topics such as accommodation options, travel passes, childcare, or attendee resources.', 'wpfaevent' ); ?>
+				</p>
+				<div class="wpfaevent-custom-tabs" data-next-index="<?php echo esc_attr( count( $custom_tabs ) ); ?>">
+					<div class="wpfaevent-custom-tabs-list">
+						<?php foreach ( $custom_tabs as $index => $custom_tab ) : ?>
+							<?php self::render_custom_tab_row( $index, $custom_tab ); ?>
+						<?php endforeach; ?>
+					</div>
+					<p class="wpfaevent-custom-tabs-empty" <?php echo empty( $custom_tabs ) ? '' : 'hidden="hidden"'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static attribute fragment. ?>>
+						<?php esc_html_e( 'No extra sections yet. Add one only when a topic needs its own tab in the event navigation.', 'wpfaevent' ); ?>
+					</p>
+					<p>
+						<button type="button" class="button wpfaevent-add-custom-tab">
+							<?php esc_html_e( 'Add Information Section', 'wpfaevent' ); ?>
+						</button>
+					</p>
+					<script type="text/template" class="wpfaevent-custom-tab-template">
+						<?php
+						self::render_custom_tab_row(
+							'{{INDEX}}',
+							array(
+								'title'   => '',
+								'slug'    => '',
+								'content' => '',
+							)
+						);
+						?>
+					</script>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render one custom tab row.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int|string $index Row index.
+	 * @param array      $tab   Custom tab data.
+	 */
+	private static function render_custom_tab_row( $index, $tab ) {
+		$index   = (string) $index;
+		$title   = isset( $tab['title'] ) && is_scalar( $tab['title'] ) ? sanitize_text_field( $tab['title'] ) : '';
+		$slug    = isset( $tab['slug'] ) && is_scalar( $tab['slug'] ) ? sanitize_title( $tab['slug'] ) : '';
+		$content = isset( $tab['content'] ) && is_scalar( $tab['content'] ) ? (string) $tab['content'] : '';
+		?>
+		<div class="wpfaevent-custom-tab-row">
+			<input type="hidden" name="wpfa_event_custom_tabs[<?php echo esc_attr( $index ); ?>][slug]" value="<?php echo esc_attr( $slug ); ?>">
+			<p>
+				<label for="wpfa_event_custom_tabs_<?php echo esc_attr( $index ); ?>_title">
+					<strong><?php esc_html_e( 'Section Title', 'wpfaevent' ); ?></strong>
+				</label>
+				<input
+					type="text"
+					id="wpfa_event_custom_tabs_<?php echo esc_attr( $index ); ?>_title"
+					name="wpfa_event_custom_tabs[<?php echo esc_attr( $index ); ?>][title]"
+					value="<?php echo esc_attr( $title ); ?>"
+					class="widefat"
+					placeholder="<?php esc_attr_e( 'Accommodation', 'wpfaevent' ); ?>"
+				>
+			</p>
+			<p>
+				<label for="wpfa_event_custom_tabs_<?php echo esc_attr( $index ); ?>_content">
+					<strong><?php esc_html_e( 'Section Content', 'wpfaevent' ); ?></strong>
+				</label>
+				<textarea
+					id="wpfa_event_custom_tabs_<?php echo esc_attr( $index ); ?>_content"
+					name="wpfa_event_custom_tabs[<?php echo esc_attr( $index ); ?>][content]"
+					rows="6"
+					class="widefat"
+					placeholder="<?php esc_attr_e( 'List recommended hotels, booking links, travel notes, or other useful event details.', 'wpfaevent' ); ?>"
+				><?php echo esc_textarea( $content ); ?></textarea>
+			</p>
+			<button type="button" class="button-link-delete wpfaevent-remove-custom-tab">
+				<?php esc_html_e( 'Remove tab', 'wpfaevent' ); ?>
+			</button>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Save Event Details meta box data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id Event post ID.
+	 */
+	public static function save_meta( $post_id ) {
+		$event_nonce = isset( $_POST['wpfa_event_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_meta_nonce'] ) ) : '';
+
+		if ( ! $event_nonce || ! wp_verify_nonce( $event_nonce, 'wpfa_event_meta_nonce' ) ) {
 			return;
 		}
 
-		foreach ( array_diff( $previous_speakers, $current_speakers ) as $speaker_id ) {
-			Wpfaevent_Meta_Speaker::remove_event_from_speaker( $speaker_id, $event_id, false );
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
 		}
 
-		foreach ( $current_speakers as $speaker_id ) {
-			Wpfaevent_Meta_Speaker::add_event_to_speaker( $speaker_id, $event_id, false );
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
 		}
+
+		if ( isset( $_POST['wpfa_event_start_date'] ) ) {
+			$posted_start_date = sanitize_text_field( wp_unslash( $_POST['wpfa_event_start_date'] ) );
+			update_post_meta( $post_id, 'wpfa_event_start_date', self::sanitize_date_value( $posted_start_date ) );
+		}
+
+		if ( isset( $_POST['wpfa_event_end_date'] ) ) {
+			$posted_end_date = sanitize_text_field( wp_unslash( $_POST['wpfa_event_end_date'] ) );
+			update_post_meta( $post_id, 'wpfa_event_end_date', self::sanitize_date_value( $posted_end_date ) );
+		}
+
+		$posted_timezone = isset( $_POST['wpfa_event_timezone'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_timezone'] ) ) : '';
+		$timezone        = self::sanitize_timezone( $posted_timezone );
+		if ( '' !== $timezone ) {
+			update_post_meta( $post_id, 'wpfa_event_timezone', $timezone );
+		} else {
+			delete_post_meta( $post_id, 'wpfa_event_timezone' );
+		}
+
+		$all_day = isset( $_POST['wpfa_event_all_day'] );
+		update_post_meta( $post_id, 'wpfa_event_all_day', $all_day ? '1' : '0' );
+
+		$posted_start_time = isset( $_POST['wpfa_event_start_time'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_start_time'] ) ) : '';
+		$posted_end_time   = isset( $_POST['wpfa_event_end_time'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_end_time'] ) ) : '';
+		$start_time        = self::sanitize_time_value( $posted_start_time );
+		$end_time          = self::sanitize_time_value( $posted_end_time );
+
+		if ( $all_day ) {
+			delete_post_meta( $post_id, 'wpfa_event_start_time' );
+			delete_post_meta( $post_id, 'wpfa_event_time' );
+			delete_post_meta( $post_id, 'wpfa_event_end_time' );
+			delete_post_meta( $post_id, 'wpfa_event_starts_at' );
+			delete_post_meta( $post_id, 'wpfa_event_ends_at' );
+		} else {
+			self::update_or_delete_meta( $post_id, 'wpfa_event_start_time', $start_time );
+			self::update_or_delete_meta( $post_id, 'wpfa_event_time', $start_time );
+			self::update_or_delete_meta( $post_id, 'wpfa_event_end_time', $end_time );
+			self::update_or_delete_meta( $post_id, 'wpfa_event_starts_at', self::build_datetime_value( get_post_meta( $post_id, 'wpfa_event_start_date', true ), $start_time, $timezone ) );
+			self::update_or_delete_meta( $post_id, 'wpfa_event_ends_at', self::build_datetime_value( get_post_meta( $post_id, 'wpfa_event_end_date', true ), $end_time, $timezone ) );
+		}
+
+		if ( isset( $_POST['wpfa_event_location'] ) ) {
+			update_post_meta( $post_id, 'wpfa_event_location', sanitize_text_field( wp_unslash( $_POST['wpfa_event_location'] ) ) );
+		}
+
+		if ( isset( $_POST['wpfa_event_venue_information'] ) ) {
+			self::update_or_delete_meta( $post_id, 'wpfa_event_venue_information', wp_kses_post( wp_unslash( $_POST['wpfa_event_venue_information'] ) ) );
+		}
+
+		$posted_custom_tabs = isset( $_POST['wpfa_event_custom_tabs'] ) ? wp_unslash( $_POST['wpfa_event_custom_tabs'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by sanitize_custom_tabs().
+		$custom_tabs        = self::sanitize_custom_tabs( $posted_custom_tabs );
+		if ( ! empty( $custom_tabs ) ) {
+			update_post_meta( $post_id, 'wpfa_event_custom_tabs', $custom_tabs );
+		} else {
+			delete_post_meta( $post_id, 'wpfa_event_custom_tabs' );
+		}
+
+		if ( isset( $_POST['wpfa_event_url'] ) ) {
+			update_post_meta( $post_id, 'wpfa_event_url', esc_url_raw( wp_unslash( $_POST['wpfa_event_url'] ) ) );
+		}
+
+		if ( isset( $_POST['wpfa_event_lead_text'] ) ) {
+			self::update_or_delete_meta( $post_id, 'wpfa_event_lead_text', sanitize_text_field( wp_unslash( $_POST['wpfa_event_lead_text'] ) ) );
+		}
+
+		if ( isset( $_POST['wpfa_event_registration_link'] ) ) {
+			self::update_or_delete_meta( $post_id, 'wpfa_event_registration_link', esc_url_raw( wp_unslash( $_POST['wpfa_event_registration_link'] ) ) );
+		}
+
+		if ( isset( $_POST['wpfa_event_cfs_link'] ) ) {
+			self::update_or_delete_meta( $post_id, 'wpfa_event_cfs_link', esc_url_raw( wp_unslash( $_POST['wpfa_event_cfs_link'] ) ) );
+		}
+
+		$languages = isset( $_POST['wpfa_event_languages'] ) ? self::sanitize_language_list( sanitize_text_field( wp_unslash( $_POST['wpfa_event_languages'] ) ) ) : array();
+		if ( ! empty( $languages ) ) {
+			update_post_meta( $post_id, 'wpfa_event_languages', $languages );
+		} else {
+			delete_post_meta( $post_id, 'wpfa_event_languages' );
+		}
+
+		foreach ( self::get_event_color_meta_fields() as $meta_key => $label ) {
+			$color = isset( $_POST[ $meta_key ] ) ? self::sanitize_color_value( sanitize_text_field( wp_unslash( $_POST[ $meta_key ] ) ) ) : '';
+			if ( '' !== $color ) {
+				update_post_meta( $post_id, $meta_key, $color );
+			} else {
+				delete_post_meta( $post_id, $meta_key );
+			}
+		}
+
+		$previous_speakers = self::get_event_speaker_ids( $post_id );
+		$speakers          = array();
+
+		if ( isset( $_POST['wpfa_event_speakers'] ) && is_array( $_POST['wpfa_event_speakers'] ) ) {
+			$speakers = self::sanitize_post_id_list(
+				array_map(
+					'sanitize_text_field',
+					wp_unslash( $_POST['wpfa_event_speakers'] )
+				)
+			);
+		}
+
+		if ( ! empty( $speakers ) ) {
+			update_post_meta( $post_id, 'wpfa_event_speakers', $speakers );
+		} else {
+			delete_post_meta( $post_id, 'wpfa_event_speakers' );
+		}
+
+		$featured_speakers = array();
+		if ( isset( $_POST['wpfa_event_featured_speakers'] ) && is_array( $_POST['wpfa_event_featured_speakers'] ) ) {
+			$featured_speakers = self::sanitize_post_id_list(
+				array_map(
+					'sanitize_text_field',
+					wp_unslash( $_POST['wpfa_event_featured_speakers'] )
+				)
+			);
+		}
+		$featured_speakers = array_values( array_intersect( $featured_speakers, $speakers ) );
+
+		if ( ! empty( $featured_speakers ) ) {
+			update_post_meta( $post_id, 'wpfa_event_featured_speakers', $featured_speakers );
+		} else {
+			delete_post_meta( $post_id, 'wpfa_event_featured_speakers' );
+		}
+
+		self::sync_event_speaker_relationships( $post_id, $previous_speakers, $speakers );
+	}
+
+	/**
+	 * Get normalized speaker IDs assigned to an event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int>
+	 */
+	public static function get_event_speaker_ids( $event_id ) {
+		return self::sanitize_post_id_list( get_post_meta( $event_id, 'wpfa_event_speakers', true ) );
+	}
+
+	/**
+	 * Get normalized featured speaker IDs assigned to an event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int>
+	 */
+	public static function get_event_featured_speaker_ids( $event_id ) {
+		return self::sanitize_post_id_list( get_post_meta( $event_id, 'wpfa_event_featured_speakers', true ) );
+	}
+
+	/**
+	 * Resolve featured speaker IDs from event meta, dashboard JSON, and speaker categories.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int               $event_id           Event post ID.
+	 * @param array<int>        $speaker_ids        Linked speaker post IDs.
+	 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
+	 * @return array<int>
+	 */
+	public static function resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers = array() ) {
+		$event_id    = absint( $event_id );
+		$speaker_ids = self::sanitize_post_id_list( $speaker_ids );
+		$featured    = array_values( array_intersect( self::get_event_featured_speaker_ids( $event_id ), $speaker_ids ) );
+
+		if ( is_array( $dashboard_speakers ) && ! empty( $dashboard_speakers ) ) {
+			$eventyay_map = array();
+			$name_map     = array();
+
+			foreach ( $speaker_ids as $speaker_id ) {
+				$eventyay_id = sanitize_text_field( get_post_meta( $speaker_id, '_wpfa_eventyay_speaker_id', true ) );
+
+				if ( '' !== $eventyay_id ) {
+					$eventyay_map[ $eventyay_id ] = $speaker_id;
+				}
+
+				$name_key = sanitize_title( get_the_title( $speaker_id ) );
+
+				if ( '' !== $name_key ) {
+					$name_map[ $name_key ] = $speaker_id;
+				}
+			}
+
+			foreach ( $dashboard_speakers as $dashboard_speaker ) {
+				if ( ! is_array( $dashboard_speaker ) || empty( $dashboard_speaker['featured'] ) ) {
+					continue;
+				}
+
+				$matched_id = 0;
+
+				if ( ! empty( $dashboard_speaker['eventyay_speaker_id'] ) && isset( $eventyay_map[ $dashboard_speaker['eventyay_speaker_id'] ] ) ) {
+					$matched_id = (int) $eventyay_map[ $dashboard_speaker['eventyay_speaker_id'] ];
+				} elseif ( ! empty( $dashboard_speaker['name'] ) ) {
+					$name_key = sanitize_title( $dashboard_speaker['name'] );
+
+					if ( isset( $name_map[ $name_key ] ) ) {
+						$matched_id = (int) $name_map[ $name_key ];
+					}
+				}
+
+				if ( $matched_id && ! in_array( $matched_id, $featured, true ) ) {
+					$featured[] = $matched_id;
+				}
+			}
+		}
+
+		if ( taxonomy_exists( 'wpfa_speaker_category' ) ) {
+			foreach ( $speaker_ids as $speaker_id ) {
+				if ( in_array( $speaker_id, $featured, true ) ) {
+					continue;
+				}
+
+				$terms = get_the_terms( $speaker_id, 'wpfa_speaker_category' );
+
+				if ( empty( $terms ) || is_wp_error( $terms ) ) {
+					continue;
+				}
+
+				foreach ( $terms as $term ) {
+					if ( preg_match( '/\b(featured|keynote|plenary|highlight)\b/i', $term->name ) ) {
+						$featured[] = $speaker_id;
+						break;
+					}
+				}
+			}
+		}
+
+		$featured = self::sanitize_post_id_list( $featured );
+		$featured = array_values( array_intersect( $featured, $speaker_ids ) );
+
+		if ( empty( $featured ) && ! empty( $speaker_ids ) ) {
+			$auto_limit = absint(
+				apply_filters(
+					'wpfa_event_auto_featured_speaker_limit',
+					1,
+					$event_id,
+					$speaker_ids,
+					$dashboard_speakers
+				)
+			);
+
+			if ( $auto_limit > 0 ) {
+				$featured = array_slice( $speaker_ids, 0, min( $auto_limit, count( $speaker_ids ) ) );
+			}
+		}
+
+		/**
+		 * Filter resolved featured speaker IDs for an event page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array<int>        $featured           Resolved featured speaker IDs.
+		 * @param int               $event_id           Event post ID.
+		 * @param array<int>        $speaker_ids        Linked speaker post IDs.
+		 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
+		 */
+		return apply_filters( 'wpfa_event_featured_speaker_ids', $featured, $event_id, $speaker_ids, $dashboard_speakers );
+	}
+
+	/**
+	 * Get speakers assigned to one event from event and reverse speaker meta.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int>
+	 */
+	public static function get_admin_event_speaker_ids( $event_id ) {
+		$event_id = absint( $event_id );
+
+		if ( ! $event_id || get_post_type( $event_id ) !== self::$post_type ) {
+			return array();
+		}
+
+		return self::sanitize_post_id_list(
+			array_merge(
+				self::get_event_speaker_ids( $event_id ),
+				Wpfaevent_Meta_Speaker::get_speakers_linked_to_event( $event_id )
+			)
+		);
+	}
+
+	/**
+	 * Get every speaker owned by any event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int>
+	 */
+	public static function get_all_event_owned_speaker_ids() {
+		$speaker_ids = array();
+		$event_ids   = get_posts(
+			array(
+				'post_type'      => self::$post_type,
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		foreach ( $event_ids as $event_id ) {
+			$speaker_ids = array_merge( $speaker_ids, self::get_event_speaker_ids( $event_id ) );
+		}
+
+		return self::sanitize_post_id_list( array_merge( $speaker_ids, Wpfaevent_Meta_Speaker::get_all_speakers_linked_to_events() ) );
 	}
 
 	/**
@@ -353,180 +1005,7 @@ class Wpfaevent_Meta_Event {
 	}
 
 	/**
-	 * Sanitize an event date value.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param mixed $date Raw date.
-	 * @return string
-	 */
-	public static function sanitize_date_value( $date ) {
-		if ( ! is_scalar( $date ) ) {
-			return '';
-		}
-
-		$date = trim( sanitize_text_field( (string) $date ) );
-
-		if ( '' === $date ) {
-			return '';
-		}
-
-		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
-			return '';
-		}
-
-		if ( ! checkdate( (int) $matches[2], (int) $matches[3], (int) $matches[1] ) ) {
-			return '';
-		}
-
-		return $date;
-	}
-
-	/**
-	 * Sanitize an event time value.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param mixed $time Raw time.
-	 * @return string
-	 */
-	public static function sanitize_time_value( $time ) {
-		if ( ! is_scalar( $time ) ) {
-			return '';
-		}
-
-		$time = trim( sanitize_text_field( (string) $time ) );
-
-		if ( '' === $time ) {
-			return '';
-		}
-
-		if ( ! preg_match( '/^([01]\d|2[0-3]):([0-5]\d)(?::[0-5]\d)?$/', $time ) ) {
-			return '';
-		}
-
-		return substr( $time, 0, 5 );
-	}
-
-	/**
-	 * Sanitize a timezone identifier or UTC offset.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param mixed $timezone Raw timezone.
-	 * @return string
-	 */
-	public static function sanitize_timezone( $timezone ) {
-		if ( ! is_scalar( $timezone ) ) {
-			return '';
-		}
-
-		$timezone = trim( sanitize_text_field( (string) $timezone ) );
-
-		if ( '' === $timezone ) {
-			return '';
-		}
-
-		$timezone = self::normalize_utc_offset_timezone( $timezone );
-
-		try {
-			new DateTimeZone( $timezone );
-			return $timezone;
-		} catch ( Exception $exception ) {
-			return '';
-		}
-	}
-
-	/**
-	 * Sanitize a boolean-like meta value.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param mixed $value Raw value.
-	 * @return bool
-	 */
-	public static function sanitize_boolean_value( $value ) {
-		return rest_sanitize_boolean( $value );
-	}
-
-	/**
-	 * Get an event timezone, falling back to the WordPress site timezone.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $event_id Event post ID.
-	 * @return string
-	 */
-	public static function get_event_timezone( $event_id ) {
-		$timezone = self::sanitize_timezone( get_post_meta( $event_id, 'wpfa_event_timezone', true ) );
-
-		if ( '' !== $timezone ) {
-			return $timezone;
-		}
-
-		$site_timezone = self::sanitize_timezone( wp_timezone_string() );
-
-		if ( '' !== $site_timezone ) {
-			return $site_timezone;
-		}
-
-		return wp_timezone()->getName();
-	}
-
-	/**
-	 * Determine whether an event should be treated as all-day.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $event_id Event post ID.
-	 * @return bool
-	 */
-	public static function get_event_all_day( $event_id ) {
-		$value = get_post_meta( $event_id, 'wpfa_event_all_day', true );
-
-		if ( '' !== $value ) {
-			return rest_sanitize_boolean( $value );
-		}
-
-		return '' === self::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_start_time', true ) )
-			&& '' === self::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_end_time', true ) )
-			&& '' === self::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_time', true ) );
-	}
-
-	/**
-	 * Build an ISO 8601 datetime for timed manual events.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $date     Date in Y-m-d format.
-	 * @param string $time     Time in H:i format.
-	 * @param string $timezone Timezone identifier.
-	 * @return string
-	 */
-	public static function build_datetime_value( $date, $time, $timezone ) {
-		$date     = self::sanitize_date_value( $date );
-		$time     = self::sanitize_time_value( $time );
-		$timezone = self::sanitize_timezone( $timezone );
-
-		if ( '' === $date || '' === $time ) {
-			return '';
-		}
-
-		if ( '' === $timezone ) {
-			$timezone = self::get_event_timezone( 0 );
-		}
-
-		try {
-			$datetime = new DateTimeImmutable( $date . ' ' . $time, new DateTimeZone( $timezone ) );
-		} catch ( Exception $exception ) {
-			return '';
-		}
-
-		return $datetime->format( DATE_ATOM );
-	}
-
-	/**
-	 * Event color meta fields imported from Eventyay settings.
+	 * Get event color meta fields.
 	 *
 	 * @since 1.0.0
 	 *
@@ -540,6 +1019,27 @@ class Wpfaevent_Meta_Event {
 			'wpfa_event_theme_success_color'    => __( 'Theme success color', 'wpfaevent' ),
 			'wpfa_event_theme_danger_color'     => __( 'Theme danger color', 'wpfaevent' ),
 		);
+	}
+
+	/**
+	 * Get sanitized event colors for a post.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<string, string>
+	 */
+	public static function get_event_colors( $event_id ) {
+		$colors = array();
+
+		foreach ( self::get_event_color_meta_fields() as $meta_key => $label ) {
+			$color = self::sanitize_color_value( get_post_meta( $event_id, $meta_key, true ) );
+			if ( '' !== $color ) {
+				$colors[ $meta_key ] = $color;
+			}
+		}
+
+		return $colors;
 	}
 
 	/**
@@ -585,18 +1085,87 @@ class Wpfaevent_Meta_Event {
 			}
 
 			$language = sanitize_text_field( (string) $language );
-			$language = trim( $language );
+			$language = trim( str_replace( '_', '-', $language ) );
 
-			if ( '' !== $language ) {
-				$normalized[] = $language;
+			if ( '' === $language ) {
+				continue;
+			}
+
+			$key = sanitize_title( $language );
+			if ( '' !== $key ) {
+				$normalized[ $key ] = $language;
 			}
 		}
 
-		return array_values( array_unique( $normalized ) );
+		return array_values( $normalized );
 	}
 
 	/**
-	 * Sanitize an imported event color value.
+	 * Sanitize event custom tabs.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $tabs Raw tab data.
+	 * @return array<int, array<string, string>>
+	 */
+	public static function sanitize_custom_tabs( $tabs ) {
+		if ( is_string( $tabs ) ) {
+			$decoded_tabs = json_decode( $tabs, true );
+
+			if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded_tabs ) ) {
+				$tabs = $decoded_tabs;
+			}
+		}
+
+		if ( ! is_array( $tabs ) ) {
+			return array();
+		}
+
+		$sanitized_tabs = array();
+		$used_slugs     = array();
+
+		foreach ( $tabs as $tab ) {
+			if ( ! is_array( $tab ) ) {
+				continue;
+			}
+
+			$title   = isset( $tab['title'] ) && is_scalar( $tab['title'] ) ? sanitize_text_field( $tab['title'] ) : '';
+			$content = isset( $tab['content'] ) && is_scalar( $tab['content'] ) ? trim( wp_kses_post( (string) $tab['content'] ) ) : '';
+
+			if ( '' === $title || '' === $content ) {
+				continue;
+			}
+
+			$slug = isset( $tab['slug'] ) && is_scalar( $tab['slug'] ) ? sanitize_title( $tab['slug'] ) : '';
+			if ( '' === $slug ) {
+				$slug = sanitize_title( $title );
+			}
+
+			if ( '' === $slug ) {
+				$slug = 'custom-tab-' . ( count( $sanitized_tabs ) + 1 );
+			}
+
+			$base_slug = $slug;
+			$suffix    = 2;
+			while ( isset( $used_slugs[ $slug ] ) ) {
+				$slug = $base_slug . '-' . $suffix;
+				++$suffix;
+			}
+
+			$used_slugs[ $slug ] = true;
+
+			$sanitized_tabs[] = array(
+				'title'   => $title,
+				'slug'    => $slug,
+				'content' => $content,
+			);
+		}
+
+		return array_values( $sanitized_tabs );
+	}
+
+	/**
+	 * Sanitize an Eventyay color value.
 	 *
 	 * @since 1.0.0
 	 *
@@ -618,7 +1187,7 @@ class Wpfaevent_Meta_Event {
 			return '';
 		}
 
-		$color = trim( sanitize_text_field( (string) $color ) );
+		$color = trim( (string) $color );
 		if ( '' === $color ) {
 			return '';
 		}
@@ -631,21 +1200,155 @@ class Wpfaevent_Meta_Event {
 			return '#' . strtoupper( $color );
 		}
 
-		if ( preg_match( '/^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(\s*,\s*(0|1|0?\.\d+))?\s*\)$/', $color ) ) {
+		if ( preg_match( '/^rgba?\(\\s*\\d{1,3}\\s*,\\s*\\d{1,3}\\s*,\\s*\\d{1,3}(\\s*,\\s*(0|1|0?\\.\\d+))?\\s*\)$/', $color ) ) {
 			return $color;
 		}
 
 		return '';
 	}
 
-	/**
-	 * Normalize old WordPress UTC offset labels into DateTimeZone-compatible offsets.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $timezone Timezone string.
-	 * @return string
-	 */
+		/**
+		 * Sanitize an event date value.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param mixed $date Raw date.
+		 * @return string
+		 */
+	public static function sanitize_date_value( $date ) {
+		if ( ! is_scalar( $date ) ) {
+			return '';
+		}
+
+		$date = trim( sanitize_text_field( (string) $date ) );
+
+		if ( '' === $date || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+			return '';
+		}
+
+		$parts = array_map( 'absint', explode( '-', $date ) );
+
+		return checkdate( $parts[1], $parts[2], $parts[0] ) ? $date : '';
+	}
+
+		/**
+		 * Sanitize an event time value.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param mixed $time Raw time.
+		 * @return string
+		 */
+	public static function sanitize_time_value( $time ) {
+		if ( ! is_scalar( $time ) ) {
+			return '';
+		}
+
+		$time = trim( sanitize_text_field( (string) $time ) );
+
+		if ( '' === $time ) {
+			return '';
+		}
+
+		if ( ! preg_match( '/^([01]\d|2[0-3]):([0-5]\d)(?::[0-5]\d)?$/', $time ) ) {
+			return '';
+		}
+
+		return substr( $time, 0, 5 );
+	}
+
+		/**
+		 * Sanitize a timezone identifier or UTC offset.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param mixed $timezone Raw timezone.
+		 * @return string
+		 */
+	public static function sanitize_timezone( $timezone ) {
+		if ( ! is_scalar( $timezone ) ) {
+			return '';
+		}
+
+		$timezone = trim( sanitize_text_field( (string) $timezone ) );
+
+		if ( '' === $timezone ) {
+			return '';
+		}
+
+		$timezone = self::normalize_utc_offset_timezone( $timezone );
+
+		try {
+			new DateTimeZone( $timezone );
+			return $timezone;
+		} catch ( Exception $exception ) {
+			return '';
+		}
+	}
+
+		/**
+		 * Sanitize a boolean-like meta value.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param mixed $value Raw value.
+		 * @return bool
+		 */
+	public static function sanitize_boolean_value( $value ) {
+		return rest_sanitize_boolean( $value );
+	}
+
+		/**
+		 * Get an event timezone, falling back to the WordPress site timezone.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $event_id Event post ID.
+		 * @return string
+		 */
+	public static function get_event_timezone( $event_id ) {
+		$timezone = self::sanitize_timezone( get_post_meta( $event_id, 'wpfa_event_timezone', true ) );
+
+		if ( '' !== $timezone ) {
+			return $timezone;
+		}
+
+		$site_timezone = self::sanitize_timezone( wp_timezone_string() );
+
+		if ( '' !== $site_timezone ) {
+			return $site_timezone;
+		}
+
+		return wp_timezone()->getName();
+	}
+
+		/**
+		 * Determine whether an event should be treated as all-day.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $event_id Event post ID.
+		 * @return bool
+		 */
+	public static function get_event_all_day( $event_id ) {
+		$value = get_post_meta( $event_id, 'wpfa_event_all_day', true );
+
+		if ( '' !== $value ) {
+			return rest_sanitize_boolean( $value );
+		}
+
+		return '' === self::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_start_time', true ) )
+			&& '' === self::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_end_time', true ) );
+	}
+
+		/**
+		 * Normalize old WordPress UTC offset labels into DateTimeZone-compatible offsets.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $timezone Timezone string.
+		 * @return string
+		 */
 	private static function normalize_utc_offset_timezone( $timezone ) {
 		if ( ! preg_match( '/^UTC([+-])(\d{1,2})(?:\.(5|50))?$/', $timezone, $matches ) ) {
 			return $timezone;
@@ -659,5 +1362,107 @@ class Wpfaevent_Meta_Event {
 		}
 
 		return sprintf( '%s%02d:%02d', $matches[1], $hours, $minutes );
+	}
+
+		/**
+		 * Build an ISO 8601 datetime for timed manual events.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $date     Date in Y-m-d format.
+		 * @param string $time     Time in H:i format.
+		 * @param string $timezone Timezone identifier.
+		 * @return string
+		 */
+	private static function build_datetime_value( $date, $time, $timezone ) {
+		$date     = self::sanitize_date_value( $date );
+		$time     = self::sanitize_time_value( $time );
+		$timezone = self::sanitize_timezone( $timezone );
+
+		if ( '' === $date || '' === $time ) {
+			return '';
+		}
+
+		if ( '' === $timezone ) {
+			$timezone = self::get_event_timezone( 0 );
+		}
+
+		try {
+			$datetime = new DateTimeImmutable( $date . ' ' . $time, new DateTimeZone( $timezone ) );
+		} catch ( Exception $exception ) {
+			return '';
+		}
+
+		return $datetime->format( DATE_ATOM );
+	}
+
+		/**
+		 * Update or remove a meta value based on emptiness.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int    $post_id Post ID.
+		 * @param string $key     Meta key.
+		 * @param string $value   Meta value.
+		 * @return void
+		 */
+	private static function update_or_delete_meta( $post_id, $key, $value ) {
+		if ( '' === $value ) {
+			delete_post_meta( $post_id, $key );
+			return;
+		}
+
+		update_post_meta( $post_id, $key, $value );
+	}
+
+		/**
+		 * Sync speaker-side event relationship meta after an event is saved.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int        $event_id          Event post ID.
+		 * @param array<int> $previous_speakers Speaker IDs before save.
+		 * @param array<int> $current_speakers  Speaker IDs after save.
+		 */
+	private static function sync_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers ) {
+		$event_id          = absint( $event_id );
+		$previous_speakers = self::sanitize_post_id_list(
+			array_merge(
+				self::sanitize_post_id_list( $previous_speakers ),
+				Wpfaevent_Meta_Speaker::get_speakers_linked_to_event( $event_id )
+			)
+		);
+		$current_speakers  = self::sanitize_post_id_list( $current_speakers );
+
+		if ( ! $event_id ) {
+			return;
+		}
+
+		foreach ( array_diff( $previous_speakers, $current_speakers ) as $speaker_id ) {
+			Wpfaevent_Meta_Speaker::remove_event_from_speaker( $speaker_id, $event_id, false );
+		}
+
+		foreach ( $current_speakers as $speaker_id ) {
+			Wpfaevent_Meta_Speaker::add_event_to_speaker( $speaker_id, $event_id, false );
+		}
+	}
+
+	/**
+	 * Sanitizes an array of speaker IDs.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $speaker_ids Array of speaker post IDs.
+	 * @return array Sanitized array of integers.
+	 */
+	public static function sanitize_speaker_ids( $speaker_ids ) {
+		if ( ! is_array( $speaker_ids ) ) {
+			return array();
+		}
+
+		$speaker_ids = array_map( 'absint', $speaker_ids );
+		$speaker_ids = array_filter( $speaker_ids );
+
+		return array_values( array_unique( $speaker_ids ) );
 	}
 }

--- a/public/class-wpfaevent-public.php
+++ b/public/class-wpfaevent-public.php
@@ -63,8 +63,8 @@ class Wpfaevent_Public {
 			return true;
 		}
 
-		if ( class_exists( 'Wpfaevent_Templates' ) ) {
-			return ! empty( Wpfaevent_Templates::get_active_template_keys() );
+		if ( class_exists( 'Wpfaevent_Templates' ) && ! empty( Wpfaevent_Templates::get_active_template_keys() ) ) {
+			return true;
 		}
 
 		$wpfa_templates = array(
@@ -72,6 +72,9 @@ class Wpfaevent_Public {
 			'page-events.php',
 			'page-past-events.php',
 			'page-schedule.php',
+			'page-additional-information.php',
+			'page-partner.php',
+			'public/partials/additional-information-page.php',
 			'page-speakers.php',
 			'page-landing.php',
 		);
@@ -82,7 +85,7 @@ class Wpfaevent_Public {
 			}
 		}
 
-		return false;
+		return is_post_type_archive( array( 'wpfa_event', 'wpfa_speaker' ) );
 	}
 
 	/**
@@ -98,8 +101,6 @@ class Wpfaevent_Public {
 					return true;
 				}
 			}
-
-			return false;
 		}
 
 		$paginated_templates = array(
@@ -115,7 +116,7 @@ class Wpfaevent_Public {
 			}
 		}
 
-		return false;
+		return is_post_type_archive( array( 'wpfa_event', 'wpfa_speaker' ) );
 	}
 
 	/**
@@ -126,8 +127,8 @@ class Wpfaevent_Public {
 	 * @return   bool             True if the template is active.
 	 */
 	private function is_wpfa_template_file_active( $template ) {
-		if ( class_exists( 'Wpfaevent_Templates' ) ) {
-			return Wpfaevent_Templates::is_template_file_active( $template );
+		if ( class_exists( 'Wpfaevent_Templates' ) && Wpfaevent_Templates::is_template_file_active( $template ) ) {
+			return true;
 		}
 
 		return is_page_template( $template );
@@ -178,32 +179,34 @@ class Wpfaevent_Public {
 	 * @return   array<string, mixed> Script data for the Events template.
 	 */
 	private function get_events_script_data() {
-		return array(
-			'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
-			'adminNonce' => wp_create_nonce( 'wpfa_events_ajax' ),
-			'isAdmin'    => current_user_can( 'manage_options' ),
-			'i18n'       => array(
-				'addEventTitle'      => __( 'Create a New Event', 'wpfaevent' ),
-				'editEventTitle'     => __( 'Edit Event', 'wpfaevent' ),
-				'addEventButton'     => __( 'Create Card', 'wpfaevent' ),
-				'editEventButton'    => __( 'Save Changes', 'wpfaevent' ),
-				'creating'           => __( 'Creating...', 'wpfaevent' ),
-				'saving'             => __( 'Saving...', 'wpfaevent' ),
-				'loading'            => __( 'Loading...', 'wpfaevent' ),
-				/* translators: %s: The name of the event being deleted. */
-				'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
-				'deleteSuccess'      => __( 'Event deleted successfully. The page will now reload.', 'wpfaevent' ),
-				'deleteError'        => __( 'Error deleting event', 'wpfaevent' ),
-				'deleteErrorGeneric' => __( 'Error deleting event. Please try again.', 'wpfaevent' ),
-				'addSuccess'         => __( 'Event created successfully. The page will now reload.', 'wpfaevent' ),
-				'addError'           => __( 'Error creating event', 'wpfaevent' ),
-				'addErrorGeneric'    => __( 'Error creating event. Please try again.', 'wpfaevent' ),
-				'updateSuccess'      => __( 'Event updated successfully. The page will now reload.', 'wpfaevent' ),
-				'updateError'        => __( 'Error updating event', 'wpfaevent' ),
-				'updateErrorGeneric' => __( 'Error updating event. Please try again.', 'wpfaevent' ),
-				'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
-				'loadError'          => __( 'Error loading event data', 'wpfaevent' ),
+		return array_merge(
+			array(
+				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+				'adminNonce' => wp_create_nonce( 'wpfa_events_ajax' ),
+				'i18n'       => array(
+					'addEventTitle'      => __( 'Create a New Event', 'wpfaevent' ),
+					'editEventTitle'     => __( 'Edit Event', 'wpfaevent' ),
+					'addEventButton'     => __( 'Create Card', 'wpfaevent' ),
+					'editEventButton'    => __( 'Save Changes', 'wpfaevent' ),
+					'creating'           => __( 'Creating...', 'wpfaevent' ),
+					'saving'             => __( 'Saving...', 'wpfaevent' ),
+					'loading'            => __( 'Loading...', 'wpfaevent' ),
+					/* translators: %s: The name of the event being deleted. */
+					'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
+					'deleteSuccess'      => __( 'Event deleted successfully. The page will now reload.', 'wpfaevent' ),
+					'deleteError'        => __( 'Error deleting event', 'wpfaevent' ),
+					'deleteErrorGeneric' => __( 'Error deleting event. Please try again.', 'wpfaevent' ),
+					'addSuccess'         => __( 'Event created successfully. The page will now reload.', 'wpfaevent' ),
+					'addError'           => __( 'Error creating event', 'wpfaevent' ),
+					'addErrorGeneric'    => __( 'Error creating event. Please try again.', 'wpfaevent' ),
+					'updateSuccess'      => __( 'Event updated successfully. The page will now reload.', 'wpfaevent' ),
+					'updateError'        => __( 'Error updating event', 'wpfaevent' ),
+					'updateErrorGeneric' => __( 'Error updating event. Please try again.', 'wpfaevent' ),
+					'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
+					'loadError'          => __( 'Error loading event data', 'wpfaevent' ),
+				),
 			),
+			Wpfaevent_Roles::get_frontend_script_capabilities()
 		);
 	}
 
@@ -261,6 +264,17 @@ class Wpfaevent_Public {
 		);
 
 		wp_register_style(
+			$this->plugin_name . '-event',
+			WPFAEVENT_URL . 'public/css/templates/event.css',
+			array(
+				$this->plugin_name,
+				$this->plugin_name . '-navigation',
+			),
+			$this->version,
+			'all'
+		);
+
+		wp_register_style(
 			$this->plugin_name . '-past-events',
 			WPFAEVENT_URL . 'public/css/templates/past-events.css',
 			array(
@@ -285,7 +299,7 @@ class Wpfaevent_Public {
 
 		wp_register_script(
 			$this->plugin_name . '-speakers',
-			plugin_dir_url( __FILE__ ) . 'js/wpfaevent-speakers.js',
+			WPFAEVENT_URL . 'public/js/wpfaevent-speakers.js',
 			array( 'jquery' ),
 			$this->version,
 			true
@@ -294,35 +308,37 @@ class Wpfaevent_Public {
 		wp_localize_script(
 			$this->plugin_name . '-speakers',
 			'wpfaeventSpeakersConfig',
-			array(
-				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
-				'adminNonce' => wp_create_nonce( 'wpfa_speakers_ajax' ),
-				'isAdmin'    => current_user_can( 'manage_options' ),
-				'i18n'       => array(
-					/* translators: %s: speaker name. */
-					'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
-					'deleteSuccess'      => __( 'Speaker deleted successfully. The page will now reload.', 'wpfaevent' ),
-					'deleteError'        => __( 'Error deleting speaker', 'wpfaevent' ),
-					'deleteErrorGeneric' => __( 'Error deleting speaker. Please try again.', 'wpfaevent' ),
-					'addSuccess'         => __( 'Speaker added successfully. The page will now reload.', 'wpfaevent' ),
-					'addError'           => __( 'Error adding speaker', 'wpfaevent' ),
-					'addErrorGeneric'    => __( 'Error adding speaker. Please try again.', 'wpfaevent' ),
-					'updateSuccess'      => __( 'Speaker updated successfully. The page will now reload.', 'wpfaevent' ),
-					'updateError'        => __( 'Error updating speaker', 'wpfaevent' ),
-					'updateErrorGeneric' => __( 'Error updating speaker. Please try again.', 'wpfaevent' ),
-					'loadError'          => __( 'Error loading speaker data', 'wpfaevent' ),
-					'fetchError'         => __( 'Error fetching speaker data', 'wpfaevent' ),
-					'fetchErrorGeneric'  => __( 'Error fetching speaker data. Please try again.', 'wpfaevent' ),
-					'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
-					/* translators: %d: number of speakers shown. */
-					'resultsCount'       => __( 'Showing %d speakers', 'wpfaevent' ),
+			array_merge(
+				array(
+					'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+					'adminNonce' => wp_create_nonce( 'wpfa_speakers_ajax' ),
+					'i18n'       => array(
+						/* translators: %s: speaker name. */
+						'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
+						'deleteSuccess'      => __( 'Speaker deleted successfully. The page will now reload.', 'wpfaevent' ),
+						'deleteError'        => __( 'Error deleting speaker', 'wpfaevent' ),
+						'deleteErrorGeneric' => __( 'Error deleting speaker. Please try again.', 'wpfaevent' ),
+						'addSuccess'         => __( 'Speaker added successfully. The page will now reload.', 'wpfaevent' ),
+						'addError'           => __( 'Error adding speaker', 'wpfaevent' ),
+						'addErrorGeneric'    => __( 'Error adding speaker. Please try again.', 'wpfaevent' ),
+						'updateSuccess'      => __( 'Speaker updated successfully. The page will now reload.', 'wpfaevent' ),
+						'updateError'        => __( 'Error updating speaker', 'wpfaevent' ),
+						'updateErrorGeneric' => __( 'Error updating speaker. Please try again.', 'wpfaevent' ),
+						'loadError'          => __( 'Error loading speaker data', 'wpfaevent' ),
+						'fetchError'         => __( 'Error fetching speaker data', 'wpfaevent' ),
+						'fetchErrorGeneric'  => __( 'Error fetching speaker data. Please try again.', 'wpfaevent' ),
+						'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
+						/* translators: %d: number of speakers shown. */
+						'resultsCount'       => __( 'Showing %d speakers', 'wpfaevent' ),
+					),
 				),
+				Wpfaevent_Roles::get_frontend_script_capabilities()
 			)
 		);
 
 		wp_register_script(
 			$this->plugin_name . '-events',
-			plugin_dir_url( __FILE__ ) . 'js/wpfaevent-events.js',
+			WPFAEVENT_URL . 'public/js/wpfaevent-events.js',
 			array( 'jquery' ),
 			$this->version,
 			true
@@ -386,7 +402,7 @@ class Wpfaevent_Public {
 			array(
 				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
 				'adminNonce' => wp_create_nonce( 'wpfa_events_ajax' ), // Same nonce as events.
-				'isAdmin'    => current_user_can( 'manage_options' ),
+				'isAdmin'    => Wpfaevent_Roles::current_user_can_manage_site_branding(),
 				'i18n'       => array(
 					'saving'            => __( 'Saving...', 'wpfaevent' ),
 					'saveFooter'        => __( 'Save Footer', 'wpfaevent' ),
@@ -407,22 +423,24 @@ class Wpfaevent_Public {
 			wp_enqueue_style( $this->plugin_name . '-code-of-conduct' );
 		}
 
-		if ( $this->is_wpfa_template_file_active( 'page-speakers.php' ) ) {
+		if ( $this->is_wpfa_template_file_active( 'page-speakers.php' ) || is_post_type_archive( 'wpfa_speaker' ) ) {
 			wp_enqueue_style( $this->plugin_name . '-speakers' );
 			wp_enqueue_script( $this->plugin_name . '-speakers' );
 		}
 
-		if ( is_singular( 'wpfa_speaker' ) ) {
-			wp_enqueue_style(
-				$this->plugin_name . '-speakers',
-				plugin_dir_url( __DIR__ ) . 'public/css/templates/speakers.css',
-				array(
-					$this->plugin_name,
-					$this->plugin_name . '-navigation',
-				),
-				$this->version,
-				'all'
-			);
+		if ( is_singular( 'wpfa_speaker' ) || is_singular( 'wpfa_event' ) ) {
+			wp_enqueue_style( $this->plugin_name . '-speakers' );
+		}
+
+		if (
+			is_singular( 'wpfa_event' )
+			|| is_post_type_archive( 'wpfa_event' )
+			|| $this->is_wpfa_template_file_active( 'page-schedule.php' )
+			|| $this->is_wpfa_template_file_active( 'page-additional-information.php' )
+			|| $this->is_wpfa_template_file_active( 'public/partials/additional-information-page.php' )
+			|| $this->is_wpfa_template_file_active( 'page-partner.php' )
+		) {
+			wp_enqueue_style( $this->plugin_name . '-event' );
 		}
 
 		// Past Events template.
@@ -492,6 +510,17 @@ class Wpfaevent_Public {
 		 * class.
 		 */
 
+		if ( ! $this->is_wpfa_template() ) {
+			return;
+		}
+
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/wpfaevent-public.js', array( 'jquery' ), $this->version, false );
+		wp_localize_script(
+			$this->plugin_name,
+			'wpfaeventPublic',
+			array(
+				'speakerPlaceholderAlt' => __( 'Speaker photo placeholder', 'wpfaevent' ),
+			)
+		);
 	}
 }

--- a/public/css/components/navigation.css
+++ b/public/css/components/navigation.css
@@ -13,14 +13,40 @@
 .wpfaevent .nav-inner {
 	display: flex;
 	align-items: center;
+	gap: 18px;
 	justify-content: space-between;
 	padding: 14px 0;
 }
 
+.wpfaevent .nav-inner > a {
+	flex: 0 0 auto;
+}
+
 .wpfaevent .nav-links {
 	display: flex;
-	gap: 0.6rem;
 	align-items: center;
+	flex: 1 1 auto;
+	gap: 16px;
+	justify-content: space-between;
+	min-width: 0;
+}
+
+.wpfaevent .nav-links-main,
+.wpfaevent .nav-links-secondary {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+	min-width: 0;
+}
+
+.wpfaevent .nav-links-main {
+	justify-content: center;
+}
+
+.wpfaevent .nav-links-secondary {
+	justify-content: flex-end;
+	margin-left: auto;
 }
 
 .wpfaevent .nav-links a {
@@ -30,6 +56,7 @@
 	color: #222;
 	font-size: 1rem;
 	line-height: 1.25;
+	white-space: nowrap;
 }
 
 .wpfaevent .nav-links a.active {
@@ -48,6 +75,34 @@
 @media (max-width: 782px) {
 	.admin-bar .wpfaevent .nav {
 		top: 46px;
+	}
+
+	.wpfaevent .nav-inner {
+		align-items: flex-start;
+		flex-wrap: wrap;
+		gap: 10px;
+	}
+
+	.wpfaevent .nav-links {
+		flex-basis: 100%;
+		flex-wrap: wrap;
+		gap: 8px;
+		padding-bottom: 4px;
+		width: 100%;
+	}
+
+	.wpfaevent .nav-links-main,
+	.wpfaevent .nav-links-secondary {
+		flex: 1 1 100%;
+		gap: 8px;
+		justify-content: flex-start;
+		margin-left: 0;
+	}
+
+	.wpfaevent .nav-links a {
+		font-size: 0.88rem;
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
 	}
 }
 

--- a/public/css/templates/event.css
+++ b/public/css/templates/event.css
@@ -1,0 +1,3088 @@
+/* ==========================================================================
+   Event Detail Template
+   ========================================================================== */
+
+.wpfaevent.wpfa-event-template,
+.wpfaevent.wpfa-schedule-template {
+	--event-primary: var(--brand, #D51007);
+	--event-primary-dark: #b20d06;
+	--event-ink: #243447;
+	--event-line: #dfe6ee;
+	--event-soft: #f4f7fb;
+	--event-panel: #fff;
+	--event-muted: #657386;
+	--event-shadow: 0 10px 28px rgba(36, 52, 71, 0.1);
+	--event-radius: 6px;
+	--event-success: #2f8f5b;
+	--event-danger: #D51007;
+
+	background: var(--event-soft);
+	color: var(--event-ink);
+	font-size: 16px;
+	font-weight: 400;
+	letter-spacing: 0;
+	line-height: 1.5;
+	overflow-x: hidden;
+}
+
+.wpfaevent.wpfa-event-template,
+.wpfaevent.wpfa-schedule-template,
+.wpfaevent.wpfa-event-template *,
+.wpfaevent.wpfa-schedule-template *,
+.wpfaevent.wpfa-event-template *::before,
+.wpfaevent.wpfa-schedule-template *::before,
+.wpfaevent.wpfa-event-template *::after,
+.wpfaevent.wpfa-schedule-template *::after {
+	box-sizing: border-box;
+}
+
+.wpfaevent.wpfa-event-template .nav {
+	border-bottom: 1px solid rgba(213, 16, 7, 0.16);
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.wpfaevent .wpfa-event-detail {
+	background:
+		linear-gradient(180deg, rgba(213, 16, 7, 0.06), rgba(244, 247, 251, 0) 440px),
+		var(--event-soft);
+	min-height: 70vh;
+}
+
+.wpfaevent .wpfa-event-hero {
+	background:
+		linear-gradient(135deg, #8f0a05 0%, #D51007 52%, #f15b53 100%);
+	color: #fff;
+	overflow: hidden;
+	padding: 56px 0 52px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-hero::before,
+.wpfaevent .wpfa-event-hero::after {
+	background: rgba(255, 255, 255, 0.11);
+	border-radius: 50%;
+	content: "";
+	position: absolute;
+}
+
+.wpfaevent .wpfa-event-hero::before {
+	height: 320px;
+	right: -120px;
+	top: -100px;
+	width: 320px;
+}
+
+.wpfaevent .wpfa-event-hero::after {
+	bottom: -150px;
+	height: 420px;
+	left: -160px;
+	width: 420px;
+}
+
+.wpfaevent .wpfa-event-hero-inner {
+	align-items: stretch;
+	display: grid;
+	gap: 32px;
+	grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+	position: relative;
+	z-index: 1;
+}
+
+.wpfaevent .wpfa-event-hero-copy {
+	align-self: center;
+	max-width: 820px;
+}
+
+.wpfaevent .wpfa-event-kicker {
+	color: rgba(255, 255, 255, 0.78);
+	font-size: 0.9rem;
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1.25;
+	margin: 0 0 12px;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-hero h1 {
+	color: #fff;
+	font-size: clamp(2.4rem, 6vw, 5.4rem);
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 0.98;
+	margin: 0;
+	max-width: 900px;
+	text-shadow: 0 2px 16px rgba(0, 0, 0, 0.18);
+}
+
+.wpfaevent .wpfa-event-hero-text {
+	color: rgba(255, 255, 255, 0.9);
+	font-size: 1.12rem;
+	font-weight: 400;
+	line-height: 1.7;
+	margin-top: 22px;
+	max-width: 720px;
+}
+
+.wpfaevent .wpfa-event-hero-text p {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-meta-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-top: 24px;
+}
+
+.wpfaevent .wpfa-event-meta-list span {
+	align-items: center;
+	background: rgba(255, 255, 255, 0.16);
+	border: 1px solid rgba(255, 255, 255, 0.25);
+	border-radius: var(--event-radius);
+	color: #fff;
+	display: inline-flex;
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.25;
+	min-height: 38px;
+	padding: 8px 12px;
+}
+
+.wpfaevent .wpfa-event-ticket-panel {
+	align-self: center;
+	background: var(--event-panel);
+	border-radius: var(--event-radius);
+	box-shadow: 0 18px 46px rgba(9, 42, 71, 0.22);
+	color: var(--event-ink);
+	display: flex;
+	flex-direction: column;
+	padding: 22px;
+}
+
+.wpfaevent .wpfa-event-ticket-head {
+	align-items: center;
+	display: flex;
+	gap: 16px;
+	justify-content: space-between;
+	margin-bottom: 16px;
+}
+
+.wpfaevent .wpfa-event-ticket-head p,
+.wpfaevent .wpfa-event-ticket-head strong {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-ticket-head p {
+	color: var(--event-muted);
+	font-size: 0.95rem;
+	font-weight: 800;
+	line-height: 1.25;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-ticket-head strong {
+	background: #e8f4ff;
+	border-radius: 999px;
+	color: var(--event-primary-dark);
+	font-size: 0.92rem;
+	font-weight: 800;
+	line-height: 1.2;
+	padding: 5px 10px;
+}
+
+.wpfaevent .wpfa-event-register {
+	align-items: center;
+	background: var(--event-primary);
+	border-radius: var(--event-radius);
+	box-shadow: 0 8px 18px rgba(213, 16, 7, 0.2);
+	color: #fff;
+	display: flex;
+	font-size: 1.12rem;
+	font-weight: 800;
+	justify-content: center;
+	line-height: 1.2;
+	min-height: 46px;
+	padding: 12px 18px;
+	text-align: center;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-register:hover {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-calendar-link {
+	align-items: center;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: flex;
+	font-size: 1.02rem;
+	font-weight: 800;
+	justify-content: center;
+	line-height: 1.2;
+	margin-top: 10px;
+	min-height: 42px;
+	padding: 10px 16px;
+	text-align: center;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-calendar-link:hover,
+.wpfaevent .wpfa-event-calendar-link:focus {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-calendar-download {
+	align-items: center;
+	color: var(--event-muted);
+	display: inline-flex;
+	font-size: 0.95rem;
+	font-weight: 800;
+	justify-content: center;
+	line-height: 1.2;
+	margin-top: 10px;
+	min-height: 32px;
+	text-align: center;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-calendar-download:hover,
+.wpfaevent .wpfa-event-calendar-download:focus {
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-facts {
+	border-top: 1px solid var(--event-line);
+	display: grid;
+	gap: 0;
+	margin: 18px 0 0;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-facts div {
+	align-items: baseline;
+	border-bottom: 1px solid var(--event-line);
+	display: grid;
+	column-gap: 18px;
+	grid-template-columns: minmax(96px, max-content) minmax(0, 1fr);
+	padding: 12px 0;
+}
+
+.wpfaevent .wpfa-event-facts div:last-child {
+	border-bottom: 0;
+}
+
+.wpfaevent .wpfa-event-facts dt,
+.wpfaevent .wpfa-event-facts dd {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-facts dt {
+	color: var(--event-muted);
+	font-size: 0.9rem;
+	font-weight: 800;
+	line-height: 1.35;
+	text-transform: uppercase;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-event-facts dd {
+	color: var(--event-ink);
+	font-size: 1.08rem;
+	font-weight: 700;
+	line-height: 1.35;
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-section-nav {
+	background: #fff;
+	border-bottom: 1px solid var(--event-line);
+	position: sticky;
+	top: 66px;
+	z-index: 30;
+}
+
+.admin-bar .wpfaevent .wpfa-event-section-nav {
+	top: 98px;
+}
+
+.wpfaevent .wpfa-event-section-nav .container {
+	display: flex;
+	gap: 8px;
+	padding-bottom: 10px;
+	padding-top: 10px;
+}
+
+.wpfaevent .wpfa-event-section-nav a {
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	font-size: 0.92rem;
+	font-weight: 800;
+	padding: 9px 12px;
+}
+
+.wpfaevent .wpfa-event-section-nav a:hover {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown {
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown-toggle {
+	background: transparent;
+	border: 0;
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	cursor: pointer;
+	font: inherit;
+	font-size: 0.92rem;
+	font-weight: 800;
+	padding: 9px 12px;
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown-toggle:hover,
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown:hover .wpfa-event-nav-dropdown-toggle {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown-content {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: none;
+	left: 0;
+	min-width: 180px;
+	padding: 8px 0;
+	position: absolute;
+	top: calc(100% + 4px);
+	z-index: 40;
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown:hover .wpfa-event-nav-dropdown-content,
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown:focus-within .wpfa-event-nav-dropdown-content {
+	display: block;
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown-content a {
+	border-radius: 0;
+	display: block;
+	padding: 10px 14px;
+}
+
+.wpfaevent .wpfa-schedule {
+	padding: 48px 0 72px;
+}
+
+.wpfaevent .wpfa-schedule-head {
+	align-items: start;
+	display: grid;
+	gap: 20px 32px;
+	grid-template-columns: minmax(260px, 1fr) minmax(0, auto);
+	margin-bottom: 28px;
+}
+
+.wpfaevent .wpfa-schedule-head > div:first-child {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-schedule-head h1 {
+	margin: 0 0 8px;
+}
+
+.wpfaevent .wpfa-schedule-head p {
+	color: var(--event-muted, #5b636a);
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-controls {
+	align-items: end;
+	display: grid;
+	gap: 12px;
+	justify-items: end;
+	min-width: 0;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-schedule-view-switch {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	display: inline-flex;
+	gap: 3px;
+	padding: 3px;
+}
+
+.wpfaevent .wpfa-schedule-view-switch a {
+	align-items: center;
+	border-radius: calc(var(--event-radius) - 1px);
+	color: var(--event-muted);
+	display: inline-flex;
+	font-size: 0.88rem;
+	font-weight: 900;
+	justify-content: center;
+	line-height: 1.2;
+	min-height: 34px;
+	min-width: 86px;
+	padding: 8px 12px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-schedule-view-switch a:hover,
+.wpfaevent .wpfa-schedule-view-switch a:focus {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-schedule-view-switch a.is-active {
+	background: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-schedule-filter-form {
+	align-items: end;
+	display: grid;
+	gap: 10px 12px;
+	grid-template-columns: minmax(260px, 456px) auto;
+	justify-content: flex-end;
+}
+
+.wpfaevent .wpfa-schedule-filter-form.has-language-filter {
+	grid-template-columns: minmax(190px, 260px) minmax(260px, 456px) auto;
+}
+
+.wpfaevent .wpfa-schedule-filter-form label {
+	display: grid;
+	gap: 5px;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-schedule-filter-form span {
+	color: var(--event-muted);
+	font-size: 0.72rem;
+	font-weight: 800;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-schedule-filter-form select {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-ink);
+	height: 40px;
+	line-height: 1.2;
+	min-height: 40px;
+	min-width: 0;
+	padding: 8px 10px;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-schedule-filter-form button {
+	align-items: center;
+	align-self: end;
+	background: var(--event-primary);
+	border: 1px solid var(--event-primary);
+	border-radius: var(--event-radius);
+	color: #fff;
+	display: inline-flex;
+	font-weight: 800;
+	height: 40px;
+	justify-content: center;
+	line-height: 1.2;
+	min-height: 40px;
+	min-width: 112px;
+	padding: 9px 14px;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-schedule-filter-form button:hover,
+.wpfaevent .wpfa-schedule-filter-form button:focus {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-schedule-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin: 0 0 24px;
+}
+
+.wpfaevent .wpfa-schedule-tabs a {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	font-weight: 800;
+	padding: 9px 14px;
+}
+
+.wpfaevent .wpfa-schedule-tabs a.is-active {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-schedule-group + .wpfa-schedule-group {
+	margin-top: 28px;
+}
+
+.wpfaevent .wpfa-schedule-date {
+	font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+	margin: 0 0 12px;
+}
+
+.wpfaevent .wpfa-schedule-items {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-schedule-item {
+	background: #fff;
+	border: 1px solid var(--event-line, #dfe6ee);
+	border-radius: 12px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px 14px;
+	margin-bottom: 10px;
+	padding: 14px 16px;
+}
+
+.wpfaevent .wpfa-schedule-time,
+.wpfaevent .wpfa-schedule-location,
+.wpfaevent .wpfa-schedule-language {
+	color: var(--event-muted, #5b636a);
+}
+
+.wpfaevent .wpfa-schedule-time::before,
+.wpfaevent .wpfa-schedule-location::before,
+.wpfaevent .wpfa-schedule-language::before {
+	content: '•';
+	margin-right: 8px;
+}
+
+.wpfaevent .wpfa-schedule-item .wpfa-calendar-action {
+	margin-left: auto;
+}
+
+.wpfaevent .wpfa-schedule-actions {
+	display: inline-flex;
+	gap: 10px;
+	margin-left: auto;
+}
+
+.wpfaevent .wpfa-schedule-actions a {
+	color: var(--event-primary-dark);
+	font-weight: 800;
+}
+
+.wpfaevent .wpfa-schedule-calendar {
+	align-items: start;
+	display: grid;
+	gap: 22px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day {
+	display: grid;
+	grid-template-columns: minmax(132px, 172px) minmax(0, 1fr);
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day-head {
+	align-content: start;
+	align-self: start;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius) 0 0 var(--event-radius);
+	border-right: 0;
+	box-shadow: 0 8px 20px rgba(36, 52, 71, 0.06);
+	display: grid;
+	gap: 10px;
+	min-height: 100%;
+	padding: 18px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day-head::before {
+	background: var(--event-primary);
+	border-radius: 999px;
+	content: "";
+	height: 36px;
+	position: absolute;
+	right: -2px;
+	top: 18px;
+	width: 4px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day-head h2,
+.wpfaevent .wpfa-schedule-calendar-day-head h3 {
+	color: var(--event-ink);
+	font-size: 1rem;
+	font-weight: 900;
+	line-height: 1.25;
+	margin: 0;
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day-head span {
+	background: #edf5fc;
+	border: 1px solid #d7e8f6;
+	border-radius: var(--event-radius);
+	color: #315a78;
+	flex: 0 0 auto;
+	justify-self: start;
+	font-size: 0.78rem;
+	font-weight: 900;
+	line-height: 1.2;
+	padding: 6px 8px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slots {
+	display: grid;
+	gap: 12px;
+	min-width: 0;
+	padding-left: 18px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slots::before {
+	background: var(--event-primary);
+	bottom: 10px;
+	content: "";
+	left: 0;
+	opacity: 0.28;
+	position: absolute;
+	top: 10px;
+	width: 2px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-left: 4px solid var(--event-primary);
+	border-radius: var(--event-radius);
+	box-shadow: 0 8px 20px rgba(36, 52, 71, 0.07);
+	display: grid;
+	gap: 8px 16px;
+	grid-template-columns: minmax(104px, 148px) minmax(0, 1fr) auto;
+	min-width: 0;
+	position: relative;
+	padding: 16px 18px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot::before {
+	background: #fff;
+	border: 3px solid var(--event-primary);
+	border-radius: 50%;
+	box-shadow: 0 0 0 4px rgba(213, 16, 7, 0.1);
+	content: "";
+	height: 12px;
+	left: -26px;
+	position: absolute;
+	top: 21px;
+	width: 12px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot time {
+	align-items: center;
+	align-self: start;
+	background: #f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: calc(var(--event-radius) - 1px);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.84rem;
+	font-weight: 900;
+	justify-content: center;
+	line-height: 1.2;
+	min-height: 36px;
+	padding: 6px 9px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot h3,
+.wpfaevent .wpfa-schedule-calendar-slot h4 {
+	color: var(--event-ink);
+	font-size: 1.04rem;
+	font-weight: 900;
+	grid-column: 2;
+	line-height: 1.35;
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot h3 a,
+.wpfaevent .wpfa-schedule-calendar-slot h4 a {
+	color: inherit;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot h3 a:hover,
+.wpfaevent .wpfa-schedule-calendar-slot h3 a:focus,
+.wpfaevent .wpfa-schedule-calendar-slot h4 a:hover,
+.wpfaevent .wpfa-schedule-calendar-slot h4 a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-schedule-calendar-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	grid-column: 2;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-schedule-calendar-meta li {
+	background: #f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	font-size: 0.8rem;
+	font-weight: 700;
+	line-height: 1.25;
+	padding: 5px 8px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	grid-column: 3;
+	grid-row: 1 / span 3;
+	margin-top: 2px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-actions a {
+	color: var(--event-primary-dark);
+	font-size: 0.86rem;
+	font-weight: 900;
+}
+
+.wpfaevent .wpfa-schedule-calendar-actions a:hover,
+.wpfaevent .wpfa-schedule-calendar-actions a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot .wpfa-schedule-session-calendar {
+	align-self: start;
+	grid-column: 3;
+	grid-row: 1 / span 3;
+	margin-top: 2px;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-event-section {
+	padding: 48px 0;
+}
+
+.wpfaevent .wpfa-event-section + .wpfa-event-section {
+	border-top: 1px solid rgba(223, 230, 238, 0.85);
+}
+
+.wpfaevent .wpfa-event-section-layout {
+	display: grid;
+	gap: 32px;
+	grid-template-columns: minmax(180px, 260px) minmax(0, 1fr);
+}
+
+.wpfaevent .wpfa-event-section-label p {
+	color: var(--event-primary);
+	font-size: 0.78rem;
+	font-weight: 900;
+	margin: 0 0 8px;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-section h2 {
+	color: var(--event-ink);
+	font-size: clamp(1.7rem, 3.2vw, 2.5rem);
+	letter-spacing: 0;
+	line-height: 1.1;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-rich-text {
+	color: #3f4d5e;
+	font-size: 1.02rem;
+	line-height: 1.75;
+	max-width: 78ch;
+}
+
+.wpfaevent .wpfa-event-rich-text p:first-child {
+	margin-top: 0;
+}
+
+.wpfaevent .wpfa-event-rich-text p:last-child {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-event-additional-preview,
+.wpfaevent .wpfa-event-custom-tab-content,
+.wpfaevent .wpfa-additional-information-body {
+	max-width: 900px;
+}
+
+.wpfaevent .wpfa-event-section-head {
+	align-items: end;
+	display: flex;
+	gap: 20px;
+	justify-content: space-between;
+	margin-bottom: 24px;
+}
+
+.wpfaevent .wpfa-event-section-head h2,
+.wpfaevent .wpfa-event-section-head p {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-section-head p,
+.wpfaevent .wpfa-empty-state {
+	color: var(--event-muted);
+}
+
+.wpfaevent .wpfa-event-section-head a {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	flex: 0 0 auto;
+	font-weight: 800;
+	padding: 10px 14px;
+}
+
+.wpfaevent .wpfa-event-section-head a:hover {
+	background: #edf5fc;
+}
+
+.wpfaevent .wpfa-event-section-actions {
+	align-items: end;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	justify-content: flex-end;
+}
+
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch {
+	align-self: end;
+}
+
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch a {
+	background: transparent;
+	border: 0;
+	border-radius: calc(var(--event-radius) - 1px);
+	color: var(--event-muted);
+	flex: 0 1 auto;
+	padding: 8px 12px;
+}
+
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch a:hover,
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch a:focus {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch a.is-active {
+	background: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-timezone-form {
+	align-items: end;
+	display: flex;
+	flex: 0 1 420px;
+	gap: 10px;
+	justify-content: flex-end;
+	min-width: 260px;
+}
+
+.wpfaevent .wpfa-event-timezone-form label {
+	display: grid;
+	flex: 1 1 240px;
+	gap: 6px;
+	margin: 0;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-event-timezone-form span {
+	color: var(--event-muted);
+	font-size: 0.78rem;
+	font-weight: 800;
+	line-height: 1.2;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-timezone-form select {
+	appearance: none;
+	background:
+		linear-gradient(45deg, transparent 50%, var(--event-muted) 50%) calc(100% - 18px) 19px / 6px 6px no-repeat,
+		linear-gradient(135deg, var(--event-muted) 50%, transparent 50%) calc(100% - 12px) 19px / 6px 6px no-repeat,
+		#fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-ink);
+	font: inherit;
+	min-height: 42px;
+	min-width: 0;
+	padding: 8px 34px 8px 11px;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-timezone-form select:focus {
+	border-color: var(--event-primary);
+	box-shadow: 0 0 0 3px rgba(213, 16, 7, 0.14);
+	outline: none;
+}
+
+.wpfaevent .wpfa-event-timezone-form button {
+	background: var(--event-primary);
+	border: 0;
+	border-radius: var(--event-radius);
+	color: #fff;
+	cursor: pointer;
+	font: inherit;
+	font-weight: 800;
+	min-height: 42px;
+	padding: 8px 14px;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-event-timezone-form button:hover,
+.wpfaevent .wpfa-event-timezone-form button:focus {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-additional-information {
+	background:
+		linear-gradient(180deg, #fff 0%, var(--event-soft) 520px),
+		var(--event-soft);
+	min-height: 70vh;
+}
+
+.wpfaevent .wpfa-additional-information-hero {
+	background: #f8fbf9;
+	border-bottom: 1px solid var(--event-line);
+	padding: 46px 0 48px;
+}
+
+@supports (background: color-mix(in srgb, red 10%, white)) {
+	.wpfaevent .wpfa-additional-information-hero {
+		background:
+			linear-gradient(
+				135deg,
+				color-mix(in srgb, var(--event-primary) 14%, #fff) 0%,
+				#fff 64%,
+				color-mix(in srgb, var(--event-primary) 7%, #fff) 100%
+			);
+		border-bottom-color: color-mix(in srgb, var(--event-primary) 18%, var(--event-line));
+	}
+}
+
+.wpfaevent .wpfa-additional-information-hero .wpfa-event-kicker {
+	color: var(--event-primary);
+	margin-bottom: 14px;
+}
+
+.wpfaevent .wpfa-additional-information-hero h1 {
+	color: var(--event-ink);
+	font-size: clamp(2.1rem, 5vw, 4rem);
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1;
+	margin: 0;
+	max-width: 860px;
+}
+
+.wpfaevent .wpfa-additional-information-hero p:last-child {
+	color: var(--event-muted);
+	font-size: 1.02rem;
+	line-height: 1.7;
+	margin: 18px 0 0;
+	max-width: 760px;
+}
+
+.wpfaevent .wpfa-additional-information-detail {
+	padding-top: 34px;
+}
+
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs {
+	margin-bottom: 30px;
+}
+
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs a {
+	color: var(--event-ink);
+}
+
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs a:hover,
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs a:focus {
+	background: #f6faf7;
+	color: var(--event-ink);
+}
+
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs a.is-active {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-additional-information-detail .wpfa-event-section-head {
+	border-bottom: 1px solid var(--event-line);
+	margin-bottom: 22px;
+	padding-bottom: 22px;
+}
+
+.wpfaevent .wpfa-additional-information-body {
+	border-left: 4px solid var(--event-primary);
+	padding-left: 20px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speakers-grid {
+	grid-template-columns: repeat(auto-fit, minmax(280px, 360px));
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-card {
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	opacity: 1;
+	transform: none;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-card:hover {
+	box-shadow: 0 16px 34px rgba(36, 52, 71, 0.14);
+	transform: translateY(-3px);
+}
+
+.wpfaevent .wpfa-event-featured-speakers {
+	margin-bottom: 32px;
+}
+
+.wpfaevent .wpfa-event-featured-speakers h3,
+.wpfaevent .wpfa-event-regular-speakers h3,
+.wpfaevent .wpfa-event-speaker-list h3 {
+	color: var(--event-ink);
+	font-size: 1.05rem;
+	font-weight: 900;
+	letter-spacing: 0;
+	line-height: 1.25;
+	margin: 0 0 14px;
+}
+
+.wpfaevent .wpfa-event-regular-speakers {
+	border-top: 1px solid var(--event-line);
+	margin-top: 28px;
+	padding-top: 24px;
+}
+
+.wpfaevent .wpfa-event-featured-speakers + .wpfa-event-regular-speakers {
+	border-top: 1px solid var(--event-line);
+}
+
+.wpfaevent .wpfa-event-speaker-list {
+	border-top: 1px solid var(--event-line);
+	margin-top: 28px;
+	padding-top: 24px;
+}
+
+.wpfaevent .wpfa-event-speaker-list ul {
+	display: grid;
+	gap: 10px;
+	grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-event-speaker-list li {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	min-width: 0;
+	padding: 14px 16px;
+}
+
+.wpfaevent .wpfa-event-speaker-list a,
+.wpfaevent .wpfa-event-speaker-list strong {
+	color: var(--event-ink);
+	font-size: 0.98rem;
+	font-weight: 800;
+	line-height: 1.25;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-speaker-list a:hover,
+.wpfaevent .wpfa-event-speaker-list a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-speaker-list span {
+	color: var(--event-muted);
+	font-size: 0.88rem;
+	line-height: 1.35;
+}
+
+.wpfaevent .wpfa-event-speaker-limit-note,
+.wpfaevent .wpfa-event-schedule-preview-note {
+	color: var(--event-muted);
+	font-size: 0.94rem;
+	font-weight: 700;
+	margin: 14px 0 0;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-photo {
+	background: #eaf1f8;
+	height: 190px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-meta {
+	padding: 18px 18px 14px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-name {
+	font-size: 1.22rem;
+	letter-spacing: 0;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-name a {
+	color: var(--event-ink);
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-expand {
+	background: #fff;
+	max-height: none;
+	opacity: 1;
+	padding: 0 18px 18px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-bio {
+	color: #3f4d5e;
+	margin: 0 0 14px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-session {
+	background: #f7fafc;
+	border-left-color: var(--event-primary);
+	margin: 12px 0 0;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-session h4 {
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-timeline {
+	display: grid;
+	gap: 14px;
+}
+
+.wpfaevent .wpfa-schedule-program {
+	display: grid;
+	gap: 28px;
+}
+
+.wpfaevent .wpfa-schedule-day {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: calc(var(--event-radius) + 4px);
+	box-shadow: var(--event-shadow);
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-schedule-day-head {
+	align-items: center;
+	background: linear-gradient(180deg, #fff 0%, #f8fafc 100%);
+	border-bottom: 1px solid var(--event-line);
+	display: flex;
+	gap: 16px;
+	justify-content: space-between;
+	padding: 18px 22px;
+}
+
+.wpfaevent .wpfa-schedule-day-head h2,
+.wpfaevent .wpfa-schedule-day-head h3 {
+	color: var(--event-ink);
+	font-size: 1.15rem;
+	font-weight: 900;
+	line-height: 1.2;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-day-head p {
+	color: var(--event-muted);
+	font-size: 0.88rem;
+	font-weight: 700;
+	margin: 4px 0 0;
+}
+
+.wpfaevent .wpfa-schedule-day-sessions {
+	display: grid;
+}
+
+.wpfaevent .wpfa-schedule-session {
+	display: grid;
+	gap: 18px;
+	grid-template-columns: 132px minmax(0, 1fr);
+	padding: 20px 22px;
+	position: relative;
+	transition: background 0.2s ease;
+}
+
+.wpfaevent .wpfa-schedule-session:hover {
+	background: #fbfcfd;
+}
+
+.wpfaevent .wpfa-schedule-session + .wpfa-schedule-session {
+	border-top: 1px solid var(--event-line);
+}
+
+.wpfaevent .wpfa-schedule-session-timecol {
+	padding-left: 18px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-schedule-session-timecol::before {
+	background: var(--event-primary);
+	border-radius: 50%;
+	box-shadow: 0 0 0 4px rgba(213, 16, 7, 0.12);
+	content: '';
+	height: 10px;
+	left: 0;
+	position: absolute;
+	top: 0.45rem;
+	width: 10px;
+}
+
+.wpfaevent .wpfa-schedule-session-timecol::after {
+	background: var(--event-line);
+	bottom: -20px;
+	content: '';
+	left: 4px;
+	position: absolute;
+	top: 1.35rem;
+	width: 2px;
+}
+
+.wpfaevent .wpfa-schedule-session:last-child .wpfa-schedule-session-timecol::after {
+	display: none;
+}
+
+.wpfaevent .wpfa-schedule-session-start {
+	color: var(--event-ink);
+	display: block;
+	font-size: 1rem;
+	font-variant-numeric: tabular-nums;
+	font-weight: 900;
+	line-height: 1.2;
+}
+
+.wpfaevent .wpfa-schedule-session-end {
+	color: var(--event-muted);
+	display: block;
+	font-size: 0.82rem;
+	font-variant-numeric: tabular-nums;
+	font-weight: 700;
+	margin-top: 4px;
+}
+
+.wpfaevent .wpfa-schedule-session-end::before {
+	content: '– ';
+}
+
+.wpfaevent .wpfa-schedule-session-main {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-schedule-session-title {
+	color: var(--event-ink);
+	font-size: 1.08rem;
+	font-weight: 900;
+	line-height: 1.35;
+	margin: 0 0 12px;
+}
+
+.wpfaevent .wpfa-schedule-session-details {
+	display: grid;
+	gap: 8px 18px;
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-detail {
+	display: grid;
+	gap: 2px;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-detail dt {
+	color: var(--event-muted);
+	font-size: 0.72rem;
+	font-weight: 800;
+	letter-spacing: 0.06em;
+	margin: 0;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-schedule-detail dd {
+	color: var(--event-ink);
+	font-size: 0.92rem;
+	font-weight: 700;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-session-calendar {
+	align-items: center;
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.88rem;
+	font-weight: 800;
+	gap: 6px;
+	margin-top: 14px;
+}
+
+.wpfaevent .wpfa-schedule-session-calendar::before {
+	content: '+';
+	display: inline-block;
+	font-size: 1rem;
+	font-weight: 900;
+	line-height: 1;
+}
+
+.wpfaevent .wpfa-schedule-session-calendar:hover,
+.wpfaevent .wpfa-schedule-session-calendar:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-session {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: grid;
+	gap: 18px;
+	grid-template-columns: minmax(150px, 190px) minmax(0, 1fr);
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-event-session-time {
+	background: #f7fafc;
+	border-right: 1px solid var(--event-line);
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 18px;
+}
+
+.wpfaevent .wpfa-event-session-time span {
+	color: var(--event-muted);
+	font-size: 0.82rem;
+	font-weight: 800;
+	margin-bottom: 6px;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-session-time strong {
+	color: var(--event-primary-dark);
+	font-size: 1.15rem;
+}
+
+.wpfaevent .wpfa-event-session-body {
+	padding: 18px 18px 18px 0;
+}
+
+.wpfaevent .wpfa-event-session-body h3 {
+	color: var(--event-ink);
+	font-size: 1.2rem;
+	line-height: 1.3;
+	margin: 0 0 10px;
+}
+
+.wpfaevent .wpfa-event-session-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.wpfaevent .wpfa-event-session-meta span {
+	background: #edf5fc;
+	border-radius: var(--event-radius);
+	color: #315a78;
+	font-size: 0.88rem;
+	font-weight: 700;
+	padding: 6px 9px;
+}
+
+.wpfaevent .wpfa-event-session-calendar-link {
+	align-items: center;
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.9rem;
+	font-weight: 800;
+	margin-top: 12px;
+}
+
+.wpfaevent .wpfa-event-session-calendar-link:hover,
+.wpfaevent .wpfa-event-session-calendar-link:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-partner-groups {
+	display: grid;
+	gap: 34px;
+}
+
+.wpfaevent .wpfa-event-partner-group {
+	border-top: 1px solid var(--event-line);
+	padding-top: 24px;
+}
+
+.wpfaevent .wpfa-event-partner-group:first-child {
+	border-top: 0;
+	padding-top: 0;
+}
+
+.wpfaevent .wpfa-event-partner-group h3 {
+	align-items: center;
+	color: var(--event-primary-dark);
+	display: flex;
+	font-size: 1.05rem;
+	font-weight: 900;
+	gap: 10px;
+	letter-spacing: 0;
+	line-height: 1.25;
+	margin: 0 0 14px;
+}
+
+.wpfaevent .wpfa-event-partner-group h3::before {
+	background: var(--event-primary);
+	border-radius: 999px;
+	content: "";
+	display: block;
+	height: 18px;
+	width: 4px;
+}
+
+.wpfaevent .wpfa-event-partner-grid,
+.wpfaevent .wpfa-event-exhibitor-grid {
+	display: grid;
+	gap: 20px;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+}
+
+.wpfaevent .wpfa-event-exhibitor-grid {
+	grid-template-columns: repeat(auto-fill, minmax(min(100%, 360px), 1fr));
+}
+
+.wpfaevent .wpfa-event-partner-card,
+.wpfaevent .wpfa-event-exhibitor-card {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	overflow: hidden;
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-partner-card {
+	display: grid;
+	gap: 0;
+	grid-template-rows: auto 1fr;
+	min-height: 100%;
+	transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.wpfaevent .wpfa-event-partner-card::before {
+	background: linear-gradient(90deg, var(--event-primary), var(--event-primary-dark));
+	content: "";
+	height: 4px;
+	inset: 0 0 auto;
+	position: absolute;
+	z-index: 1;
+}
+
+.wpfaevent .wpfa-event-partner-logo {
+	align-items: center;
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.68), rgba(247, 250, 252, 0.95)),
+		#f7fafc;
+	border-bottom: 1px solid var(--event-line);
+	display: flex;
+	justify-content: center;
+	min-height: 148px;
+	padding: 28px 24px 22px;
+}
+
+.wpfaevent .wpfa-event-partner-logo img {
+	display: block;
+	max-height: var(--partner-logo-size, 160px);
+	max-width: 100%;
+	object-fit: contain;
+}
+
+.wpfaevent .wpfa-event-partner-body,
+.wpfaevent .wpfa-event-exhibitor-body {
+	padding: 18px;
+}
+
+.wpfaevent .wpfa-event-partner-body {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card {
+	display: flex;
+	flex-direction: column;
+	min-height: 188px;
+	transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card::before {
+	background: linear-gradient(180deg, var(--event-primary), var(--event-primary-dark));
+	content: "";
+	inset: 0 auto 0 0;
+	position: absolute;
+	width: 4px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card:hover,
+.wpfaevent .wpfa-event-exhibitor-card:focus-within {
+	border-color: var(--event-primary);
+	box-shadow: 0 16px 34px rgba(36, 52, 71, 0.14);
+	transform: translateY(-2px);
+}
+
+.wpfaevent .wpfa-event-exhibitor-card.has-banner::before {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-summary {
+	cursor: pointer;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 18px;
+	justify-content: space-between;
+	list-style: none;
+	padding: 22px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card.has-banner .wpfa-event-exhibitor-summary {
+	padding-top: 0;
+}
+
+.wpfaevent .wpfa-event-exhibitor-summary::-webkit-details-marker {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-summary::marker {
+	content: "";
+}
+
+.wpfaevent .wpfa-event-exhibitor-body {
+	border-top: 1px solid var(--event-line);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 16px 22px 20px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-main {
+	align-items: center;
+	display: grid;
+	gap: 16px;
+	grid-template-columns: auto minmax(0, 1fr);
+}
+
+.wpfaevent .wpfa-event-exhibitor-card.has-banner .wpfa-event-exhibitor-main {
+	align-items: end;
+	margin-top: -36px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-copy {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-event-exhibitor-eyebrow {
+	color: var(--event-primary-dark);
+	font-size: 0.74rem;
+	font-weight: 900;
+	letter-spacing: 0.08em;
+	line-height: 1.2;
+	margin: 0 0 5px;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-exhibitor-toggle {
+	align-items: center;
+	align-self: flex-start;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.84rem;
+	font-weight: 900;
+	gap: 8px;
+	line-height: 1;
+	padding: 8px 10px;
+	transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.wpfaevent .wpfa-event-exhibitor-toggle::after {
+	content: "+";
+	font-size: 1rem;
+	line-height: 1;
+}
+
+.wpfaevent .wpfa-event-exhibitor-toggle-open,
+.wpfaevent .wpfa-event-exhibitor-card[open] .wpfa-event-exhibitor-toggle-closed {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link {
+	color: inherit;
+	display: flex;
+	flex-direction: column;
+	min-height: 168px;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link:hover,
+.wpfaevent .wpfa-event-exhibitor-card-link:focus-visible {
+	color: inherit;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link .wpfa-event-exhibitor-toggle-open {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link .wpfa-event-exhibitor-toggle-closed {
+	display: inline;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link .wpfa-event-exhibitor-toggle::after {
+	content: "→";
+}
+
+.wpfaevent .wpfa-event-exhibitor-name {
+	color: var(--event-ink);
+	display: block;
+	font-size: 1.12rem;
+	font-weight: 900;
+	line-height: 1.25;
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-partner-card-link {
+	color: inherit;
+	display: grid;
+	grid-template-rows: auto 1fr;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-partner-card-link:hover,
+.wpfaevent .wpfa-event-partner-card-link:focus-visible {
+	border-color: var(--event-primary);
+	box-shadow: 0 16px 34px rgba(36, 52, 71, 0.14);
+	color: inherit;
+	text-decoration: none;
+	transform: translateY(-2px);
+}
+
+.wpfaevent .wpfa-event-partner-card-link:focus-visible,
+.wpfaevent .wpfa-event-exhibitor-card-link:focus-visible {
+	outline: 3px solid var(--event-primary);
+	outline-offset: 3px;
+}
+
+.wpfaevent .wpfa-event-partner-view-details {
+	align-self: flex-start;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.84rem;
+	font-weight: 900;
+	line-height: 1;
+	margin-top: 12px;
+	padding: 8px 10px;
+}
+
+.wpfaevent .wpfa-event-partner-view-details::after {
+	content: "→";
+	margin-left: 8px;
+}
+
+.wpfaevent .wpfa-event-partner-card-link:hover .wpfa-event-partner-view-details,
+.wpfaevent .wpfa-event-partner-card-link:focus-visible .wpfa-event-partner-view-details,
+.wpfaevent .wpfa-event-exhibitor-card-link:hover .wpfa-event-exhibitor-toggle,
+.wpfaevent .wpfa-event-exhibitor-card-link:focus-visible .wpfa-event-exhibitor-toggle {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-partner-detail {
+	background:
+		linear-gradient(180deg, rgba(33, 133, 208, 0.08), rgba(244, 247, 251, 0) 430px),
+		var(--event-soft);
+	min-height: 70vh;
+}
+
+.wpfaevent .wpfa-partner-detail-hero {
+	background:
+		linear-gradient(135deg, rgba(36, 52, 71, 0.22), rgba(36, 52, 71, 0)),
+		linear-gradient(135deg, var(--event-primary-dark), var(--event-primary));
+	color: #fff;
+	overflow: hidden;
+	padding: 58px 0 84px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-partner-detail-hero::before {
+	background:
+		linear-gradient(115deg, rgba(255, 255, 255, 0.12) 0 18%, transparent 18% 100%),
+		linear-gradient(115deg, transparent 0 64%, rgba(255, 255, 255, 0.1) 64% 72%, transparent 72% 100%);
+	content: "";
+	inset: 0;
+	position: absolute;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-inner {
+	align-items: end;
+	display: grid;
+	gap: 28px;
+	grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+	position: relative;
+	z-index: 1;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-copy {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-hero .wpfa-event-kicker {
+	color: rgba(255, 255, 255, 0.82);
+}
+
+.wpfaevent .wpfa-partner-detail-hero h1 {
+	color: #fff;
+	font-size: 3.25rem;
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1;
+	margin: 0;
+	max-width: 880px;
+	overflow-wrap: anywhere;
+	text-shadow: 0 2px 18px rgba(0, 0, 0, 0.18);
+}
+
+.wpfaevent .wpfa-partner-detail-lead {
+	color: rgba(255, 255, 255, 0.88);
+	font-size: 1.05rem;
+	line-height: 1.65;
+	margin: 18px 0 0;
+	max-width: 660px;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-meta {
+	background: rgba(255, 255, 255, 0.14);
+	border: 1px solid rgba(255, 255, 255, 0.26);
+	border-radius: var(--event-radius);
+	box-shadow: 0 16px 34px rgba(36, 52, 71, 0.18);
+	display: grid;
+	gap: 7px;
+	padding: 18px;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-meta span,
+.wpfaevent .wpfa-partner-detail-hero-meta em {
+	color: rgba(255, 255, 255, 0.78);
+	font-size: 0.82rem;
+	font-style: normal;
+	font-weight: 800;
+	line-height: 1.35;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-meta span {
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-meta strong {
+	color: #fff;
+	font-size: 1.24rem;
+	line-height: 1.25;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-partner-detail-body {
+	margin-top: -44px;
+	padding: 0 0 68px;
+	position: relative;
+	z-index: 2;
+}
+
+.wpfaevent .wpfa-partner-detail-banner {
+	display: block;
+	height: 210px;
+	object-fit: cover;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-partner-detail-card {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: grid;
+	grid-template-columns: minmax(260px, 0.38fr) minmax(0, 1fr);
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-partner-detail-media {
+	background:
+		linear-gradient(180deg, #fff, #f7fafc);
+	border-right: 1px solid var(--event-line);
+	display: grid;
+	grid-template-rows: auto 1fr auto;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-partner-detail.no-banner .wpfa-partner-detail-media {
+	grid-template-rows: 1fr auto;
+}
+
+.wpfaevent .wpfa-partner-detail-identity {
+	align-content: center;
+	display: grid;
+	gap: 18px;
+	justify-items: start;
+	padding: 28px;
+}
+
+.wpfaevent .wpfa-partner-detail-identity-copy {
+	display: grid;
+	gap: 5px;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-identity-copy span {
+	color: var(--event-primary-dark);
+	font-size: 0.78rem;
+	font-weight: 900;
+	letter-spacing: 0;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-partner-detail-identity-copy strong {
+	color: var(--event-ink);
+	font-size: 1.2rem;
+	font-weight: 900;
+	line-height: 1.25;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-partner-detail-logo {
+	align-items: center;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: 0 12px 26px rgba(36, 52, 71, 0.08);
+	display: flex;
+	height: 112px;
+	justify-content: center;
+	padding: 20px;
+	width: 148px;
+}
+
+.wpfaevent .wpfa-partner-detail-logo img {
+	display: block;
+	max-height: 100%;
+	max-width: 100%;
+	object-fit: contain;
+}
+
+.wpfaevent .wpfa-partner-detail-content {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	padding: 34px;
+}
+
+.wpfaevent .wpfa-partner-detail-header {
+	margin-bottom: 18px;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-content .wpfa-event-kicker {
+	color: var(--event-primary-dark);
+	margin-bottom: 8px;
+}
+
+.wpfaevent .wpfa-partner-detail-meta,
+.wpfaevent .wpfa-partner-detail-group {
+	color: #667788;
+	font-size: 0.94rem;
+	margin: 6px 0 0;
+}
+
+.wpfaevent .wpfa-partner-detail-group {
+	border-top: 1px solid var(--event-line);
+	margin: 0;
+	padding: 16px 28px;
+}
+
+.wpfaevent .wpfa-partner-detail-description {
+	color: #33465c;
+	font-size: 1.02rem;
+	line-height: 1.72;
+	margin-top: 0;
+	max-width: 760px;
+}
+
+.wpfaevent .wpfa-partner-detail-description p {
+	margin: 0 0 16px;
+}
+
+.wpfaevent .wpfa-partner-detail-description p:last-child {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-empty {
+	background: #f8fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	margin: 0;
+	padding: 16px;
+}
+
+.wpfaevent .wpfa-partner-detail-links {
+	margin-top: 24px;
+	padding-top: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-links a {
+	min-height: 42px;
+	padding: 11px 14px;
+}
+
+.wpfaevent .wpfa-partner-detail-links a:first-child {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-partner-detail-back {
+	margin: 24px 0 0;
+}
+
+.wpfaevent .wpfa-partner-detail-back a {
+	align-items: center;
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-weight: 900;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-partner-detail-back a::before {
+	content: "←";
+	margin-right: 8px;
+}
+
+.wpfaevent .wpfa-partner-detail-back a:hover,
+.wpfaevent .wpfa-partner-detail-back a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card[open] .wpfa-event-exhibitor-toggle-open {
+	display: inline;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card[open] .wpfa-event-exhibitor-toggle::after {
+	content: "-";
+}
+
+.wpfaevent .wpfa-event-partner-body h4,
+.wpfaevent .wpfa-event-exhibitor-body h3,
+.wpfaevent .wpfa-partner-detail-header h2 {
+	color: var(--event-ink);
+	font-size: 1.12rem;
+	font-weight: 900;
+	letter-spacing: 0;
+	line-height: 1.25;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-header h2 {
+	font-size: 2rem;
+	line-height: 1.12;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-partner-body a,
+.wpfaevent .wpfa-event-exhibitor-body h3 a {
+	color: var(--event-ink);
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-partner-body a:hover,
+.wpfaevent .wpfa-event-partner-body a:focus,
+.wpfaevent .wpfa-event-exhibitor-body h3 a:hover,
+.wpfaevent .wpfa-event-exhibitor-body h3 a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-partner-description {
+	color: #3f4d5e;
+	font-size: 0.94rem;
+	line-height: 1.55;
+	margin-top: 2px;
+}
+
+.wpfaevent .wpfa-event-partner-description p {
+	margin: 0 0 10px;
+}
+
+.wpfaevent .wpfa-event-partner-description p:last-child {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-event-exhibitor-banner {
+	background: #f7fafc;
+	border-bottom: 1px solid var(--event-line);
+	display: block;
+	height: 150px;
+	object-fit: cover;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-exhibitor-logo {
+	align-items: center;
+	background: #f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	display: flex;
+	height: 70px;
+	justify-content: center;
+	padding: 12px;
+	width: 88px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card.has-banner .wpfa-event-exhibitor-logo {
+	background: #fff;
+	box-shadow: 0 10px 24px rgba(36, 52, 71, 0.12);
+	height: 78px;
+	width: 96px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-logo img {
+	display: block;
+	max-height: 100%;
+	max-width: 100%;
+	object-fit: contain;
+}
+
+.wpfaevent .wpfa-event-exhibitor-placeholder {
+	align-items: center;
+	background:
+		linear-gradient(135deg, #fff, var(--event-soft)),
+		#f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: flex;
+	font-size: 1.25rem;
+	font-weight: 900;
+	height: 64px;
+	justify-content: center;
+	width: 64px;
+}
+
+.wpfaevent .wpfa-partner-detail-media .wpfa-event-exhibitor-placeholder {
+	font-size: 2.1rem;
+	height: 112px;
+	width: 112px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: auto;
+	padding-top: 4px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-links a {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	font-size: 0.86rem;
+	font-weight: 800;
+	padding: 8px 11px;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-links a:hover,
+.wpfaevent .wpfa-event-exhibitor-links a:focus {
+	background: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-empty-state {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	margin: 0;
+	padding: 22px;
+}
+
+/* ==========================================================================
+   Event Archive Template
+   ========================================================================== */
+
+.wpfaevent .wpfa-event-archive {
+	background:
+		linear-gradient(180deg, rgba(213, 16, 7, 0.05), rgba(244, 247, 251, 0) 520px),
+		var(--event-soft);
+	min-height: 70vh;
+}
+
+.wpfaevent .wpfa-event-directory-hero {
+	background: var(--event-primary);
+	color: #fff;
+	padding: 58px 0 92px;
+}
+
+.wpfaevent .wpfa-event-directory-hero-inner {
+	align-items: end;
+	display: grid;
+	gap: 28px;
+	grid-template-columns: minmax(0, 1fr) minmax(170px, 220px);
+}
+
+.wpfaevent .wpfa-event-directory-hero-inner > *,
+.wpfaevent .wpfa-event-filter-form > *,
+.wpfaevent .wpfa-event-filter-grid > *,
+.wpfaevent .wpfa-event-directory-card > *,
+.wpfaevent .wpfa-event-directory-card-main > * {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-event-directory-hero h1 {
+	color: #fff;
+	font-size: clamp(2.15rem, 5vw, 4.5rem);
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1;
+	margin: 0;
+	max-width: 980px;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-directory-lead {
+	color: rgba(255, 255, 255, 0.88);
+	font-size: 1.05rem;
+	line-height: 1.7;
+	margin: 20px 0 0;
+	max-width: 720px;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-directory-count {
+	border: 1px solid rgba(255, 255, 255, 0.3);
+	border-radius: var(--event-radius);
+	display: grid;
+	gap: 4px;
+	padding: 18px;
+	text-align: left;
+}
+
+.wpfaevent .wpfa-event-directory-count strong {
+	color: #fff;
+	font-size: 2.3rem;
+	line-height: 1;
+}
+
+.wpfaevent .wpfa-event-directory-count span {
+	color: rgba(255, 255, 255, 0.82);
+	font-size: 0.88rem;
+	font-weight: 800;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-directory-controls {
+	margin-top: -54px;
+	position: relative;
+	z-index: 2;
+}
+
+.wpfaevent .wpfa-event-filter-form {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: grid;
+	gap: 20px;
+	padding: 24px;
+}
+
+.wpfaevent .wpfa-event-filter-head {
+	align-items: start;
+	display: flex;
+	gap: 18px;
+	justify-content: space-between;
+}
+
+.wpfaevent .wpfa-event-filter-head h2,
+.wpfaevent .wpfa-event-filter-head p {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-filter-head h2 {
+	color: var(--event-ink);
+	font-size: 1.35rem;
+	line-height: 1.25;
+}
+
+.wpfaevent .wpfa-event-filter-head p {
+	color: var(--event-muted);
+	margin-top: 6px;
+}
+
+.wpfaevent .wpfa-event-reset {
+	align-items: center;
+	border: 1px solid rgba(213, 16, 7, 0.22);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-weight: 800;
+	min-height: 38px;
+	padding: 8px 12px;
+}
+
+.wpfaevent .wpfa-event-reset:hover {
+	background: rgba(213, 16, 7, 0.07);
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-filter-grid {
+	align-items: end;
+	display: grid;
+	gap: 14px;
+	grid-template-columns: minmax(260px, 1.35fr) repeat(4, minmax(170px, 1fr));
+}
+
+.wpfaevent .wpfa-event-field {
+	display: grid;
+	gap: 8px;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-event-field span,
+.wpfaevent .wpfa-event-when-filter legend {
+	color: var(--event-muted);
+	font-size: 0.78rem;
+	font-weight: 800;
+	line-height: 1.2;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-field input,
+.wpfaevent .wpfa-event-field select {
+	appearance: none;
+	background: #f9fbfd;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-ink);
+	font: inherit;
+	min-height: 46px;
+	min-width: 0;
+	padding: 10px 12px;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-field select {
+	background-image:
+		linear-gradient(45deg, transparent 50%, var(--event-muted) 50%),
+		linear-gradient(135deg, var(--event-muted) 50%, transparent 50%);
+	background-position:
+		calc(100% - 18px) 20px,
+		calc(100% - 12px) 20px;
+	background-repeat: no-repeat;
+	background-size: 6px 6px;
+	padding-right: 34px;
+}
+
+.wpfaevent .wpfa-event-field input:focus,
+.wpfaevent .wpfa-event-field select:focus {
+	background: #fff;
+	border-color: var(--event-primary);
+	box-shadow: 0 0 0 3px rgba(213, 16, 7, 0.14);
+	outline: none;
+}
+
+.wpfaevent .wpfa-event-filter-bottom {
+	align-items: end;
+	display: grid;
+	gap: 16px;
+	grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.wpfaevent .wpfa-event-when-filter {
+	border: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin: 0;
+	min-width: 0;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-event-when-filter legend {
+	flex: 0 0 100%;
+	margin-bottom: 2px;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-event-when-filter label {
+	display: inline-flex;
+	margin: 0;
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-when-filter input {
+	height: 1px;
+	opacity: 0;
+	position: absolute;
+	width: 1px;
+}
+
+.wpfaevent .wpfa-event-when-filter span {
+	align-items: center;
+	background: #f6f9fc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-ink);
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 0.92rem;
+	font-weight: 800;
+	min-height: 40px;
+	padding: 8px 13px;
+}
+
+.wpfaevent .wpfa-event-when-filter input:checked + span {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-when-filter input:focus + span {
+	box-shadow: 0 0 0 3px rgba(213, 16, 7, 0.16);
+}
+
+.wpfaevent .wpfa-event-filter-submit {
+	background: var(--event-primary);
+	border: 0;
+	border-radius: var(--event-radius);
+	box-shadow: 0 8px 18px rgba(213, 16, 7, 0.2);
+	color: #fff;
+	cursor: pointer;
+	font: inherit;
+	font-weight: 800;
+	max-width: 100%;
+	min-height: 46px;
+	min-width: 170px;
+	padding: 11px 18px;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-event-filter-submit:hover,
+.wpfaevent .wpfa-event-filter-submit:focus {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-directory-results {
+	padding: 42px 0 64px;
+}
+
+.wpfaevent .wpfa-event-results-head {
+	align-items: end;
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 18px;
+}
+
+.wpfaevent .wpfa-event-results-head h2,
+.wpfaevent .wpfa-event-results-head p {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-results-head h2 {
+	font-size: 1.75rem;
+	line-height: 1.2;
+}
+
+.wpfaevent .wpfa-event-results-head p {
+	color: var(--event-muted);
+	margin-top: 5px;
+}
+
+.wpfaevent .wpfa-event-card-grid {
+	display: grid;
+	gap: 16px;
+}
+
+.wpfaevent .wpfa-event-directory-card {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(156px, 190px);
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-event-directory-card:hover {
+	box-shadow: 0 16px 36px rgba(36, 52, 71, 0.14);
+}
+
+.wpfaevent .wpfa-event-directory-card-main {
+	color: inherit;
+	display: grid;
+	grid-template-columns: minmax(170px, 220px) minmax(0, 1fr);
+	min-height: 210px;
+}
+
+.wpfaevent .wpfa-event-directory-card-main:hover {
+	color: inherit;
+}
+
+.wpfaevent .wpfa-event-card-media {
+	background: #f1f5f9;
+	border-right: 1px solid var(--event-line);
+	display: grid;
+	min-height: 210px;
+	overflow: hidden;
+	place-items: stretch;
+}
+
+.wpfaevent .wpfa-event-card-media img {
+	height: 100%;
+	object-fit: cover;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-card-date {
+	align-content: center;
+	background:
+		linear-gradient(180deg, rgba(213, 16, 7, 0.12), rgba(213, 16, 7, 0)),
+		#fff;
+	color: var(--event-primary-dark);
+	display: grid;
+	gap: 8px;
+	justify-items: center;
+	min-height: 100%;
+	padding: 24px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-event-card-date span {
+	font-size: 0.85rem;
+	font-weight: 900;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-card-date strong {
+	font-size: clamp(1.2rem, 2vw, 1.55rem);
+	letter-spacing: 0;
+	line-height: 1.2;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-card-body {
+	display: grid;
+	gap: 12px;
+	padding: 24px;
+}
+
+.wpfaevent .wpfa-event-card-topline,
+.wpfaevent .wpfa-event-card-meta,
+.wpfaevent .wpfa-event-badges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.wpfaevent .wpfa-event-card-topline span,
+.wpfaevent .wpfa-event-badges span {
+	align-items: center;
+	background: #edf5fc;
+	border-radius: var(--event-radius);
+	color: #315a78;
+	display: inline-flex;
+	font-size: 0.8rem;
+	font-weight: 800;
+	min-height: 28px;
+	padding: 5px 9px;
+}
+
+.wpfaevent .wpfa-event-card-topline .wpfa-event-status {
+	background: rgba(213, 16, 7, 0.1);
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-card-topline .wpfa-event-status.is-past {
+	background: #eef2f6;
+	color: #536273;
+}
+
+.wpfaevent .wpfa-event-card-body h3 {
+	color: var(--event-ink);
+	font-size: clamp(1.35rem, 2vw, 1.75rem);
+	letter-spacing: 0;
+	line-height: 1.15;
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-directory-card-main:hover h3 {
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-card-meta {
+	color: var(--event-muted);
+	font-weight: 700;
+}
+
+.wpfaevent .wpfa-event-card-meta span {
+	max-width: 100%;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-card-body p {
+	color: #3f4d5e;
+	line-height: 1.65;
+	margin: 0;
+	max-width: 70ch;
+}
+
+.wpfaevent .wpfa-event-card-actions {
+	background: #f9fbfd;
+	border-left: 1px solid var(--event-line);
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	justify-content: center;
+	padding: 18px;
+}
+
+.wpfaevent .wpfa-event-card-actions a {
+	align-items: center;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-weight: 800;
+	justify-content: center;
+	min-height: 40px;
+	padding: 8px 12px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-event-card-actions a:first-child {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-card-actions a:hover {
+	background: rgba(213, 16, 7, 0.08);
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-card-actions a:first-child:hover {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-empty-state {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	padding: 34px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-event-empty-state h3 {
+	color: var(--event-ink);
+	margin: 0 0 8px;
+}
+
+.wpfaevent .wpfa-event-empty-state p {
+	color: var(--event-muted);
+	margin: 0 auto 18px;
+	max-width: 520px;
+}
+
+.wpfaevent .wpfa-event-empty-state a {
+	background: var(--event-primary);
+	border-radius: var(--event-radius);
+	color: #fff;
+	display: inline-flex;
+	font-weight: 800;
+	min-height: 42px;
+	padding: 10px 14px;
+}
+
+.wpfaevent .wpfa-event-empty-state a:hover {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+@media (max-width: 1180px) {
+	.wpfaevent .wpfa-schedule-head {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-controls {
+		justify-items: start;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form {
+		justify-content: stretch;
+	}
+}
+
+@media (max-width: 900px) {
+	.wpfaevent .wpfa-event-hero-inner,
+	.wpfaevent .wpfa-event-section-layout,
+	.wpfaevent .wpfa-event-session,
+	.wpfaevent .wpfa-schedule-session,
+	.wpfaevent .wpfa-partner-detail-hero-inner,
+	.wpfaevent .wpfa-partner-detail-card {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-ticket-panel {
+		align-self: stretch;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero-meta {
+		max-width: 360px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-media {
+		border-bottom: 1px solid var(--event-line);
+		border-right: 0;
+	}
+
+	.wpfaevent .wpfa-partner-detail.no-banner .wpfa-partner-detail-media {
+		grid-template-rows: auto auto;
+	}
+
+	.wpfaevent .wpfa-event-facts div {
+		column-gap: 28px;
+		grid-template-columns: minmax(126px, 0.28fr) minmax(0, 1fr);
+	}
+
+	.wpfaevent .wpfa-event-section-nav {
+		top: 64px;
+	}
+
+	.wpfaevent .wpfa-schedule-session {
+		gap: 12px;
+		padding: 16px 18px;
+	}
+
+	.wpfaevent .wpfa-schedule-session-timecol {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		padding-left: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-session-timecol::before,
+	.wpfaevent .wpfa-schedule-session-timecol::after {
+		display: none;
+	}
+
+	.wpfaevent .wpfa-schedule-session-end::before {
+		content: '– ';
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-day {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-day-head {
+		border-radius: var(--event-radius) var(--event-radius) 0 0;
+		border-right: 1px solid var(--event-line);
+		min-height: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-day-head::before,
+	.wpfaevent .wpfa-schedule-calendar-slots::before,
+	.wpfaevent .wpfa-schedule-calendar-slot::before {
+		display: none;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slots {
+		gap: 0;
+		padding-left: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slot {
+		border-left-width: 1px;
+		border-radius: 0;
+		box-shadow: none;
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slot + .wpfa-schedule-calendar-slot {
+		border-top: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slot:last-child {
+		border-radius: 0 0 var(--event-radius) var(--event-radius);
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slot h3,
+	.wpfaevent .wpfa-schedule-calendar-slot h4,
+	.wpfaevent .wpfa-schedule-calendar-meta,
+	.wpfaevent .wpfa-schedule-calendar-actions,
+	.wpfaevent .wpfa-schedule-calendar-slot .wpfa-schedule-session-calendar {
+		grid-column: 1;
+		grid-row: auto;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-actions {
+		margin-top: 4px;
+	}
+
+	.wpfaevent .wpfa-event-session-time {
+		border-bottom: 1px solid var(--event-line);
+		border-right: 0;
+	}
+
+	.wpfaevent .wpfa-event-session-body {
+		padding: 0 18px 18px;
+	}
+
+	.wpfaevent .wpfa-event-directory-hero-inner,
+	.wpfaevent .wpfa-event-directory-card,
+	.wpfaevent .wpfa-event-directory-card-main {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-filter-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.wpfaevent .wpfa-event-directory-hero {
+		padding-bottom: 82px;
+	}
+
+	.wpfaevent .wpfa-event-directory-count {
+		max-width: 240px;
+	}
+
+	.wpfaevent .wpfa-event-card-media {
+		border-bottom: 1px solid var(--event-line);
+		border-right: 0;
+		min-height: 180px;
+	}
+
+	.wpfaevent .wpfa-event-card-actions {
+		border-left: 0;
+		border-top: 1px solid var(--event-line);
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form.has-language-filter {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (max-width: 760px) {
+	.wpfaevent.wpfa-event-template .container {
+		box-sizing: border-box;
+		max-width: 100%;
+		padding-left: 20px;
+		padding-right: 20px;
+		width: auto;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-inner {
+		align-items: flex-start;
+		flex-wrap: wrap;
+		gap: 10px;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		min-width: 0;
+		padding-bottom: 4px;
+		width: 100%;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-links-main,
+	.wpfaevent.wpfa-event-template .nav-links-secondary {
+		display: flex;
+		flex: 1 1 100%;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-links a {
+		font-size: 0.84rem;
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
+		white-space: nowrap;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-links-secondary .btn {
+		padding-left: 0.75rem;
+		padding-right: 0.75rem;
+	}
+
+	.wpfaevent .wpfa-event-hero {
+		padding: 40px 0;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero {
+		padding: 44px 0 72px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero h1 {
+		font-size: 2.35rem;
+	}
+
+	.wpfaevent .wpfa-partner-detail-body {
+		margin-top: -34px;
+		padding-bottom: 48px;
+	}
+
+	.wpfaevent .wpfa-event-section {
+		padding: 36px 0;
+	}
+
+	.wpfaevent .wpfa-partner-detail-body.wpfa-event-section {
+		padding-bottom: 48px;
+		padding-top: 0;
+	}
+
+	.wpfaevent .wpfa-event-section-head {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.wpfaevent .wpfa-event-timezone-form {
+		align-items: stretch;
+		flex-direction: column;
+		min-width: 0;
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-section-actions,
+	.wpfaevent .wpfa-schedule-filter-form {
+		align-items: stretch;
+		grid-template-columns: 1fr;
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-schedule-controls,
+	.wpfaevent .wpfa-schedule-view-switch {
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-schedule-view-switch a {
+		flex: 1 1 0;
+		min-width: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form.has-language-filter {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form button,
+	.wpfaevent .wpfa-schedule-filter-form select {
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-timezone-form button {
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-section-nav .container {
+		overflow-x: auto;
+	}
+
+	.wpfaevent .wpfa-event-meta-list {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.wpfaevent .wpfa-event-meta-list span {
+		max-width: 100%;
+		min-width: 0;
+	}
+
+	.wpfaevent .wpfa-event-directory-hero {
+		padding: 40px 0 72px;
+	}
+
+	.wpfaevent .wpfa-event-directory-hero h1 {
+		font-size: 2rem;
+		max-width: calc(100vw - 40px);
+		width: 100%;
+		word-break: break-word;
+	}
+
+	.wpfaevent .wpfa-event-directory-lead,
+	.wpfaevent .wpfa-event-directory-count,
+	.wpfaevent .wpfa-event-filter-form,
+	.wpfaevent .wpfa-event-directory-card {
+		max-width: calc(100vw - 40px);
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-filter-form {
+		padding: 18px;
+	}
+
+	.wpfaevent .wpfa-event-filter-head,
+	.wpfaevent .wpfa-event-results-head {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.wpfaevent .wpfa-event-filter-bottom {
+		align-items: stretch;
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-filter-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-filter-submit {
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-card-body {
+		padding: 20px;
+	}
+
+	.wpfaevent .wpfa-event-card-actions a {
+		flex: 1 1 148px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-content,
+	.wpfaevent .wpfa-partner-detail-identity {
+		padding: 24px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-group {
+		padding-left: 24px;
+		padding-right: 24px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-header h2 {
+		font-size: 1.72rem;
+	}
+}
+
+@media (max-width: 480px) {
+	.wpfaevent.wpfa-event-template .nav-links-secondary {
+		display: none;
+	}
+}
+
+@media (max-width: 520px) {
+	.wpfaevent .wpfa-event-facts div {
+		align-items: start;
+		gap: 4px;
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-facts dt {
+		white-space: normal;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero h1 {
+		font-size: 2rem;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero-meta,
+	.wpfaevent .wpfa-partner-detail-card,
+	.wpfaevent .wpfa-partner-detail-back {
+		max-width: 350px;
+		width: calc(100vw - 40px);
+	}
+
+	.wpfaevent .wpfa-partner-detail-identity {
+		gap: 14px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-logo,
+	.wpfaevent .wpfa-partner-detail-media .wpfa-event-exhibitor-placeholder {
+		height: 92px;
+		width: 112px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-links a {
+		justify-content: center;
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-directory-hero h1,
+	.wpfaevent .wpfa-event-directory-lead,
+	.wpfaevent .wpfa-event-directory-count,
+	.wpfaevent .wpfa-event-filter-form,
+	.wpfaevent .wpfa-event-directory-card {
+		max-width: 350px;
+		width: calc(100vw - 40px);
+	}
+}

--- a/public/css/templates/events.css
+++ b/public/css/templates/events.css
@@ -373,69 +373,14 @@
 }
 
 .wpfaevent #createEventForm input,
-.wpfaevent #createEventForm select,
-.wpfaevent #createEventForm textarea,
 .wpfaevent #editEventForm input,
-.wpfaevent #editEventForm select,
-.wpfaevent #editEventForm textarea,
-.wpfaevent #edit-footer-form input,
-.wpfaevent #edit-footer-form select,
-.wpfaevent #edit-footer-form textarea {
+.wpfaevent #edit-footer-form input {
 	width: 100%;
 	padding: 10px;
 	border: 1px solid #ddd;
 	border-radius: 8px;
 	font-family: inherit;
 	font-size: 1rem;
-}
-
-.wpfaevent #createEventForm .wpfaevent-checkbox-label,
-.wpfaevent #editEventForm .wpfaevent-checkbox-label {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-bottom: 0;
-	font-weight: 600;
-}
-
-.wpfaevent #createEventForm .wpfaevent-checkbox-label input,
-.wpfaevent #editEventForm .wpfaevent-checkbox-label input {
-	width: auto;
-	margin: 0;
-	padding: 0;
-}
-
-.wpfaevent #createEventForm .wpfaevent-time-fields,
-.wpfaevent #editEventForm .wpfaevent-time-fields {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 12px;
-}
-
-.wpfaevent .wpfaevent-time-fields > div {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-}
-
-.wpfaevent #createEventForm .wpfaevent-time-fields label,
-.wpfaevent #editEventForm .wpfaevent-time-fields label {
-	margin-bottom: 0;
-}
-
-.wpfaevent .wpfaevent-time-fields.is-disabled {
-	opacity: 0.55;
-}
-
-.wpfaevent .wpfaevent-time-fields.is-disabled input {
-	cursor: not-allowed;
-}
-
-@media (max-width: 520px) {
-	.wpfaevent #createEventForm .wpfaevent-time-fields,
-	.wpfaevent #editEventForm .wpfaevent-time-fields {
-		grid-template-columns: 1fr;
-	}
 }
 
 .wpfaevent .char-counter {

--- a/public/css/templates/speakers.css
+++ b/public/css/templates/speakers.css
@@ -22,6 +22,43 @@
 	margin-bottom: 40px;
 }
 
+.wpfaevent .wpfa-speakers-list {
+	display: flex;
+	flex-direction: column;
+	gap: 36px;
+	margin-bottom: 40px;
+}
+
+.wpfaevent .wpfa-speaker-group {
+	scroll-margin-top: 96px;
+}
+
+.wpfaevent .wpfa-speaker-group.is-hidden {
+	display: none;
+}
+
+.wpfaevent .wpfa-speaker-group .wpfa-speakers-grid {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-speaker-group-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin: 0 0 18px;
+}
+
+.wpfaevent .wpfa-speaker-group-head h2 {
+	margin: 0;
+	color: var(--text);
+	font-size: 1.6rem;
+	line-height: 1.2;
+}
+
+.wpfaevent .wpfa-featured-speaker-group .wpfa-speaker-group-head h2 {
+	color: var(--brand);
+}
+
 /* Footer */
 .wpfaevent .wpfa-footer {
 	padding: 28px 0;
@@ -172,9 +209,18 @@
 	transform: none;
 }
 
+.wpfaevent .wpfa-speaker-card.is-featured {
+	outline: 2px solid var(--event-primary, var(--brand, #D51007));
+	box-shadow: 0 18px 42px rgba(213, 16, 7, 0.16);
+}
+
 .wpfaevent .wpfa-speaker-card:hover {
 	transform: translateY(-6px);
 	box-shadow: 0 18px 40px rgba(11, 11, 11, 0.12);
+}
+
+.wpfaevent .wpfa-speaker-card.is-featured:hover {
+	box-shadow: 0 22px 46px rgba(213, 16, 7, 0.2);
 }
 
 /* Speaker Photo */
@@ -195,6 +241,11 @@
 
 .wpfaevent .wpfa-speaker-card:hover .wpfa-speaker-photo img {
 	transform: scale(1.05);
+}
+
+.wpfaevent .wpfa-speaker-placeholder-img {
+	background: #f4f7fb;
+	object-position: center center;
 }
 
 .wpfaevent .wpfa-placeholder-svg {
@@ -223,6 +274,21 @@
 	line-height: 1;
 	text-transform: uppercase;
 	letter-spacing: 0.02em;
+}
+
+.wpfaevent .wpfa-speaker-featured-badge {
+	display: inline-flex;
+	align-items: center;
+	background: var(--event-primary, var(--brand, #D51007));
+	border-radius: 3px;
+	color: #fff;
+	font-size: 11px;
+	font-weight: 800;
+	letter-spacing: 0.04em;
+	line-height: 1;
+	margin: 0 0 8px;
+	padding: 6px 9px;
+	text-transform: uppercase;
 }
 
 .wpfaevent .wpfa-speaker-card:has(.pill) .wpfa-speaker-name {

--- a/public/js/wpfaevent-events.js
+++ b/public/js/wpfaevent-events.js
@@ -42,8 +42,7 @@ const WPFA_Events = (function() {
 		// Setup character counters
 		setupCharacterCounters();
 
-		// Setup admin functionality if user is admin
-		if (config.isAdmin) {
+		if (config.canManageContent) {
 			setupAdminFunctionality();
 		}
 
@@ -122,9 +121,6 @@ const WPFA_Events = (function() {
 			elements.editEventForm.addEventListener('submit', handleEditEventFormSubmit);
 		}
 
-		setupTimeFormatControls(elements.createEventForm);
-		setupTimeFormatControls(elements.editEventForm);
-
 		// Event card actions delegation
 		if (elements.eventsContainer) {
 			elements.eventsContainer.addEventListener('click', handleCardActions);
@@ -168,76 +164,6 @@ const WPFA_Events = (function() {
 				}
 			}
 		});
-	}
-
-	/**
-	 * Setup all-day toggles for event time inputs
-	 */
-	function setupTimeFormatControls(form) {
-		const allDayField = form?.querySelector('[name="all_day"]');
-
-		if (!allDayField) {
-			return;
-		}
-
-		allDayField.addEventListener('change', () => syncTimeFields(form));
-		form.addEventListener('reset', () => {
-			setTimeout(() => syncTimeFields(form), 0);
-		});
-
-		syncTimeFields(form);
-	}
-
-	/**
-	 * Disable time inputs while an event is marked all-day
-	 */
-	function syncTimeFields(form) {
-		const allDayField = form?.querySelector('[name="all_day"]');
-		const timeFields = form?.querySelector('.wpfaevent-time-fields');
-		const timeInputs = form?.querySelectorAll('[name="start_time"], [name="end_time"]') || [];
-		const isAllDay = Boolean(allDayField?.checked);
-
-		timeFields?.classList.toggle('is-disabled', isAllDay);
-		timeInputs.forEach(input => {
-			input.disabled = isAllDay;
-
-			if (isAllDay) {
-				input.value = '';
-			}
-		});
-	}
-
-	/**
-	 * Select a timezone value without losing the server-rendered default
-	 */
-	function setSelectValue(select, value) {
-		if (!select || !value) {
-			return;
-		}
-
-		const previousValue = select.value;
-		select.value = value;
-
-		if (select.value !== value) {
-			select.value = previousValue;
-		}
-	}
-
-	/**
-	 * Preserve the legacy time payload expected by older handlers
-	 */
-	function appendLegacyTimeAlias(formData) {
-		const startTime = formData.get('start_time') || '';
-
-		if (formData.has('time')) {
-			formData.set('time', formData.get('time') || startTime);
-		} else {
-			formData.append('time', startTime);
-		}
-
-		if (!formData.has('all_day')) {
-			formData.append('all_day', '0');
-		}
 	}
 
 	/**
@@ -352,7 +278,6 @@ const WPFA_Events = (function() {
 
 			// Use the smart function to reset all counters to "0 / max"
 			setupCharacterCounters();
-			syncTimeFields(elements.createEventForm);
 		}
 
 		// Show modal
@@ -378,26 +303,7 @@ const WPFA_Events = (function() {
 		document.getElementById('editEventLeadText').value = card.dataset.leadText || '';
 		document.getElementById('editRegistrationLink').value = card.dataset.registrationLink || '';
 		document.getElementById('editCfsLink').value = card.dataset.cfsLink || '';
-
-		const editStartTime = document.getElementById('editEventStartTime');
-		const editEndTime = document.getElementById('editEventEndTime');
-		const editAllDay = document.getElementById('editEventAllDay');
-		const editTimezone = document.getElementById('editEventTimezone');
-
-		if (editStartTime) {
-			editStartTime.value = card.dataset.startTime || card.dataset.time || '';
-		}
-
-		if (editEndTime) {
-			editEndTime.value = card.dataset.endTime || '';
-		}
-
-		if (editAllDay) {
-			editAllDay.checked = card.dataset.allDay === '1' || card.dataset.allDay === 'true';
-		}
-
-		setSelectValue(editTimezone, card.dataset.timezone || '');
-		syncTimeFields(elements.editEventForm);
+		document.getElementById('editEventTime').value = card.dataset.time || '';
 
 		// Sync all counters at once
 		// This looks for all textareas and updates their specific counters
@@ -422,7 +328,6 @@ const WPFA_Events = (function() {
 
 		const form = e.target;
 		const formData = new FormData(form);
-		appendLegacyTimeAlias(formData);
 		const submitBtn = form.querySelector('button[type="submit"]');
 
 		// Validate required fields - using ACTUAL form field names
@@ -494,14 +399,13 @@ const WPFA_Events = (function() {
 	function handleEditEventFormSubmit(e) {
 		e.preventDefault();
 
-		if (!config.isAdmin) {
+		if (!config.canManageContent) {
 			alert(config.i18n.noPermission || 'You do not have permission to perform this action.');
 			return;
 		}
 
 		const form = e.target;
 		const formData = new FormData(form);
-		appendLegacyTimeAlias(formData);
 		const submitBtn = form.querySelector('button[type="submit"]');
 
 		// Validate required fields - using ACTUAL form field names

--- a/public/js/wpfaevent-public.js
+++ b/public/js/wpfaevent-public.js
@@ -29,4 +29,44 @@
 	 * practising this, we should strive to set a better example in our own work.
 	 */
 
+	$(function() {
+		$('.wpfa-event-timezone-select').on('change', function() {
+			if (this.form) {
+				this.form.submit();
+			}
+		});
+
+		const speakerPlaceholderSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Speaker placeholder"><defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#f8d8d6"/><stop offset="0.58" stop-color="#f4f7fb"/><stop offset="1" stop-color="#dfe9f3"/></linearGradient><linearGradient id="accent" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#d51007"/><stop offset="1" stop-color="#b20d06"/></linearGradient></defs><rect width="600" height="600" fill="url(#bg)"/><circle cx="476" cy="118" r="96" fill="#fff" opacity="0.54"/><circle cx="96" cy="486" r="126" fill="#d51007" opacity="0.08"/><circle cx="300" cy="245" r="105" fill="#ffffff"/><circle cx="300" cy="245" r="78" fill="#d8e3ee"/><path d="M128 526c20-108 96-168 172-168s152 60 172 168" fill="#ffffff"/><path d="M164 526c24-77 82-116 136-116s112 39 136 116" fill="#d8e3ee"/><path d="M70 0h92v600H70z" fill="url(#accent)" opacity="0.92"/><path d="M92 120h48v240H92z" fill="#fff" opacity="0.18"/></svg>';
+		const speakerPlaceholderSrc = 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(speakerPlaceholderSvg);
+		const getSpeakerPlaceholderAlt = function() {
+			const settings = window.wpfaeventPublic || {};
+
+			if (typeof settings.speakerPlaceholderAlt === 'string' && settings.speakerPlaceholderAlt.trim()) {
+				return settings.speakerPlaceholderAlt;
+			}
+
+			return 'Speaker photo placeholder';
+		};
+
+		const applySpeakerPlaceholder = function() {
+			if (!this || this.classList.contains('wpfa-speaker-placeholder-img') || this.src === speakerPlaceholderSrc) {
+				return;
+			}
+
+			this.removeAttribute('srcset');
+			this.removeAttribute('sizes');
+			this.classList.add('wpfa-speaker-placeholder-img');
+			this.alt = getSpeakerPlaceholderAlt();
+			this.src = speakerPlaceholderSrc;
+		};
+
+		$('.wpfa-speaker-photo img:not(.wpfa-speaker-placeholder-img), .wpfa-speaker-profile-photo img:not(.wpfa-speaker-placeholder-img)')
+			.on('error', applySpeakerPlaceholder)
+			.each(function() {
+				if (this.complete && this.naturalWidth === 0) {
+					applySpeakerPlaceholder.call(this);
+				}
+			});
+	});
+
 })( jQuery );

--- a/public/js/wpfaevent-speakers.js
+++ b/public/js/wpfaevent-speakers.js
@@ -117,12 +117,10 @@ const WPFA_Speakers = (function() {
 			elements.searchInput.addEventListener('input', handleSearch);
 		}
 		
-		// Filter buttons
-		if (elements.filterButtons.length > 0) {
-			elements.filterButtons.forEach(button => {
-				button.addEventListener('click', handleFilterClick);
-			});
-		}
+		// Category filter buttons only; event chooser links navigate normally.
+		document.querySelectorAll('.wpfa-filter-btn[data-filter]').forEach(button => {
+			button.addEventListener('click', handleFilterClick);
+		});
 		
 		// Card click for expand/collapse and admin actions
 		if (elements.speakerGrid) {
@@ -190,14 +188,19 @@ const WPFA_Speakers = (function() {
 	 * Handle filter button click
 	 */
 	function handleFilterClick(e) {
-		// Update active button
-		elements.filterButtons.forEach(btn => btn.classList.remove('active'));
-		e.target.classList.add('active');
-		
-		// Update current filter
-		currentFilter = e.target.dataset.filter;
-		
-		// Re-render speakers
+		const button = e.currentTarget;
+		const filterValue = button.getAttribute('data-filter');
+
+		if (!filterValue) {
+			return;
+		}
+
+		e.preventDefault();
+
+		document.querySelectorAll('.wpfa-filter-btn[data-filter]').forEach(btn => btn.classList.remove('active'));
+		button.classList.add('active');
+
+		currentFilter = filterValue;
 		filterAndRenderSpeakers();
 	}
 	
@@ -315,15 +318,29 @@ const WPFA_Speakers = (function() {
 		// Show filtered speakers
 		filteredSpeakers.forEach(speaker => {
 			if (speaker.element) {
-				speaker.element.style.display = 'block';
+				speaker.element.style.display = '';
+				speaker.element.classList.add('visible');
 			}
 		});
+
+		updateSpeakerGroupVisibility();
 		
 		// Update results count
 		updateResultsCount(filteredSpeakers.length);
 		
 		// Show/hide no results message
 		showNoResults(filteredSpeakers.length === 0);
+	}
+
+	/**
+	 * Show only speaker groups that still contain visible cards.
+	 */
+	function updateSpeakerGroupVisibility() {
+		document.querySelectorAll('.wpfa-speaker-group').forEach(group => {
+			const hasVisibleCards = Array.from(group.querySelectorAll('.wpfa-speaker-card')).some(card => card.style.display !== 'none');
+
+			group.classList.toggle('is-hidden', !hasVisibleCards);
+		});
 	}
 	
 	/**
@@ -383,6 +400,14 @@ const WPFA_Speakers = (function() {
 		// Observe all speaker cards
 		document.querySelectorAll('.wpfa-speaker-card:not(.visible)').forEach(card => {
 			observer.observe(card);
+		});
+
+		// Ensure cards already in view are visible even if the observer misses the first paint.
+		document.querySelectorAll('.wpfa-speaker-card:not(.visible)').forEach(card => {
+			const rect = card.getBoundingClientRect();
+			if (rect.top < window.innerHeight && rect.bottom > 0) {
+				card.classList.add('visible');
+			}
 		});
 	}
 	
@@ -723,21 +748,22 @@ const WPFA_Speakers = (function() {
 	function handleFormSubmit(e) {
 		e.preventDefault();
 		
-		if (!config.isAdmin) {
-			const errorMsg = config.i18n && config.i18n.noPermission 
-				? config.i18n.noPermission 
-				: 'You do not have permission to perform this action.';
-			alert(errorMsg);
-			return;
-		}
-
 		if (!elements.speakerForm) {
 			console.error('Speaker form element not found');
 			return;
 		}
-		
+
 		const formData = new FormData(elements.speakerForm);
 		const action = formData.get('action');
+		const canSubmit = action === 'add' ? config.isAdmin : config.canManageContent;
+
+		if (!canSubmit) {
+			const errorMsg = config.i18n && config.i18n.noPermission
+				? config.i18n.noPermission
+				: 'You do not have permission to perform this action.';
+			alert(errorMsg);
+			return;
+		}
 		const submitBtn = elements.speakerForm.querySelector('button[type="submit"]');
 		
 		// Disable button during submission

--- a/public/partials/additional-information-page.php
+++ b/public/partials/additional-information-page.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Legacy proxy for the additional information page template.
+ *
+ * @package Wpfaevent
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$template = dirname( __DIR__ ) . '/templates/page-additional-information.php';
+
+if ( file_exists( $template ) ) {
+	include $template;
+}

--- a/public/partials/event-section-nav.php
+++ b/public/partials/event-section-nav.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Event section navigation partial.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/partials
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( empty( $wpfa_event_nav_items ) || ! is_array( $wpfa_event_nav_items ) ) {
+	return;
+}
+?>
+<nav class="wpfa-event-section-nav" aria-label="<?php esc_attr_e( 'Event sections', 'wpfaevent' ); ?>">
+	<div class="container">
+		<?php foreach ( $wpfa_event_nav_items as $nav_item ) : ?>
+			<?php
+			if ( empty( $nav_item['text'] ) ) {
+				continue;
+			}
+
+			$nav_type = isset( $nav_item['type'] ) ? (string) $nav_item['type'] : 'link';
+			?>
+			<?php if ( 'dropdown' === $nav_type && ! empty( $nav_item['items'] ) && is_array( $nav_item['items'] ) ) : ?>
+				<div class="wpfa-event-nav-dropdown nav-dropdown">
+					<button type="button" class="wpfa-event-nav-dropdown-toggle nav-dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+						<?php echo esc_html( $nav_item['text'] ); ?>
+					</button>
+					<div class="wpfa-event-nav-dropdown-content nav-dropdown-content">
+						<?php foreach ( $nav_item['items'] as $sub_item ) : ?>
+							<?php if ( empty( $sub_item['href'] ) || empty( $sub_item['text'] ) ) : ?>
+								<?php continue; ?>
+							<?php endif; ?>
+							<a href="<?php echo esc_url( $sub_item['href'] ); ?>"><?php echo esc_html( $sub_item['text'] ); ?></a>
+						<?php endforeach; ?>
+					</div>
+				</div>
+			<?php elseif ( ! empty( $nav_item['href'] ) ) : ?>
+				<a href="<?php echo esc_url( $nav_item['href'] ); ?>"><?php echo esc_html( $nav_item['text'] ); ?></a>
+			<?php endif; ?>
+		<?php endforeach; ?>
+	</div>
+</nav>

--- a/public/partials/events/event-card.php
+++ b/public/partials/events/event-card.php
@@ -30,34 +30,17 @@ $today = current_time( 'Y-m-d' );
 // Get meta data exactly as the main template does.
 $event_date        = get_post_meta( $event_id, 'wpfa_event_start_date', true );
 $event_end_date    = get_post_meta( $event_id, 'wpfa_event_end_date', true );
-$event_start_time  = get_post_meta( $event_id, 'wpfa_event_start_time', true );
-$event_end_time    = get_post_meta( $event_id, 'wpfa_event_end_time', true );
-$event_legacy_time = get_post_meta( $event_id, 'wpfa_event_time', true );
-$event_timezone    = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_timezone( $event_id ) : '';
-$event_all_day     = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_all_day( $event_id ) : false;
 $event_place       = get_post_meta( $event_id, 'wpfa_event_location', true );
 $event_description = get_the_excerpt( $event_id );
 $featured_img_url  = get_the_post_thumbnail_url( $event_id, 'large' ) ?? '';
-$event_time_value  = $event_start_time ? $event_start_time : $event_legacy_time;
-
-$event_calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-$event_calendar_data = is_wp_error( $event_calendar_data ) ? array() : $event_calendar_data;
 
 // Check if date is valid (Admin Warning Logic).
 $is_valid_date = ! empty( $event_date ) && strtotime( $event_date ) !== false;
 $is_past_event = $is_valid_date && strtotime( $event_date ) < strtotime( $today );
 
 // Format the date string.
-$formatted_date      = __( 'Date not set', 'wpfaevent' );
-$formatted_time_meta = '';
-if ( ! empty( $event_calendar_data['date_label'] ) ) {
-	$formatted_date      = sanitize_text_field( $event_calendar_data['date_label'] );
-	$formatted_time_meta = ! empty( $event_calendar_data['time_label'] ) ? sanitize_text_field( $event_calendar_data['time_label'] ) : '';
-
-	if ( $formatted_time_meta && empty( $event_calendar_data['all_day'] ) && ! empty( $event_calendar_data['timezone_label'] ) ) {
-		$formatted_time_meta .= ' (' . sanitize_text_field( $event_calendar_data['timezone_label'] ) . ')';
-	}
-} elseif ( $is_valid_date ) {
+$formatted_date = __( 'Date not set', 'wpfaevent' );
+if ( $is_valid_date ) {
 	if ( ! empty( $event_end_date ) && $event_end_date !== $event_date && strtotime( $event_end_date ) !== false ) {
 		$formatted_date = date_i18n( 'M j', strtotime( $event_date ) ) . ' - ' . date_i18n( 'M j, Y', strtotime( $event_end_date ) );
 	} else {
@@ -65,7 +48,10 @@ if ( ! empty( $event_calendar_data['date_label'] ) ) {
 	}
 }
 
-$is_admin = current_user_can( 'manage_options' );
+$can_manage_content  = Wpfaevent_Roles::current_user_can_manage_dashboard();
+$can_delete_content  = Wpfaevent_Roles::current_user_can_delete_content();
+$can_edit_this_event = $can_manage_content && current_user_can( 'edit_post', $event_id );
+$can_delete_event    = $can_delete_content && current_user_can( 'delete_post', $event_id );
 ?>
 
 <div class="event-card"
@@ -78,13 +64,9 @@ $is_admin = current_user_can( 'manage_options' );
 	data-lead-text="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) ); ?>"
 	data-registration-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_registration_link', true ) ); ?>"
 	data-cfs-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_cfs_link', true ) ); ?>"
-	data-start-time="<?php echo esc_attr( $event_time_value ); ?>"
-	data-end-time="<?php echo esc_attr( $event_end_time ); ?>"
-	data-timezone="<?php echo esc_attr( $event_timezone ); ?>"
-	data-all-day="<?php echo esc_attr( $event_all_day ? '1' : '0' ); ?>"
-	data-time="<?php echo esc_attr( $event_time_value ); ?>">
+	data-time="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_time', true ) ); ?>">
 
-	<?php if ( $is_admin && ( ! $is_valid_date || $is_past_event ) ) : ?>
+	<?php if ( $can_manage_content && ( ! $is_valid_date || $is_past_event ) ) : ?>
 		<div class="wpfaevent-admin-warning">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="wpfaevent-warning-icon" aria-hidden="true">
 				<path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>
@@ -101,27 +83,25 @@ $is_admin = current_user_can( 'manage_options' );
 		</div>
 	<?php endif; ?>
 
-	<?php if ( $is_admin ) : ?>
+	<?php if ( $can_edit_this_event ) : ?>
 	<div class="event-card-actions">
-			<button class="btn-edit-event"
-					data-post-id="<?php echo esc_attr( $event_id ); ?>"
-					data-name="<?php echo esc_attr( get_the_title( $event_id ) ); ?>"
-					data-date="<?php echo esc_attr( $event_date ); ?>"
-					data-end-date="<?php echo esc_attr( $event_end_date ); ?>"
-					data-place="<?php echo esc_attr( $event_place ); ?>"
-					data-description="<?php echo esc_attr( $event_description ); ?>"
-					data-lead-text="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) ); ?>"
-					data-registration-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_registration_link', true ) ); ?>"
-					data-cfs-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_cfs_link', true ) ); ?>"
-					data-start-time="<?php echo esc_attr( $event_time_value ); ?>"
-					data-end-time="<?php echo esc_attr( $event_end_time ); ?>"
-					data-timezone="<?php echo esc_attr( $event_timezone ); ?>"
-					data-all-day="<?php echo esc_attr( $event_all_day ? '1' : '0' ); ?>"
-					data-time="<?php echo esc_attr( $event_time_value ); ?>">
+		<button class="btn-edit-event"
+				data-post-id="<?php echo esc_attr( $event_id ); ?>"
+				data-name="<?php echo esc_attr( get_the_title( $event_id ) ); ?>"
+				data-date="<?php echo esc_attr( $event_date ); ?>"
+				data-end-date="<?php echo esc_attr( $event_end_date ); ?>"
+				data-place="<?php echo esc_attr( $event_place ); ?>"
+				data-description="<?php echo esc_attr( $event_description ); ?>"
+				data-lead-text="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) ); ?>"
+				data-registration-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_registration_link', true ) ); ?>"
+				data-cfs-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_cfs_link', true ) ); ?>"
+				data-time="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_time', true ) ); ?>">
 			<?php esc_html_e( 'Edit Details', 'wpfaevent' ); ?>
 		</button>
 		<a href="<?php echo esc_url( admin_url( 'post.php?post=' . $event_id . '&action=edit' ) ); ?>" class="btn-edit-content"><?php esc_html_e( 'Edit Content', 'wpfaevent' ); ?></a>
-		<button class="btn-delete-event"><?php esc_html_e( 'Delete', 'wpfaevent' ); ?></button>
+		<?php if ( $can_delete_event ) : ?>
+			<button class="btn-delete-event"><?php esc_html_e( 'Delete', 'wpfaevent' ); ?></button>
+		<?php endif; ?>
 	</div>
 	<?php endif; ?>
 
@@ -136,9 +116,6 @@ $is_admin = current_user_can( 'manage_options' );
 					<path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"></path>
 				</svg>
 				<?php echo esc_html( $formatted_date ); ?>
-				<?php if ( $formatted_time_meta ) : ?>
-					<span class="event-card-time"><?php echo esc_html( ' | ' . $formatted_time_meta ); ?></span>
-				<?php endif; ?>
 			</p>
 			<?php if ( ! empty( $event_place ) ) : ?>
 			<p>

--- a/public/partials/events/event-modal.php
+++ b/public/partials/events/event-modal.php
@@ -15,8 +15,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-
-$wpfaevent_default_timezone = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_timezone( 0 ) : wp_timezone_string();
 ?>
 
 <!-- Create Event Modal -->
@@ -35,26 +33,8 @@ $wpfaevent_default_timezone = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent
 			<label for="eventEndDate"><?php esc_html_e( 'Event End Date (optional):', 'wpfaevent' ); ?></label>
 			<input type="date" id="eventEndDate" name="end_date">
 
-			<label for="eventTimezone"><?php esc_html_e( 'Timezone:', 'wpfaevent' ); ?></label>
-			<select id="eventTimezone" name="timezone">
-				<?php echo wp_timezone_choice( $wpfaevent_default_timezone ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes timezone option markup. ?>
-			</select>
-
-			<label class="wpfaevent-checkbox-label" for="eventAllDay">
-				<input type="checkbox" id="eventAllDay" name="all_day" value="1">
-				<span><?php esc_html_e( 'All-day event', 'wpfaevent' ); ?></span>
-			</label>
-
-			<div class="wpfaevent-time-fields">
-				<div>
-					<label for="eventStartTime"><?php esc_html_e( 'Start Time:', 'wpfaevent' ); ?></label>
-					<input type="time" id="eventStartTime" name="start_time">
-				</div>
-				<div>
-					<label for="eventEndTime"><?php esc_html_e( 'End Time:', 'wpfaevent' ); ?></label>
-					<input type="time" id="eventEndTime" name="end_time">
-				</div>
-			</div>
+			<label for="eventTime"><?php esc_html_e( 'Event Time:', 'wpfaevent' ); ?></label>
+			<input type="time" id="eventTime" name="time" required>
 
 			<label for="eventPlace"><?php esc_html_e( 'Event Place:', 'wpfaevent' ); ?></label>
 			<input type="text" id="eventPlace" name="location" required>
@@ -98,26 +78,8 @@ $wpfaevent_default_timezone = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent
 			<label for="editEventEndDate"><?php esc_html_e( 'Event End Date (optional):', 'wpfaevent' ); ?></label>
 			<input type="date" id="editEventEndDate" name="end_date">
 
-			<label for="editEventTimezone"><?php esc_html_e( 'Timezone:', 'wpfaevent' ); ?></label>
-			<select id="editEventTimezone" name="timezone">
-				<?php echo wp_timezone_choice( $wpfaevent_default_timezone ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes timezone option markup. ?>
-			</select>
-
-			<label class="wpfaevent-checkbox-label" for="editEventAllDay">
-				<input type="checkbox" id="editEventAllDay" name="all_day" value="1">
-				<span><?php esc_html_e( 'All-day event', 'wpfaevent' ); ?></span>
-			</label>
-
-			<div class="wpfaevent-time-fields">
-				<div>
-					<label for="editEventStartTime"><?php esc_html_e( 'Start Time:', 'wpfaevent' ); ?></label>
-					<input type="time" id="editEventStartTime" name="start_time">
-				</div>
-				<div>
-					<label for="editEventEndTime"><?php esc_html_e( 'End Time:', 'wpfaevent' ); ?></label>
-					<input type="time" id="editEventEndTime" name="end_time">
-				</div>
-			</div>
+			<label for="editEventTime"><?php esc_html_e( 'Event Time:', 'wpfaevent' ); ?></label>
+			<input type="time" id="editEventTime" name="time" required>
 
 			<label for="editEventPlace"><?php esc_html_e( 'Event Place:', 'wpfaevent' ); ?></label>
 			<input type="text" id="editEventPlace" name="location" required>

--- a/public/partials/footer.php
+++ b/public/partials/footer.php
@@ -23,7 +23,7 @@ if ( empty( $footer_text ) ) {
 }
 
 // Check if user is admin.
-$is_admin = current_user_can( 'manage_options' );
+$is_admin = Wpfaevent_Roles::current_user_can_manage_site_branding();
 ?>
 
 <!-- Main Site Footer -->

--- a/public/partials/speakers/dashboard-speaker-card.php
+++ b/public/partials/speakers/dashboard-speaker-card.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Dashboard Speaker Card Partial.
+ *
+ * Renders a speaker entry from imported dashboard JSON.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/partials/speakers
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! isset( $speaker ) || ! is_array( $speaker ) || empty( $speaker['name'] ) ) {
+	return;
+}
+
+$speaker_name        = sanitize_text_field( $speaker['name'] );
+$speaker_social      = isset( $speaker['social'] ) && is_array( $speaker['social'] ) ? $speaker['social'] : array();
+$session             = ! empty( $speaker['sessions'][0] ) && is_array( $speaker['sessions'][0] ) ? $speaker['sessions'][0] : array();
+$placeholder_url     = ! empty( $speaker_placeholder_url ) ? $speaker_placeholder_url : WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
+$is_featured_speaker = ! empty( $wpfa_dashboard_speaker_is_featured ) || ! empty( $speaker['featured'] );
+?>
+<article class="wpfa-speaker-card visible <?php echo esc_attr( $is_featured_speaker ? 'is-featured' : '' ); ?>">
+	<div class="wpfa-speaker-photo">
+		<?php if ( ! empty( $speaker['image'] ) ) : ?>
+			<?php /* translators: %s: Speaker name. */ ?>
+			<img src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy">
+		<?php else : ?>
+			<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img">
+		<?php endif; ?>
+	</div>
+	<div class="wpfa-speaker-meta">
+		<?php if ( $is_featured_speaker ) : ?>
+			<p class="wpfa-speaker-featured-badge"><?php esc_html_e( 'Featured Speaker', 'wpfaevent' ); ?></p>
+		<?php endif; ?>
+
+		<?php if ( ! empty( $speaker['category'] ) ) : ?>
+			<p class="pill"><?php echo esc_html( $speaker['category'] ); ?></p>
+		<?php endif; ?>
+
+		<h3 class="wpfa-speaker-name"><?php echo esc_html( $speaker_name ); ?></h3>
+		<?php if ( ! empty( $speaker['position'] ) || ! empty( $speaker['organization'] ) ) : ?>
+			<p class="wpfa-speaker-role">
+				<?php echo esc_html( trim( ( $speaker['position'] ?? '' ) . ( ! empty( $speaker['position'] ) && ! empty( $speaker['organization'] ) ? ' | ' : '' ) . ( $speaker['organization'] ?? '' ) ) ); ?>
+			</p>
+		<?php endif; ?>
+	</div>
+	<div class="wpfa-speaker-expand">
+		<?php if ( ! empty( $speaker['bio'] ) ) : ?>
+			<div class="wpfa-speaker-bio"><?php echo wp_kses_post( wpautop( $speaker['bio'] ) ); ?></div>
+		<?php endif; ?>
+		<?php if ( ! empty( $session['title'] ) ) : ?>
+			<div class="wpfa-speaker-session">
+				<h4><?php esc_html_e( 'Session Details', 'wpfaevent' ); ?></h4>
+				<p><strong><?php echo esc_html( $session['title'] ); ?></strong></p>
+			</div>
+		<?php endif; ?>
+		<?php if ( ! empty( $speaker_social ) ) : ?>
+			<div class="wpfa-speaker-social">
+				<?php foreach ( $speaker_social as $social_label => $social_url ) : ?>
+					<?php if ( $social_url ) : ?>
+						<a href="<?php echo esc_url( $social_url ); ?>" target="_blank" rel="noopener noreferrer" class="wpfa-social-link">
+							<?php echo esc_html( ucfirst( $social_label ) ); ?>
+						</a>
+					<?php endif; ?>
+				<?php endforeach; ?>
+			</div>
+		<?php endif; ?>
+	</div>
+</article>

--- a/public/partials/speakers/speaker-card.php
+++ b/public/partials/speakers/speaker-card.php
@@ -40,12 +40,23 @@ if ( empty( $sid ) || ! is_numeric( $sid ) ) {
 
 $sid = (int) $sid;
 
-$name         = get_the_title( $sid );
-$org          = sanitize_text_field( get_post_meta( $sid, 'wpfa_speaker_organization', true ) );
-$position     = sanitize_text_field( get_post_meta( $sid, 'wpfa_speaker_position', true ) );
-$photo_url    = get_post_meta( $sid, 'wpfa_speaker_headshot_url', true );
-$speaker_link = get_permalink( $sid );
-$is_admin     = current_user_can( 'manage_options' );
+$name                  = get_the_title( $sid );
+$org                   = sanitize_text_field( get_post_meta( $sid, 'wpfa_speaker_organization', true ) );
+$position              = sanitize_text_field( get_post_meta( $sid, 'wpfa_speaker_position', true ) );
+$photo_url             = get_post_meta( $sid, 'wpfa_speaker_headshot_url', true );
+$placeholder_url       = WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
+$speaker_link          = get_permalink( $sid );
+$hide_admin_actions    = ! empty( $wpfa_hide_speaker_card_admin_actions );
+$can_manage_content    = ! $hide_admin_actions && Wpfaevent_Roles::current_user_can_manage_dashboard();
+$can_delete_content    = ! $hide_admin_actions && Wpfaevent_Roles::current_user_can_delete_content();
+$can_edit_this_speaker = $can_manage_content && current_user_can( 'edit_post', $sid );
+$can_delete_speaker    = $can_delete_content && current_user_can( 'delete_post', $sid );
+$featured_speaker_ids  = isset( $wpfa_featured_speaker_ids ) && is_array( $wpfa_featured_speaker_ids ) ? array_map( 'absint', $wpfa_featured_speaker_ids ) : array();
+$is_featured_speaker   = in_array( $sid, $featured_speaker_ids, true );
+
+if ( empty( $photo_url ) && has_post_thumbnail( $sid ) ) {
+	$photo_url = get_the_post_thumbnail_url( $sid, 'medium_large' );
+}
 
 // Get categories from the taxonomy.
 $speaker_categories = array();
@@ -62,35 +73,75 @@ $talk_date     = get_post_meta( $sid, 'wpfa_speaker_talk_date', true );
 $talk_time     = get_post_meta( $sid, 'wpfa_speaker_talk_time', true );
 $talk_end_time = get_post_meta( $sid, 'wpfa_speaker_talk_end_time', true );
 $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
+
+$speaker_card_timezone = isset( $wpfa_schedule_display_timezone ) && $wpfa_schedule_display_timezone instanceof DateTimeZone ? $wpfa_schedule_display_timezone : wp_timezone();
+
+$format_speaker_talk_datetime = static function ( $date, $time, $format ) use ( $speaker_card_timezone ) {
+	$date = trim( (string) $date );
+	$time = trim( (string) $time );
+
+	if ( '' === $date ) {
+		return '';
+	}
+
+	$value = trim( $date . ' ' . $time );
+
+	try {
+		$datetime = new DateTimeImmutable( $value, wp_timezone() );
+	} catch ( Exception $exception ) {
+		return '';
+	}
+
+	return wp_date( $format, $datetime->getTimestamp(), $speaker_card_timezone );
+};
+
+$formatted_talk_date = $format_speaker_talk_datetime( $talk_date, '', get_option( 'date_format' ) );
+$formatted_talk_time = $format_speaker_talk_datetime( $talk_date, $talk_time, get_option( 'time_format' ) );
+$formatted_end_time  = $format_speaker_talk_datetime( $talk_date, $talk_end_time, get_option( 'time_format' ) );
+
+if ( ! $formatted_talk_date ) {
+	$formatted_talk_date = $talk_date;
+}
+
+if ( ! $formatted_talk_time ) {
+	$formatted_talk_time = $talk_time;
+}
+
+if ( ! $formatted_end_time ) {
+	$formatted_end_time = $talk_end_time;
+}
 ?>
-<article class="wpfa-speaker-card" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( $sid ); ?>">
+<article class="wpfa-speaker-card <?php echo esc_attr( $is_featured_speaker ? 'is-featured' : '' ); ?>" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( $sid ); ?>">
 	<a class="wpfa-speaker-photo" href="<?php echo esc_url( $speaker_link ); ?>">
-			<?php if ( $photo_url ) : ?>
-				<?php /* translators: %s: Speaker name. */ ?>
-				<img src="<?php echo esc_url( $photo_url ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $name ) ); ?>" loading="lazy" itemprop="image" />
+		<?php if ( $photo_url ) : ?>
+			<?php /* translators: %s: Speaker name. */ ?>
+			<img src="<?php echo esc_url( $photo_url ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $name ) ); ?>" loading="lazy" itemprop="image" />
 		<?php else : ?>
-			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" class="wpfa-placeholder-svg">
-				<rect width="100%" height="100%" fill="#eee" />
-				<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#999">Speaker</text>
-			</svg>
+			<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img" itemprop="image" />
 		<?php endif; ?>
 	</a>
 	<div class="wpfa-speaker-meta">
-		<?php if ( $is_admin ) : ?>
+		<?php if ( $can_edit_this_speaker ) : ?>
 			<button class="btn-edit-speaker" data-id="<?php echo esc_attr( $sid ); ?>" data-name="<?php echo esc_attr( $name ); ?>" title="<?php esc_attr_e( 'Edit Speaker', 'wpfaevent' ); ?>">
 				✎
 			</button>
+		<?php endif; ?>
+		<?php if ( $can_delete_speaker ) : ?>
 			<button class="btn-delete-speaker" data-id="<?php echo esc_attr( $sid ); ?>" data-name="<?php echo esc_attr( $name ); ?>" title="<?php esc_attr_e( 'Delete Speaker', 'wpfaevent' ); ?>">
 				×
 			</button>
 		<?php endif; ?>
-		
+
+		<?php if ( $is_featured_speaker ) : ?>
+			<p class="wpfa-speaker-featured-badge"><?php esc_html_e( 'Featured Speaker', 'wpfaevent' ); ?></p>
+		<?php endif; ?>
+
 		<?php if ( ! empty( $speaker_categories ) ) : ?>
 			<p class="pill">
 				<?php echo esc_html( $speaker_categories[0] ); ?>
 			</p>
 		<?php endif; ?>
-		
+
 		<h3 class="wpfa-speaker-name" itemprop="name"><a href="<?php echo esc_url( $speaker_link ); ?>"><?php echo esc_html( $name ); ?></a></h3>
 		<?php if ( $position || $org ) : ?>
 			<p class="wpfa-speaker-role"><?php echo esc_html( trim( $position . ( $position && $org ? ' · ' : '' ) . $org ) ); ?></p>
@@ -105,30 +156,31 @@ $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
 				<?php echo wp_kses_post( wpautop( $bio ) ); ?>
 			</div>
 		<?php endif; ?>
-		
+
 		<?php if ( $talk_title ) : ?>
 			<div class="wpfa-speaker-session">
 				<h4><?php esc_html_e( 'Session Details', 'wpfaevent' ); ?></h4>
 				<p><strong><?php echo esc_html( $talk_title ); ?></strong></p>
-				
+
 				<?php if ( $talk_date || $talk_time ) : ?>
 					<p>
 						<?php
 						$date_time = array();
-						if ( $talk_date ) {
-							$date_time[] = esc_html( $talk_date );
+						if ( $formatted_talk_date ) {
+							$date_time[] = esc_html( $formatted_talk_date );
 						}
-						if ( $talk_time ) {
-							$date_time[] = esc_html( $talk_time );
-							if ( $talk_end_time ) {
-								$date_time[] = esc_html( $talk_end_time );
+						if ( $formatted_talk_time ) {
+							$time_label = $formatted_talk_time;
+							if ( $formatted_end_time && $formatted_end_time !== $formatted_talk_time ) {
+								$time_label .= ' - ' . $formatted_end_time;
 							}
+							$date_time[] = esc_html( $time_label );
 						}
 						echo esc_html( implode( ' • ', $date_time ) );
 						?>
 					</p>
 				<?php endif; ?>
-				
+
 				<?php if ( $talk_abstract ) : ?>
 					<div class="wpfa-talk-abstract">
 						<?php echo wp_kses_post( wpautop( $talk_abstract ) ); ?>

--- a/public/templates/archive-wpfa-event.php
+++ b/public/templates/archive-wpfa-event.php
@@ -1,0 +1,666 @@
+<?php
+/**
+ * Event Archive Template.
+ *
+ * Displays a searchable and filterable directory of WPFA events.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/templates
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$archive_url = get_post_type_archive_link( 'wpfa_event' );
+if ( ! $archive_url ) {
+	$archive_url = home_url( '/events/' );
+}
+
+$read_filter_value = static function ( $key, $type = 'text' ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- These are read-only archive filters.
+	if ( ! isset( $_GET[ $key ] ) ) {
+		return '';
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized by type below.
+	$value = wp_unslash( $_GET[ $key ] );
+
+	if ( is_array( $value ) ) {
+		return '';
+	}
+
+	if ( 'key' === $type ) {
+		return sanitize_key( $value );
+	}
+
+	if ( 'slug' === $type ) {
+		return sanitize_title( $value );
+	}
+
+	if ( 'int' === $type ) {
+		return absint( $value );
+	}
+
+	return sanitize_text_field( $value );
+};
+
+$search_query     = $read_filter_value( 'q' );
+$current_track    = $read_filter_value( 'track', 'slug' );
+$current_tag      = $read_filter_value( 'tag', 'slug' );
+$current_when     = $read_filter_value( 'when', 'key' );
+$current_location = $read_filter_value( 'location', 'slug' );
+$current_language = $read_filter_value( 'language', 'slug' );
+$current_page     = max( 1, absint( get_query_var( 'paged', 1 ) ) );
+$query_page       = $read_filter_value( 'paged', 'int' );
+
+if ( $query_page ) {
+	$current_page = max( 1, $query_page );
+}
+
+if ( ! in_array( $current_when, array( 'all', 'upcoming', 'past' ), true ) ) {
+	$current_when = 'all';
+}
+
+$today           = current_time( 'Y-m-d' );
+$events_per_page = max( 1, absint( apply_filters( 'wpfa_event_archive_events_per_page', 12 ) ) );
+
+$format_event_date = static function ( $date ) {
+	$date = trim( (string) $date );
+
+	if ( '' === $date ) {
+		return '';
+	}
+
+	$timestamp = strtotime( $date );
+
+	return $timestamp ? date_i18n( get_option( 'date_format' ), $timestamp ) : $date;
+};
+
+$format_event_date_range = static function ( $start_date, $end_date ) use ( $format_event_date ) {
+	$start_label = $format_event_date( $start_date );
+	$end_label   = $format_event_date( $end_date );
+
+	if ( $start_label && $end_label && $start_label !== $end_label ) {
+		return $start_label . ' - ' . $end_label;
+	}
+
+	return $start_label ? $start_label : $end_label;
+};
+
+$normalize_event_date = static function ( $date ) {
+	$date = sanitize_text_field( $date );
+
+	if ( '' === $date ) {
+		return '';
+	}
+
+	$timestamp = strtotime( $date );
+
+	return $timestamp ? date_i18n( 'Y-m-d', $timestamp ) : '';
+};
+
+$format_language_label = static function ( $language ) {
+	$language = trim( (string) $language );
+
+	if ( '' === $language ) {
+		return '';
+	}
+
+	$normalized = strtolower( str_replace( '_', '-', $language ) );
+	$labels     = array(
+		'ar'          => __( 'Arabic', 'wpfaevent' ),
+		'bn'          => __( 'Bengali', 'wpfaevent' ),
+		'bg'          => __( 'Bulgarian', 'wpfaevent' ),
+		'ca'          => __( 'Catalan', 'wpfaevent' ),
+		'cs'          => __( 'Czech', 'wpfaevent' ),
+		'da'          => __( 'Danish', 'wpfaevent' ),
+		'de'          => __( 'German', 'wpfaevent' ),
+		'en'          => __( 'English', 'wpfaevent' ),
+		'en-ca'       => __( 'English (Canada)', 'wpfaevent' ),
+		'es'          => __( 'Spanish', 'wpfaevent' ),
+		'fr'          => __( 'French', 'wpfaevent' ),
+		'gu'          => __( 'Gujarati', 'wpfaevent' ),
+		'hi'          => __( 'Hindi', 'wpfaevent' ),
+		'it'          => __( 'Italian', 'wpfaevent' ),
+		'ja'          => __( 'Japanese', 'wpfaevent' ),
+		'ko'          => __( 'Korean', 'wpfaevent' ),
+		'nl'          => __( 'Dutch', 'wpfaevent' ),
+		'nl-informal' => __( 'Dutch (Informal)', 'wpfaevent' ),
+		'pt'          => __( 'Portuguese', 'wpfaevent' ),
+		'ru'          => __( 'Russian', 'wpfaevent' ),
+		'si'          => __( 'Sinhala', 'wpfaevent' ),
+		'ta'          => __( 'Tamil', 'wpfaevent' ),
+		'zh-hans'     => __( 'Chinese (Simplified)', 'wpfaevent' ),
+		'zh-hant'     => __( 'Chinese (Traditional)', 'wpfaevent' ),
+	);
+
+	if ( isset( $labels[ $normalized ] ) ) {
+		return $labels[ $normalized ];
+	}
+
+	if ( false === strpos( $language, ' ' ) && preg_match( '/^[a-z]{2,3}(?:[-_][a-z0-9]+)*$/i', $language ) ) {
+		return ucwords( str_replace( '-', ' ', $normalized ) );
+	}
+
+	return $language;
+};
+
+$get_event_terms = static function ( $event_id, $taxonomy ) {
+	$terms = get_the_terms( $event_id, $taxonomy );
+
+	if ( empty( $terms ) || is_wp_error( $terms ) ) {
+		return array();
+	}
+
+	return array_values( $terms );
+};
+
+$get_term_names = static function ( $terms ) {
+	return array_map(
+		static function ( $term ) {
+			return $term->name;
+		},
+		$terms
+	);
+};
+
+$get_term_slugs = static function ( $terms ) {
+	return array_map(
+		static function ( $term ) {
+			return $term->slug;
+		},
+		$terms
+	);
+};
+
+$build_event_excerpt = static function ( $event_id ) {
+	$excerpt = trim( (string) get_post_field( 'post_excerpt', $event_id ) );
+
+	if ( '' === $excerpt ) {
+		$content = wp_strip_all_tags( strip_shortcodes( get_post_field( 'post_content', $event_id ) ) );
+		$excerpt = wp_trim_words( $content, 28, '...' );
+	}
+
+	return $excerpt;
+};
+
+$event_ids = get_posts(
+	array(
+		'post_type'      => 'wpfa_event',
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	)
+);
+
+$events    = array();
+$locations = array();
+$languages = array();
+
+foreach ( $event_ids as $event_id ) {
+	$event_id        = absint( $event_id );
+	$event_title     = get_the_title( $event_id );
+	$start_date      = $normalize_event_date( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
+	$end_date        = $normalize_event_date( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
+	$location        = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+	$event_languages = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_language_list( get_post_meta( $event_id, 'wpfa_event_languages', true ) ) : array();
+	$language_labels = array_map( $format_language_label, $event_languages );
+	$event_url       = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_url', true ) );
+	$track_terms     = $get_event_terms( $event_id, 'wpfa_event_track' );
+	$tag_terms       = $get_event_terms( $event_id, 'wpfa_event_tag' );
+	$track_names     = $get_term_names( $track_terms );
+	$tag_names       = $get_term_names( $tag_terms );
+	$track_slugs     = $get_term_slugs( $track_terms );
+	$tag_slugs       = $get_term_slugs( $tag_terms );
+	$excerpt         = $build_event_excerpt( $event_id );
+	$image_url       = get_the_post_thumbnail_url( $event_id, 'large' );
+	$date_key        = $end_date ? $end_date : $start_date;
+	$event_status    = ( $date_key && $date_key < $today ) ? 'past' : 'upcoming';
+	$sort_date       = $start_date ? $start_date : $end_date;
+	$sort_time       = $sort_date ? strtotime( $sort_date ) : PHP_INT_MAX;
+	$speaker_ids     = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_admin_event_speaker_ids( $event_id ) : array();
+	$event_slug      = get_post_field( 'post_name', $event_id );
+
+	if ( $location ) {
+		$locations[ sanitize_title( $location ) ] = $location;
+	}
+
+	foreach ( $event_languages as $language ) {
+		$languages[ sanitize_title( $language ) ] = $format_language_label( $language );
+	}
+
+	$events[] = array(
+		'id'            => $event_id,
+		'title'         => $event_title,
+		'start_date'    => $start_date,
+		'end_date'      => $end_date,
+		'date_label'    => $format_event_date_range( $start_date, $end_date ),
+		'location'      => $location,
+		'location_key'  => sanitize_title( $location ),
+		'languages'     => $language_labels,
+		'language_keys' => array_map( 'sanitize_title', $event_languages ),
+		'event_url'     => $event_url,
+		'track_names'   => $track_names,
+		'track_slugs'   => $track_slugs,
+		'tag_names'     => $tag_names,
+		'tag_slugs'     => $tag_slugs,
+		'excerpt'       => $excerpt,
+		'image_url'     => $image_url,
+		'status'        => $event_status,
+		'sort_time'     => $sort_time,
+		'speaker_ids'   => $speaker_ids,
+		'speakers_url'  => add_query_arg( 'event', $event_slug, home_url( '/speakers/' ) ),
+	);
+}
+
+asort( $locations );
+asort( $languages );
+
+$tracks = get_terms(
+	array(
+		'taxonomy'   => 'wpfa_event_track',
+		'hide_empty' => true,
+	)
+);
+
+if ( is_wp_error( $tracks ) ) {
+	$tracks = array();
+}
+
+$tags = get_terms(
+	array(
+		'taxonomy'   => 'wpfa_event_tag',
+		'hide_empty' => true,
+	)
+);
+
+if ( is_wp_error( $tags ) ) {
+	$tags = array();
+}
+
+$filtered_events = array();
+
+foreach ( $events as $event ) {
+	if ( 'all' !== $current_when && $event['status'] !== $current_when ) {
+		continue;
+	}
+
+	if ( $current_track && ! in_array( $current_track, $event['track_slugs'], true ) ) {
+		continue;
+	}
+
+	if ( $current_tag && ! in_array( $current_tag, $event['tag_slugs'], true ) ) {
+		continue;
+	}
+
+	if ( $current_location && $current_location !== $event['location_key'] ) {
+		continue;
+	}
+
+	if ( $current_language && ! in_array( $current_language, $event['language_keys'], true ) ) {
+		continue;
+	}
+
+	if ( $search_query ) {
+		$searchable_text = implode(
+			' ',
+			array_merge(
+				array(
+					$event['title'],
+					$event['excerpt'],
+					$event['location'],
+					$event['date_label'],
+				),
+				$event['track_names'],
+				$event['tag_names'],
+				$event['languages']
+			)
+		);
+
+		if ( false === stripos( $searchable_text, $search_query ) ) {
+			continue;
+		}
+	}
+
+	$filtered_events[] = $event;
+}
+
+usort(
+	$filtered_events,
+	static function ( $event_a, $event_b ) use ( $current_when ) {
+		if ( $event_a['sort_time'] === $event_b['sort_time'] ) {
+			return strcasecmp( $event_a['title'], $event_b['title'] );
+		}
+
+		if ( 'past' === $current_when ) {
+			return ( $event_a['sort_time'] < $event_b['sort_time'] ) ? 1 : -1;
+		}
+
+		return ( $event_a['sort_time'] < $event_b['sort_time'] ) ? -1 : 1;
+	}
+);
+
+$total_events = count( $filtered_events );
+$total_pages  = max( 1, (int) ceil( $total_events / $events_per_page ) );
+$current_page = min( $current_page, $total_pages );
+$offset       = ( $current_page - 1 ) * $events_per_page;
+$paged_events = array_slice( $filtered_events, $offset, $events_per_page );
+
+$active_filter_args = array();
+
+if ( '' !== $search_query ) {
+	$active_filter_args['q'] = $search_query;
+}
+
+if ( '' !== $current_track ) {
+	$active_filter_args['track'] = $current_track;
+}
+
+if ( '' !== $current_tag ) {
+	$active_filter_args['tag'] = $current_tag;
+}
+
+if ( 'all' !== $current_when ) {
+	$active_filter_args['when'] = $current_when;
+}
+
+if ( '' !== $current_location ) {
+	$active_filter_args['location'] = $current_location;
+}
+
+if ( '' !== $current_language ) {
+	$active_filter_args['language'] = $current_language;
+}
+
+$has_active_filters = ! empty( $active_filter_args );
+$site_logo_url      = get_option( 'wpfa_site_logo_url', '' );
+
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class( 'wpfaevent wpfa-event-template wpfa-event-archive-page' ); ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+	<?php
+	$show_back_button     = false;
+	$show_register_button = false;
+
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
+
+	<main class="wpfa-event-archive">
+		<section class="wpfa-event-directory-hero">
+			<div class="container wpfa-event-directory-hero-inner">
+				<div>
+					<p class="wpfa-event-kicker"><?php esc_html_e( 'Event Directory', 'wpfaevent' ); ?></p>
+					<h1><?php esc_html_e( 'Open source events from the FOSSASIA community', 'wpfaevent' ); ?></h1>
+					<p class="wpfa-event-directory-lead">
+						<?php esc_html_e( 'Search by event name, topic, track, location, or date and find the right event faster.', 'wpfaevent' ); ?>
+					</p>
+				</div>
+				<div class="wpfa-event-directory-count" aria-label="<?php esc_attr_e( 'Event count', 'wpfaevent' ); ?>">
+					<strong><?php echo esc_html( number_format_i18n( count( $events ) ) ); ?></strong>
+					<span><?php esc_html_e( 'published events', 'wpfaevent' ); ?></span>
+				</div>
+			</div>
+		</section>
+
+		<section class="wpfa-event-directory-controls" aria-labelledby="wpfa-event-filter-title">
+			<div class="container">
+				<form class="wpfa-event-filter-form" action="<?php echo esc_url( $archive_url ); ?>" method="get">
+					<div class="wpfa-event-filter-head">
+						<div>
+							<h2 id="wpfa-event-filter-title"><?php esc_html_e( 'Find Events', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Filter events by name, topic, track, date, location, and language.', 'wpfaevent' ); ?></p>
+						</div>
+						<?php if ( $has_active_filters ) : ?>
+							<a class="wpfa-event-reset" href="<?php echo esc_url( $archive_url ); ?>">
+								<?php esc_html_e( 'Reset', 'wpfaevent' ); ?>
+							</a>
+						<?php endif; ?>
+					</div>
+
+					<div class="wpfa-event-filter-grid">
+						<label class="wpfa-event-field wpfa-event-field-search">
+							<span><?php esc_html_e( 'Search events', 'wpfaevent' ); ?></span>
+							<input type="search" name="q" value="<?php echo esc_attr( $search_query ); ?>" placeholder="<?php esc_attr_e( 'Search by event name or topic', 'wpfaevent' ); ?>">
+						</label>
+
+						<label class="wpfa-event-field">
+							<span><?php esc_html_e( 'Track', 'wpfaevent' ); ?></span>
+							<select name="track">
+								<option value=""><?php esc_html_e( 'All tracks', 'wpfaevent' ); ?></option>
+								<?php foreach ( $tracks as $track ) : ?>
+									<option value="<?php echo esc_attr( $track->slug ); ?>" <?php selected( $current_track, $track->slug ); ?>>
+										<?php echo esc_html( $track->name ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</label>
+
+						<label class="wpfa-event-field">
+							<span><?php esc_html_e( 'Topic', 'wpfaevent' ); ?></span>
+							<select name="tag">
+								<option value=""><?php esc_html_e( 'All topics', 'wpfaevent' ); ?></option>
+								<?php foreach ( $tags as $event_tag ) : ?>
+									<option value="<?php echo esc_attr( $event_tag->slug ); ?>" <?php selected( $current_tag, $event_tag->slug ); ?>>
+										<?php echo esc_html( $event_tag->name ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</label>
+
+						<label class="wpfa-event-field">
+							<span><?php esc_html_e( 'Location', 'wpfaevent' ); ?></span>
+							<select name="location">
+								<option value=""><?php esc_html_e( 'All locations', 'wpfaevent' ); ?></option>
+								<?php foreach ( $locations as $location_key => $location_label ) : ?>
+									<option value="<?php echo esc_attr( $location_key ); ?>" <?php selected( $current_location, $location_key ); ?>>
+										<?php echo esc_html( $location_label ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</label>
+
+						<label class="wpfa-event-field">
+							<span><?php esc_html_e( 'Language', 'wpfaevent' ); ?></span>
+							<select name="language">
+								<option value=""><?php esc_html_e( 'All languages', 'wpfaevent' ); ?></option>
+								<?php foreach ( $languages as $language_key => $language_label ) : ?>
+									<option value="<?php echo esc_attr( $language_key ); ?>" <?php selected( $current_language, $language_key ); ?>>
+										<?php echo esc_html( $language_label ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</label>
+					</div>
+
+					<div class="wpfa-event-filter-bottom">
+						<fieldset class="wpfa-event-when-filter">
+							<legend><?php esc_html_e( 'Date', 'wpfaevent' ); ?></legend>
+							<label>
+								<input type="radio" name="when" value="all" <?php checked( $current_when, 'all' ); ?>>
+								<span><?php esc_html_e( 'All', 'wpfaevent' ); ?></span>
+							</label>
+							<label>
+								<input type="radio" name="when" value="upcoming" <?php checked( $current_when, 'upcoming' ); ?>>
+								<span><?php esc_html_e( 'Upcoming', 'wpfaevent' ); ?></span>
+							</label>
+							<label>
+								<input type="radio" name="when" value="past" <?php checked( $current_when, 'past' ); ?>>
+								<span><?php esc_html_e( 'Past', 'wpfaevent' ); ?></span>
+							</label>
+						</fieldset>
+
+						<button type="submit" class="wpfa-event-filter-submit">
+							<?php esc_html_e( 'Search Events', 'wpfaevent' ); ?>
+						</button>
+					</div>
+				</form>
+			</div>
+		</section>
+
+		<section class="wpfa-event-directory-results" aria-labelledby="wpfa-event-results-title">
+			<div class="container">
+				<div class="wpfa-event-results-head">
+					<div>
+						<h2 id="wpfa-event-results-title"><?php esc_html_e( 'Events', 'wpfaevent' ); ?></h2>
+						<p>
+							<?php
+							printf(
+								/* translators: %1$d: number of shown events, %2$d: total matching events. */
+								esc_html__( 'Showing %1$d of %2$d matching events', 'wpfaevent' ),
+								absint( count( $paged_events ) ),
+								absint( $total_events )
+							);
+							?>
+						</p>
+					</div>
+				</div>
+
+				<?php if ( $paged_events ) : ?>
+					<div class="wpfa-event-card-grid">
+						<?php foreach ( $paged_events as $event ) : ?>
+							<?php
+							$event_date_card_label = $event['date_label'] ? $event['date_label'] : __( 'TBA', 'wpfaevent' );
+							$speaker_count         = count( $event['speaker_ids'] );
+							?>
+							<article class="wpfa-event-directory-card">
+								<a class="wpfa-event-directory-card-main" href="<?php echo esc_url( get_permalink( $event['id'] ) ); ?>">
+									<div class="wpfa-event-card-media">
+										<?php if ( $event['image_url'] ) : ?>
+											<img src="<?php echo esc_url( $event['image_url'] ); ?>" alt="<?php echo esc_attr( $event['title'] ); ?>" loading="lazy">
+										<?php else : ?>
+											<div class="wpfa-event-card-date">
+												<span><?php esc_html_e( 'Date', 'wpfaevent' ); ?></span>
+												<strong><?php echo esc_html( $event_date_card_label ); ?></strong>
+											</div>
+										<?php endif; ?>
+									</div>
+
+									<div class="wpfa-event-card-body">
+										<div class="wpfa-event-card-topline">
+											<span class="wpfa-event-status <?php echo esc_attr( 'is-' . $event['status'] ); ?>">
+												<?php echo esc_html( 'past' === $event['status'] ? __( 'Past', 'wpfaevent' ) : __( 'Upcoming', 'wpfaevent' ) ); ?>
+											</span>
+											<?php if ( $speaker_count ) : ?>
+												<span>
+													<?php
+													printf(
+														/* translators: %d: number of speakers. */
+														esc_html( _n( '%d speaker', '%d speakers', $speaker_count, 'wpfaevent' ) ),
+														absint( $speaker_count )
+													);
+													?>
+												</span>
+											<?php endif; ?>
+										</div>
+
+										<h3><?php echo esc_html( $event['title'] ); ?></h3>
+
+										<div class="wpfa-event-card-meta">
+											<?php if ( $event['date_label'] ) : ?>
+												<span><?php echo esc_html( $event['date_label'] ); ?></span>
+											<?php endif; ?>
+											<?php if ( $event['location'] ) : ?>
+												<span><?php echo esc_html( $event['location'] ); ?></span>
+											<?php endif; ?>
+										</div>
+
+										<?php if ( $event['excerpt'] ) : ?>
+											<p><?php echo esc_html( $event['excerpt'] ); ?></p>
+										<?php endif; ?>
+
+										<?php if ( ! empty( $event['track_names'] ) || ! empty( $event['tag_names'] ) || ! empty( $event['languages'] ) ) : ?>
+											<div class="wpfa-event-badges" aria-label="<?php esc_attr_e( 'Event categories', 'wpfaevent' ); ?>">
+												<?php foreach ( array_slice( array_merge( $event['track_names'], $event['tag_names'], $event['languages'] ), 0, 5 ) as $badge_label ) : ?>
+													<span><?php echo esc_html( $badge_label ); ?></span>
+												<?php endforeach; ?>
+											</div>
+										<?php endif; ?>
+									</div>
+								</a>
+
+								<div class="wpfa-event-card-actions">
+									<a href="<?php echo esc_url( get_permalink( $event['id'] ) ); ?>"><?php esc_html_e( 'View Event', 'wpfaevent' ); ?></a>
+									<?php if ( $speaker_count ) : ?>
+										<a href="<?php echo esc_url( $event['speakers_url'] ); ?>"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+									<?php if ( $event['event_url'] ) : ?>
+										<a href="<?php echo esc_url( $event['event_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Register', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+								</div>
+							</article>
+						<?php endforeach; ?>
+					</div>
+
+					<?php
+					if ( $total_pages > 1 ) {
+						$pagination_url   = ! empty( $active_filter_args ) ? add_query_arg( $active_filter_args, $archive_url ) : $archive_url;
+						$pagination_links = paginate_links(
+							array(
+								'base'      => esc_url_raw( add_query_arg( 'paged', '%#%', $pagination_url ) ),
+								'format'    => '',
+								'current'   => $current_page,
+								'total'     => $total_pages,
+								'prev_text' => __( 'Previous', 'wpfaevent' ),
+								'next_text' => __( 'Next', 'wpfaevent' ),
+								'type'      => 'array',
+							)
+						);
+
+						if ( $pagination_links ) {
+							echo '<nav class="wpfa-pagination" aria-label="' . esc_attr__( 'Events pagination', 'wpfaevent' ) . '">';
+							foreach ( $pagination_links as $pagination_link ) {
+								echo wp_kses_post( $pagination_link );
+							}
+							echo '</nav>';
+						}
+					}
+					?>
+				<?php else : ?>
+					<div class="wpfa-event-empty-state">
+						<h3><?php esc_html_e( 'No events matched your filters', 'wpfaevent' ); ?></h3>
+						<p><?php esc_html_e( 'Try a different search term or clear the filters to see every event.', 'wpfaevent' ); ?></p>
+						<a href="<?php echo esc_url( $archive_url ); ?>"><?php esc_html_e( 'Clear Filters', 'wpfaevent' ); ?></a>
+					</div>
+				<?php endif; ?>
+			</div>
+		</section>
+	</main>
+
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
+</div>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/public/templates/page-additional-information.php
+++ b/public/templates/page-additional-information.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Template Name: WPFA - Additional Information
+ *
+ * Displays event-specific attendee information such as nearby hotels,
+ * transportation, parking, directions, and venue notes.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/templates
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$additional_information_page_url = get_permalink();
+
+if ( ! $additional_information_page_url && class_exists( 'Wpfaevent_Additional_Information_Helper' ) ) {
+	$additional_information_page_url = Wpfaevent_Additional_Information_Helper::get_additional_information_page_url();
+}
+
+$read_filter_value = static function ( $key ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- These are read-only page filters.
+	if ( ! isset( $_GET[ $key ] ) ) {
+		return '';
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized below.
+	$value = wp_unslash( $_GET[ $key ] );
+
+	if ( is_array( $value ) ) {
+		return '';
+	}
+
+	return sanitize_text_field( $value );
+};
+
+$resolve_event_filter = static function ( $event_filter ) {
+	$event_filter = trim( (string) $event_filter );
+
+	if ( '' === $event_filter ) {
+		return 0;
+	}
+
+	if ( is_numeric( $event_filter ) ) {
+		$event_id = absint( $event_filter );
+
+		return ( $event_id && 'wpfa_event' === get_post_type( $event_id ) && 'publish' === get_post_status( $event_id ) ) ? $event_id : 0;
+	}
+
+	$events = get_posts(
+		array(
+			'name'           => sanitize_title( $event_filter ),
+			'post_type'      => 'wpfa_event',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		)
+	);
+
+	return ! empty( $events[0] ) ? absint( $events[0] ) : 0;
+};
+
+$current_event_filter = $read_filter_value( 'event' );
+$selected_event_id    = $resolve_event_filter( $current_event_filter );
+$selected_event_slug  = $selected_event_id ? get_post_field( 'post_name', $selected_event_id ) : '';
+$selected_event_title = $selected_event_id ? get_the_title( $selected_event_id ) : '';
+$selected_event_url   = $selected_event_id ? get_permalink( $selected_event_id ) : '';
+$venue_information    = $selected_event_id ? trim( (string) get_post_meta( $selected_event_id, 'wpfa_event_venue_information', true ) ) : '';
+$has_information      = '' !== trim( wp_strip_all_tags( $venue_information ) );
+$schedule_page_url    = class_exists( 'Wpfaevent_Schedule_Helper' ) ? Wpfaevent_Schedule_Helper::get_schedule_page_url() : home_url( '/full-schedule/' );
+$event_schedule_url   = $selected_event_id ? add_query_arg( 'event', $selected_event_slug, $schedule_page_url ) : $schedule_page_url;
+$event_additional_url = $selected_event_id ? add_query_arg( 'event', $selected_event_slug, $additional_information_page_url ) : $additional_information_page_url;
+$event_style_attr     = '';
+
+if ( $selected_event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$event_colors        = Wpfaevent_Meta_Event::get_event_colors( $selected_event_id );
+	$event_color_var_map = array(
+		'wpfa_event_primary_color'          => '--event-primary',
+		'wpfa_event_hover_button_color'     => '--event-primary-dark',
+		'wpfa_event_theme_background_color' => '--event-soft',
+		'wpfa_event_theme_success_color'    => '--event-success',
+		'wpfa_event_theme_danger_color'     => '--event-danger',
+	);
+	$event_style_vars    = array();
+
+	foreach ( $event_color_var_map as $meta_key => $css_var ) {
+		if ( ! empty( $event_colors[ $meta_key ] ) ) {
+			$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+		}
+	}
+
+	$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+}
+
+$site_logo_url = get_option( 'wpfa_site_logo_url', '' );
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+
+$header_vars = array(
+	'site_logo_url'        => $site_logo_url,
+	'event_page_url'       => $selected_event_url ? $selected_event_url : home_url( '/events/' ),
+	'show_back_button'     => true,
+	'show_register_button' => false,
+	'back_button_text'     => $selected_event_url ? __( 'Back to Event', 'wpfaevent' ) : __( 'Back to Events', 'wpfaevent' ),
+	'register_button_url'  => '',
+	'register_button_text' => __( 'Register', 'wpfaevent' ),
+);
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class( 'wpfaevent wpfa-event-template wpfa-additional-information-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+	<?php
+	$site_logo_url        = $header_vars['site_logo_url'];
+	$event_page_url       = $header_vars['event_page_url'];
+	$show_back_button     = $header_vars['show_back_button'];
+	$show_register_button = $header_vars['show_register_button'];
+	$back_button_text     = $header_vars['back_button_text'];
+	$register_button_url  = $header_vars['register_button_url'];
+	$register_button_text = $header_vars['register_button_text'];
+
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
+
+	<main class="wpfa-additional-information">
+		<section class="wpfa-additional-information-hero">
+			<div class="container">
+				<p class="wpfa-event-kicker"><?php esc_html_e( 'Venue and travel', 'wpfaevent' ); ?></p>
+				<h1><?php esc_html_e( 'Additional information', 'wpfaevent' ); ?></h1>
+				<p>
+					<?php
+					if ( $selected_event_title ) {
+						printf(
+							/* translators: %s: event title. */
+							esc_html__( 'Hotels, transportation, parking, directions, and other attendee details for %s.', 'wpfaevent' ),
+							esc_html( $selected_event_title )
+						);
+					} else {
+						esc_html_e( 'Hotels, transportation, parking, directions, and other attendee details for an event.', 'wpfaevent' );
+					}
+					?>
+				</p>
+			</div>
+		</section>
+
+		<section class="wpfa-event-section wpfa-additional-information-detail" aria-labelledby="wpfa-additional-information-title">
+			<div class="container">
+				<?php if ( $selected_event_id ) : ?>
+					<nav class="wpfa-schedule-tabs" aria-label="<?php esc_attr_e( 'Event detail navigation', 'wpfaevent' ); ?>">
+						<a href="<?php echo esc_url( $selected_event_url ); ?>"><?php esc_html_e( 'Info', 'wpfaevent' ); ?></a>
+						<a href="<?php echo esc_url( $event_schedule_url ); ?>"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></a>
+						<a class="is-active" href="<?php echo esc_url( $event_additional_url ); ?>"><?php esc_html_e( 'Additional Information', 'wpfaevent' ); ?></a>
+					</nav>
+				<?php endif; ?>
+
+				<div class="wpfa-event-section-head">
+					<div>
+						<h2 id="wpfa-additional-information-title">
+							<?php echo esc_html( $selected_event_title ? $selected_event_title : __( 'Additional information', 'wpfaevent' ) ); ?>
+						</h2>
+						<p><?php esc_html_e( 'Venue, hotel, and transportation notes for attendees.', 'wpfaevent' ); ?></p>
+					</div>
+				</div>
+
+				<?php if ( $selected_event_id && $has_information ) : ?>
+					<div class="wpfa-event-rich-text wpfa-additional-information-body">
+						<?php echo wp_kses_post( wpautop( $venue_information ) ); ?>
+					</div>
+				<?php elseif ( $selected_event_id ) : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'No additional information has been added for this event yet.', 'wpfaevent' ); ?></p>
+				<?php else : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'Open this page from an event to view event-specific additional information.', 'wpfaevent' ); ?></p>
+				<?php endif; ?>
+			</div>
+		</section>
+	</main>
+
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
+</div>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/public/templates/page-events.php
+++ b/public/templates/page-events.php
@@ -22,11 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$wpfaevent_is_embed = ! empty( $GLOBALS['wpfaevent_template_embed'] );
-$today              = current_time( 'Y-m-d' );
-$events_per_page    = max( 1, (int) apply_filters( 'wpfa_events_per_page', 10 ) );
-$current_page       = max( 1, (int) get_query_var( 'paged', 1 ) );
-$is_admin           = current_user_can( 'manage_options' );
+$wpfaevent_is_embed  = ! empty( $GLOBALS['wpfaevent_template_embed'] );
+$today               = current_time( 'Y-m-d' );
+$events_per_page     = max( 1, (int) apply_filters( 'wpfa_events_per_page', 10 ) );
+$current_page        = max( 1, (int) get_query_var( 'paged', 1 ) );
+$can_manage_content  = Wpfaevent_Roles::current_user_can_manage_dashboard();
+$can_publish_content = Wpfaevent_Roles::current_user_can_publish_content();
 
 // Pull all published event IDs to replicate upstream's data handling pattern.
 $args = array(
@@ -47,7 +48,7 @@ foreach ( $event_ids as $eid ) {
 	$is_valid = ! empty( $start );
 
 	// Admins can see items even if the start date metadata is missing or broken.
-	if ( ! $is_valid && $is_admin ) {
+	if ( ! $is_valid && $can_manage_content ) {
 		$upcoming_events[] = array(
 			'id'    => (int) $eid,
 			'start' => '',
@@ -178,7 +179,7 @@ $header_vars = array(
 				<div class="main-content">
 					<div class="main-content-header">
 						<h1><?php esc_html_e( 'Events', 'wpfaevent' ); ?></h1>
-						<?php if ( $is_admin ) : ?>
+						<?php if ( $can_publish_content ) : ?>
 							<button id="createEventBtn" class="btn btn-primary">
 								<?php esc_html_e( 'Create Custom Event', 'wpfaevent' ); ?>
 							</button>
@@ -245,20 +246,10 @@ $header_vars = array(
 									$event_description = get_the_excerpt( $event_id );
 									$thumbnail_raw     = get_the_post_thumbnail_url( $event_id, 'large' );
 									$featured_img_url  = ! empty( $thumbnail_raw ) ? $thumbnail_raw : '';
-									$calendar_data     = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-									$calendar_data     = is_wp_error( $calendar_data ) ? array() : $calendar_data;
 
 									// Format descriptive timeline layout markers.
-									$formatted_date      = __( 'Date not set', 'wpfaevent' );
-									$formatted_time_meta = '';
-									if ( ! empty( $calendar_data['date_label'] ) ) {
-										$formatted_date      = sanitize_text_field( $calendar_data['date_label'] );
-										$formatted_time_meta = ! empty( $calendar_data['time_label'] ) ? sanitize_text_field( $calendar_data['time_label'] ) : '';
-
-										if ( $formatted_time_meta && empty( $calendar_data['all_day'] ) && ! empty( $calendar_data['timezone_label'] ) ) {
-											$formatted_time_meta .= ' (' . sanitize_text_field( $calendar_data['timezone_label'] ) . ')';
-										}
-									} elseif ( ! empty( $event_date ) ) {
+									$formatted_date = __( 'Date not set', 'wpfaevent' );
+									if ( ! empty( $event_date ) ) {
 										if ( ! empty( $event_end_date ) && $event_end_date !== $event_date ) {
 											$formatted_date = date_i18n( 'M j', strtotime( $event_date ) ) . ' - ' . date_i18n( 'M j, Y', strtotime( $event_end_date ) );
 										} else {
@@ -284,12 +275,9 @@ $header_vars = array(
 												<p>
 													<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
 														<path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"></path>
-														</svg>
-														<?php echo esc_html( $formatted_date ); ?>
-														<?php if ( $formatted_time_meta ) : ?>
-															<span class="event-card-time"><?php echo esc_html( ' | ' . $formatted_time_meta ); ?></span>
-														<?php endif; ?>
-													</p>
+													</svg>
+													<?php echo esc_html( $formatted_date ); ?>
+												</p>
 												<?php if ( ! empty( $event_place ) ) : ?>
 												<p>
 													<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -329,7 +317,7 @@ $header_vars = array(
 					} else {
 						echo '<p class="news-loading-text">' . esc_html__( 'Latest news feed loading...', 'wpfaevent' ) . '</p>';
 
-						if ( current_user_can( 'manage_options' ) ) {
+						if ( $can_manage_content ) {
 							echo '<div class="wpfaevent-admin-warning">';
 								echo '<svg class="wpfaevent-warning-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">';
 									echo '<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>';
@@ -356,7 +344,7 @@ $header_vars = array(
 <?php endif; ?>
 
 <?php
-if ( $is_admin ) {
+if ( $can_manage_content ) {
 	include WPFAEVENT_PATH . 'public/partials/events/event-modal.php';
 }
 ?>

--- a/public/templates/page-partner.php
+++ b/public/templates/page-partner.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Template Name: WPFA - Partner
+ *
+ * Displays full sponsor or exhibitor details for an event.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/templates
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$partner_request = class_exists( 'Wpfaevent_Partner_Helper' )
+	? Wpfaevent_Partner_Helper::resolve_partner_request()
+	: array(
+		'event_id'      => 0,
+		'event_slug'    => '',
+		'event_title'   => '',
+		'event_url'     => '',
+		'type'          => '',
+		'partner_key'   => '',
+		'partner'       => array(),
+		'group_name'    => '',
+		'partner_label' => '',
+	);
+
+$event_id         = absint( $partner_request['event_id'] );
+$event_title      = $partner_request['event_title'];
+$event_url        = $partner_request['event_url'];
+$partner_type     = $partner_request['type'];
+$partner          = $partner_request['partner'];
+$group_name       = $partner_request['group_name'];
+$partner_label    = $partner_request['partner_label'];
+$has_partner      = ! empty( $partner['name'] );
+$partner_name     = $has_partner ? sanitize_text_field( $partner['name'] ) : '';
+$description      = ! empty( $partner['description'] ) ? wp_kses_post( $partner['description'] ) : '';
+$website_link     = ! empty( $partner['link'] ) ? esc_url_raw( $partner['link'] ) : '';
+$logo_url         = '';
+$banner_url       = '';
+$video_url        = ! empty( $partner['video'] ) ? esc_url_raw( $partner['video'] ) : '';
+$slides_url       = ! empty( $partner['slides'] ) ? esc_url_raw( $partner['slides'] ) : '';
+$contact_link     = ! empty( $partner['contact_link'] ) ? esc_url_raw( $partner['contact_link'] ) : '';
+$contact_email    = ! empty( $partner['contact_email'] ) ? sanitize_email( $partner['contact_email'] ) : '';
+$event_style_attr = '';
+
+if ( 'sponsor' === $partner_type ) {
+	$logo_url = ! empty( $partner['image'] ) ? esc_url_raw( $partner['image'] ) : '';
+} else {
+	$logo_url   = ! empty( $partner['logo'] ) ? esc_url_raw( $partner['logo'] ) : '';
+	$banner_url = ! empty( $partner['banner'] ) ? esc_url_raw( $partner['banner'] ) : '';
+}
+
+if ( $event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$event_colors        = Wpfaevent_Meta_Event::get_event_colors( $event_id );
+	$event_color_var_map = array(
+		'wpfa_event_primary_color'          => '--event-primary',
+		'wpfa_event_hover_button_color'     => '--event-primary-dark',
+		'wpfa_event_theme_background_color' => '--event-soft',
+		'wpfa_event_theme_success_color'    => '--event-success',
+		'wpfa_event_theme_danger_color'     => '--event-danger',
+	);
+	$event_style_vars    = array();
+
+	foreach ( $event_color_var_map as $meta_key => $css_var ) {
+		if ( ! empty( $event_colors[ $meta_key ] ) ) {
+			$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+		}
+	}
+
+	$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+}
+
+$site_logo_url = get_option( 'wpfa_site_logo_url', '' );
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+
+$back_url = $event_url ? $event_url . '#exhibitors' : home_url( '/events/' );
+if ( 'sponsor' === $partner_type && $event_url ) {
+	$back_url = $event_url . '#sponsors';
+}
+
+$header_vars = array(
+	'site_logo_url'        => $site_logo_url,
+	'event_page_url'       => $event_url ? $event_url : home_url( '/events/' ),
+	'show_back_button'     => true,
+	'show_register_button' => false,
+	'back_button_text'     => $event_url ? __( 'Back to Event', 'wpfaevent' ) : __( 'Back to Events', 'wpfaevent' ),
+	'register_button_url'  => '',
+	'register_button_text' => __( 'Register', 'wpfaevent' ),
+);
+
+$partner_initial = $partner_name ? strtoupper( substr( $partner_name, 0, 1 ) ) : '';
+$has_links       = $website_link || $video_url || $slides_url || $contact_link || $contact_email;
+$partner_classes = array(
+	'wpfa-partner-detail',
+	$partner_type ? 'is-' . sanitize_html_class( $partner_type ) : 'is-partner',
+	$logo_url ? 'has-logo' : 'no-logo',
+	$banner_url ? 'has-banner' : 'no-banner',
+	$has_links ? 'has-links' : 'no-links',
+);
+$partner_label   = $partner_label ? $partner_label : __( 'Partner', 'wpfaevent' );
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class( 'wpfaevent wpfa-event-template wpfa-partner-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+	<?php
+	$site_logo_url        = $header_vars['site_logo_url'];
+	$event_page_url       = $header_vars['event_page_url'];
+	$show_back_button     = $header_vars['show_back_button'];
+	$show_register_button = $header_vars['show_register_button'];
+	$back_button_text     = $header_vars['back_button_text'];
+	$register_button_url  = $header_vars['register_button_url'];
+	$register_button_text = $header_vars['register_button_text'];
+
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
+
+	<main class="<?php echo esc_attr( implode( ' ', $partner_classes ) ); ?>">
+		<section class="wpfa-partner-detail-hero">
+			<div class="container">
+				<div class="wpfa-partner-detail-hero-inner">
+					<div class="wpfa-partner-detail-hero-copy">
+						<p class="wpfa-event-kicker"><?php echo esc_html( $partner_label ); ?></p>
+						<h1><?php echo esc_html( $partner_name ? $partner_name : __( 'Partner', 'wpfaevent' ) ); ?></h1>
+						<?php if ( $event_title ) : ?>
+							<p class="wpfa-partner-detail-lead">
+								<?php
+								printf(
+									/* translators: %s: event title. */
+									esc_html__( 'Details for %s.', 'wpfaevent' ),
+									esc_html( $event_title )
+								);
+								?>
+							</p>
+						<?php endif; ?>
+					</div>
+					<?php if ( $has_partner ) : ?>
+						<div class="wpfa-partner-detail-hero-meta" aria-label="<?php esc_attr_e( 'Partner summary', 'wpfaevent' ); ?>">
+							<span><?php echo esc_html( $partner_label ); ?></span>
+							<strong><?php echo esc_html( $event_title ? $event_title : __( 'Event partner', 'wpfaevent' ) ); ?></strong>
+							<?php if ( $group_name ) : ?>
+								<em><?php echo esc_html( $group_name ); ?></em>
+							<?php endif; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			</div>
+		</section>
+
+		<section class="wpfa-event-section wpfa-partner-detail-body" aria-labelledby="wpfa-partner-detail-title">
+			<div class="container">
+				<?php if ( $has_partner ) : ?>
+					<div class="wpfa-partner-detail-card">
+						<div class="wpfa-partner-detail-media">
+							<?php if ( $banner_url ) : ?>
+								<img class="wpfa-partner-detail-banner" src="<?php echo esc_url( $banner_url ); ?>" alt="<?php echo esc_attr( $partner_name ); ?>" loading="lazy">
+							<?php endif; ?>
+
+							<div class="wpfa-partner-detail-identity">
+								<?php if ( $logo_url ) : ?>
+									<div class="wpfa-partner-detail-logo">
+										<img src="<?php echo esc_url( $logo_url ); ?>" alt="<?php echo esc_attr( $partner_name ); ?>" loading="lazy">
+									</div>
+								<?php else : ?>
+									<div class="wpfa-event-exhibitor-placeholder" aria-hidden="true">
+										<?php echo esc_html( $partner_initial ); ?>
+									</div>
+								<?php endif; ?>
+								<div class="wpfa-partner-detail-identity-copy">
+									<span><?php echo esc_html( $partner_label ); ?></span>
+									<strong><?php echo esc_html( $partner_name ); ?></strong>
+								</div>
+							</div>
+
+							<?php if ( $group_name ) : ?>
+								<p class="wpfa-partner-detail-group"><?php echo esc_html( $group_name ); ?></p>
+							<?php endif; ?>
+						</div>
+
+						<div class="wpfa-partner-detail-content">
+							<div class="wpfa-partner-detail-header">
+								<p class="wpfa-event-kicker"><?php esc_html_e( 'Profile', 'wpfaevent' ); ?></p>
+								<h2 id="wpfa-partner-detail-title"><?php echo esc_html( $partner_name ); ?></h2>
+								<?php if ( $group_name ) : ?>
+									<p class="wpfa-partner-detail-meta"><?php echo esc_html( $group_name ); ?></p>
+								<?php endif; ?>
+							</div>
+
+							<?php if ( $description ) : ?>
+								<div class="wpfa-event-rich-text wpfa-partner-detail-description">
+									<?php echo wp_kses_post( wpautop( $description ) ); ?>
+								</div>
+							<?php else : ?>
+								<p class="wpfa-partner-detail-empty"><?php esc_html_e( 'No profile details have been added yet.', 'wpfaevent' ); ?></p>
+							<?php endif; ?>
+
+							<?php if ( $has_links ) : ?>
+								<div class="wpfa-event-exhibitor-links wpfa-partner-detail-links">
+									<?php if ( $website_link ) : ?>
+										<a href="<?php echo esc_url( $website_link ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Website', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+									<?php if ( $video_url ) : ?>
+										<a href="<?php echo esc_url( $video_url ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Video', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+									<?php if ( $slides_url ) : ?>
+										<a href="<?php echo esc_url( $slides_url ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Slides', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+									<?php if ( $contact_link ) : ?>
+										<a href="<?php echo esc_url( $contact_link ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Contact', 'wpfaevent' ); ?></a>
+									<?php elseif ( $contact_email ) : ?>
+										<a href="<?php echo esc_url( 'mailto:' . $contact_email ); ?>"><?php esc_html_e( 'Contact', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+								</div>
+							<?php endif; ?>
+						</div>
+					</div>
+
+					<p class="wpfa-partner-detail-back">
+						<a href="<?php echo esc_url( $back_url ); ?>"><?php esc_html_e( 'Back to event partners', 'wpfaevent' ); ?></a>
+					</p>
+				<?php elseif ( $event_id ) : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'This partner could not be found for the selected event.', 'wpfaevent' ); ?></p>
+				<?php else : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'Open a partner card from an event page to view full details.', 'wpfaevent' ); ?></p>
+				<?php endif; ?>
+			</div>
+		</section>
+	</main>
+
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
+</div>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/public/templates/page-past-events.php
+++ b/public/templates/page-past-events.php
@@ -156,23 +156,13 @@ $header_vars = array(
 						$location      = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
 						$event_url_raw = get_post_meta( $event_id, 'wpfa_event_url', true );
 						$event_url     = $event_url_raw ? esc_url( $event_url_raw ) : get_permalink();
-						$calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-						$calendar_data = is_wp_error( $calendar_data ) ? array() : $calendar_data;
 
 						$image_url = get_the_post_thumbnail_url( $event_id, 'medium' );
 
 						// Format date for display.
-						$display_date      = '';
-						$display_time_meta = '';
+						$display_date = '';
 
-						if ( ! empty( $calendar_data['date_label'] ) ) {
-							$display_date      = sanitize_text_field( $calendar_data['date_label'] );
-							$display_time_meta = ! empty( $calendar_data['time_label'] ) ? sanitize_text_field( $calendar_data['time_label'] ) : '';
-
-							if ( $display_time_meta && empty( $calendar_data['all_day'] ) && ! empty( $calendar_data['timezone_label'] ) ) {
-								$display_time_meta .= ' (' . sanitize_text_field( $calendar_data['timezone_label'] ) . ')';
-							}
-						} elseif ( ! empty( $start_date ) ) {
+						if ( ! empty( $start_date ) ) {
 							$start_datetime = date_create( $start_date );
 
 							if ( $start_datetime instanceof DateTime ) {
@@ -237,9 +227,6 @@ $header_vars = array(
 													<path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"></path>
 												</svg>
 												<?php echo esc_html( $display_date ); ?>
-												<?php if ( $display_time_meta ) : ?>
-													<span class="wpfa-past-event-card-time"><?php echo esc_html( ' | ' . $display_time_meta ); ?></span>
-												<?php endif; ?>
 											</div>
 										<?php endif; ?>
 										<?php if ( $location ) : ?>

--- a/public/templates/page-schedule.php
+++ b/public/templates/page-schedule.php
@@ -23,20 +23,92 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$wpfaevent_is_embed         = ! empty( $GLOBALS['wpfaevent_template_embed'] );
-$wpfaevent_use_theme_layout = ! $wpfaevent_is_embed && ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() );
+$wpfaevent_is_embed = ! empty( $GLOBALS['wpfaevent_template_embed'] );
+$events_per_page    = max( 1, (int) apply_filters( 'wpfa_schedule_events_per_page', 20 ) );
+$current_page       = max( 1, (int) get_query_var( 'paged', 1 ) );
+$schedule_page_url  = get_permalink();
 
-if ( $wpfaevent_use_theme_layout ) {
-	get_header();
+if ( ! $schedule_page_url && class_exists( 'Wpfaevent_Schedule_Helper' ) ) {
+	$schedule_page_url = Wpfaevent_Schedule_Helper::get_schedule_page_url();
 }
 
-$events_per_page = max( 1, (int) apply_filters( 'wpfa_schedule_events_per_page', 20 ) );
-$current_page    = max( 1, (int) get_query_var( 'paged', 1 ) );
+$read_filter_value = static function ( $key, $type = 'text' ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- These are read-only schedule filters.
+	if ( ! isset( $_GET[ $key ] ) ) {
+		return '';
+	}
 
-$site_timezone_string           = wp_timezone_string();
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized by type below.
+	$value = wp_unslash( $_GET[ $key ] );
+
+	if ( is_array( $value ) ) {
+		return '';
+	}
+
+	if ( 'slug' === $type ) {
+		return sanitize_title( $value );
+	}
+
+	if ( 'int' === $type ) {
+		return absint( $value );
+	}
+
+	return sanitize_text_field( $value );
+};
+
+$current_language     = $read_filter_value( 'language', 'slug' );
+$current_event_filter = $read_filter_value( 'event' );
+$current_view         = $read_filter_value( 'view', 'slug' );
+$query_page           = $read_filter_value( 'paged', 'int' );
+
+if ( $query_page ) {
+	$current_page = max( 1, $query_page );
+}
+
+if ( ! in_array( $current_view, array( 'list', 'calendar' ), true ) ) {
+	$current_view = 'list';
+}
+
+$resolve_event_filter = static function ( $event_filter ) {
+	$event_filter = trim( (string) $event_filter );
+
+	if ( '' === $event_filter ) {
+		return 0;
+	}
+
+	if ( is_numeric( $event_filter ) ) {
+		$event_id = absint( $event_filter );
+
+		return ( $event_id && 'wpfa_event' === get_post_type( $event_id ) ) ? $event_id : 0;
+	}
+
+	$events = get_posts(
+		array(
+			'name'           => sanitize_title( $event_filter ),
+			'post_type'      => 'wpfa_event',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		)
+	);
+
+	return ! empty( $events[0] ) ? absint( $events[0] ) : 0;
+};
+
+$selected_event_id   = $resolve_event_filter( $current_event_filter );
+$selected_event_slug = $selected_event_id ? get_post_field( 'post_name', $selected_event_id ) : '';
+
+$site_timezone_string    = wp_timezone_string();
+$primary_timezone_string = $site_timezone_string;
+
+if ( $selected_event_id && class_exists( 'Wpfaevent_Calendar' ) ) {
+	$primary_timezone_string = Wpfaevent_Calendar::get_event_timezone_string( $selected_event_id );
+}
+
 $selected_schedule_timezone_str = class_exists( 'Wpfaevent_Schedule_Helper' )
-	? Wpfaevent_Schedule_Helper::get_selected_timezone_string( $site_timezone_string )
-	: $site_timezone_string;
+	? Wpfaevent_Schedule_Helper::get_selected_timezone_string( $primary_timezone_string )
+	: $primary_timezone_string;
 
 try {
 	$selected_schedule_timezone = new DateTimeZone( $selected_schedule_timezone_str );
@@ -46,16 +118,84 @@ try {
 }
 
 $schedule_timezone_options = class_exists( 'Wpfaevent_Schedule_Helper' )
-	? Wpfaevent_Schedule_Helper::get_timezone_options( $site_timezone_string )
-	: array( $site_timezone_string, 'UTC' );
+	? Wpfaevent_Schedule_Helper::get_timezone_options( $primary_timezone_string )
+	: array( $primary_timezone_string, 'UTC' );
 
-$format_timezone_label = static function ( $timezone_string ) use ( $site_timezone_string ) {
+$build_schedule_view_url = static function ( $view ) use ( $schedule_page_url, $selected_event_slug, $current_language, $selected_schedule_timezone_str, $primary_timezone_string ) {
+	$args = array();
+
+	if ( $selected_event_slug ) {
+		$args['event'] = $selected_event_slug;
+	}
+
+	if ( $current_language ) {
+		$args['language'] = $current_language;
+	}
+
+	if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $primary_timezone_string ) {
+		$args['schedule_tz'] = $selected_schedule_timezone_str;
+	}
+
+	if ( 'calendar' === $view ) {
+		$args['view'] = 'calendar';
+	}
+
+	return add_query_arg( $args, $schedule_page_url );
+};
+
+$format_timezone_label = static function ( $timezone_string ) use ( $primary_timezone_string ) {
 	return class_exists( 'Wpfaevent_Schedule_Helper' )
-		? Wpfaevent_Schedule_Helper::format_timezone_label( $timezone_string, $site_timezone_string )
+		? Wpfaevent_Schedule_Helper::format_timezone_label( $timezone_string, $primary_timezone_string )
 		: str_replace( '_', ' ', $timezone_string );
 };
 
-$event_ids       = get_posts(
+$format_language_label = static function ( $language ) {
+	$language = trim( (string) $language );
+
+	if ( '' === $language ) {
+		return '';
+	}
+
+	$normalized = strtolower( str_replace( '_', '-', $language ) );
+	$labels     = array(
+		'ar'          => __( 'Arabic', 'wpfaevent' ),
+		'bn'          => __( 'Bengali', 'wpfaevent' ),
+		'bg'          => __( 'Bulgarian', 'wpfaevent' ),
+		'ca'          => __( 'Catalan', 'wpfaevent' ),
+		'cs'          => __( 'Czech', 'wpfaevent' ),
+		'da'          => __( 'Danish', 'wpfaevent' ),
+		'de'          => __( 'German', 'wpfaevent' ),
+		'en'          => __( 'English', 'wpfaevent' ),
+		'en-ca'       => __( 'English (Canada)', 'wpfaevent' ),
+		'es'          => __( 'Spanish', 'wpfaevent' ),
+		'fr'          => __( 'French', 'wpfaevent' ),
+		'gu'          => __( 'Gujarati', 'wpfaevent' ),
+		'hi'          => __( 'Hindi', 'wpfaevent' ),
+		'it'          => __( 'Italian', 'wpfaevent' ),
+		'ja'          => __( 'Japanese', 'wpfaevent' ),
+		'ko'          => __( 'Korean', 'wpfaevent' ),
+		'nl'          => __( 'Dutch', 'wpfaevent' ),
+		'nl-informal' => __( 'Dutch (Informal)', 'wpfaevent' ),
+		'pt'          => __( 'Portuguese', 'wpfaevent' ),
+		'ru'          => __( 'Russian', 'wpfaevent' ),
+		'si'          => __( 'Sinhala', 'wpfaevent' ),
+		'ta'          => __( 'Tamil', 'wpfaevent' ),
+		'zh-hans'     => __( 'Chinese (Simplified)', 'wpfaevent' ),
+		'zh-hant'     => __( 'Chinese (Traditional)', 'wpfaevent' ),
+	);
+
+	if ( isset( $labels[ $normalized ] ) ) {
+		return $labels[ $normalized ];
+	}
+
+	if ( false === strpos( $language, ' ' ) && preg_match( '/^[a-z]{2,3}(?:[-_][a-z0-9]+)*$/i', $language ) ) {
+		return ucwords( str_replace( '-', ' ', $normalized ) );
+	}
+
+	return $language;
+};
+
+$event_ids              = get_posts(
 	array(
 		'post_type'      => 'wpfa_event',
 		'post_status'    => 'publish',
@@ -64,18 +204,54 @@ $event_ids       = get_posts(
 		'no_found_rows'  => true,
 	)
 );
-$schedule_events = array();
+$schedule_events        = array();
+$languages              = array();
+$filtered_event_ids     = array();
+$is_event_schedule      = (bool) $selected_event_id;
+$event_session_schedule = array(
+	'items'  => array(),
+	'groups' => array(),
+);
 
 foreach ( $event_ids as $event_id ) {
-	$entry = class_exists( 'Wpfaevent_Schedule_Helper' )
-		? Wpfaevent_Schedule_Helper::build_event_schedule_entry( $event_id, $selected_schedule_timezone )
-		: null;
+	$event_id        = absint( $event_id );
+	$event_languages = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_language_list( get_post_meta( $event_id, 'wpfa_event_languages', true ) ) : array();
+	$language_keys   = array_map( 'sanitize_title', $event_languages );
 
-	if ( ! $entry ) {
+	if ( $selected_event_id && $selected_event_id !== $event_id ) {
 		continue;
 	}
 
-	$schedule_events[] = $entry;
+	foreach ( $event_languages as $language ) {
+		$languages[ sanitize_title( $language ) ] = $format_language_label( $language );
+	}
+
+	if ( $current_language && ! in_array( $current_language, $language_keys, true ) ) {
+		continue;
+	}
+
+	$filtered_event_ids[] = $event_id;
+
+	if ( ! $is_event_schedule ) {
+		$entry = class_exists( 'Wpfaevent_Schedule_Helper' )
+			? Wpfaevent_Schedule_Helper::build_event_schedule_entry( $event_id, $selected_schedule_timezone )
+			: null;
+
+		if ( ! $entry ) {
+			continue;
+		}
+
+		$entry['languages']      = $event_languages;
+		$entry['language_keys']  = $language_keys;
+		$entry['language_label'] = implode( ', ', array_map( $format_language_label, $event_languages ) );
+		$schedule_events[]       = $entry;
+	}
+}
+
+asort( $languages );
+
+if ( $is_event_schedule && in_array( $selected_event_id, $filtered_event_ids, true ) && class_exists( 'Wpfaevent_Schedule_Helper' ) ) {
+	$event_session_schedule = Wpfaevent_Schedule_Helper::build_event_session_schedule( $selected_event_id, $selected_schedule_timezone );
 }
 
 usort(
@@ -111,6 +287,29 @@ foreach ( $paged_schedule_events as $schedule_event ) {
 	$groups[ $group_key ]['events'][] = $schedule_event;
 }
 
+$selected_event_title = $selected_event_id ? get_the_title( $selected_event_id ) : '';
+$event_style_attr     = '';
+
+if ( $selected_event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$event_colors        = Wpfaevent_Meta_Event::get_event_colors( $selected_event_id );
+	$event_color_var_map = array(
+		'wpfa_event_primary_color'          => '--event-primary',
+		'wpfa_event_hover_button_color'     => '--event-primary-dark',
+		'wpfa_event_theme_background_color' => '--event-soft',
+		'wpfa_event_theme_success_color'    => '--event-success',
+		'wpfa_event_theme_danger_color'     => '--event-danger',
+	);
+	$event_style_vars    = array();
+
+	foreach ( $event_color_var_map as $meta_key => $css_var ) {
+		if ( ! empty( $event_colors[ $meta_key ] ) ) {
+			$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+		}
+	}
+
+	$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+}
+
 $site_logo_url = get_option( 'wpfa_site_logo_url', '' );
 if ( empty( $site_logo_url ) ) {
 	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
@@ -127,9 +326,12 @@ $header_vars = array(
 	'register_button_text' => __( 'Register', 'wpfaevent' ),
 );
 
-$schedule_page_url = get_permalink();
+$filter_form_classes = 'wpfa-schedule-filter-form';
+if ( ! empty( $languages ) ) {
+	$filter_form_classes .= ' has-language-filter';
+}
 ?>
-<?php if ( ! $wpfaevent_is_embed && ! $wpfaevent_use_theme_layout ) : ?>
+<?php if ( ! $wpfaevent_is_embed ) : ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
@@ -137,7 +339,7 @@ $schedule_page_url = get_permalink();
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<?php wp_head(); ?>
 </head>
-<body <?php body_class( 'wpfaevent wpfa-schedule-template' ); ?>>
+<body <?php body_class( 'wpfaevent wpfa-schedule-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
 	<?php wp_body_open(); ?>
 
 <div id="page" class="site">
@@ -158,100 +360,367 @@ $schedule_page_url = get_permalink();
 <?php endif; ?>
 
 <?php if ( $wpfaevent_is_embed ) : ?>
-<section class="wpfa-schedule">
+	<section class="wpfa-schedule">
 <?php else : ?>
-<main class="wpfa-schedule">
+	<main class="wpfa-schedule">
 <?php endif; ?>
-	<div class="container">
-		<div class="wpfa-schedule-head">
-			<div>
-				<h1><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></h1>
-				<p><?php esc_html_e( 'Upcoming events grouped by start date.', 'wpfaevent' ); ?></p>
+		<div class="container">
+			<div class="wpfa-schedule-head">
+				<div>
+					<?php if ( $is_event_schedule && $selected_event_title ) : ?>
+						<h1><?php echo esc_html( $selected_event_title ); ?></h1>
+						<p><?php esc_html_e( 'Event schedule grouped by session date.', 'wpfaevent' ); ?></p>
+					<?php else : ?>
+						<h1><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></h1>
+						<p><?php esc_html_e( 'Upcoming events grouped by start date.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</div>
+				<?php if ( ! empty( $event_ids ) ) : ?>
+					<div class="wpfa-schedule-controls">
+						<nav class="wpfa-schedule-view-switch" aria-label="<?php esc_attr_e( 'Schedule view', 'wpfaevent' ); ?>">
+							<a
+								class="<?php echo esc_attr( 'list' === $current_view ? 'is-active' : '' ); ?>"
+								href="<?php echo esc_url( $build_schedule_view_url( 'list' ) ); ?>"
+								<?php if ( 'list' === $current_view ) : ?>
+									aria-current="page"
+								<?php endif; ?>
+							>
+								<?php esc_html_e( 'List', 'wpfaevent' ); ?>
+							</a>
+							<a
+								class="<?php echo esc_attr( 'calendar' === $current_view ? 'is-active' : '' ); ?>"
+								href="<?php echo esc_url( $build_schedule_view_url( 'calendar' ) ); ?>"
+								<?php if ( 'calendar' === $current_view ) : ?>
+									aria-current="page"
+								<?php endif; ?>
+							>
+								<?php esc_html_e( 'Calendar', 'wpfaevent' ); ?>
+							</a>
+						</nav>
+						<form class="<?php echo esc_attr( $filter_form_classes ); ?>" action="<?php echo esc_url( $schedule_page_url ); ?>" method="get">
+							<?php if ( $selected_event_slug ) : ?>
+								<input type="hidden" name="event" value="<?php echo esc_attr( $selected_event_slug ); ?>">
+							<?php endif; ?>
+							<?php if ( 'calendar' === $current_view ) : ?>
+								<input type="hidden" name="view" value="calendar">
+							<?php endif; ?>
+							<?php if ( ! empty( $languages ) ) : ?>
+								<label for="wpfa-schedule-language">
+									<span><?php esc_html_e( 'Language', 'wpfaevent' ); ?></span>
+									<select id="wpfa-schedule-language" name="language">
+										<option value=""><?php esc_html_e( 'All languages', 'wpfaevent' ); ?></option>
+										<?php foreach ( $languages as $language_key => $language_label ) : ?>
+											<option value="<?php echo esc_attr( $language_key ); ?>" <?php selected( $current_language, $language_key ); ?>>
+												<?php echo esc_html( $language_label ); ?>
+											</option>
+										<?php endforeach; ?>
+									</select>
+								</label>
+							<?php endif; ?>
+							<label for="wpfa-schedule-timezone">
+								<span><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></span>
+								<select id="wpfa-schedule-timezone" class="wpfa-event-timezone-select" name="schedule_tz">
+									<?php foreach ( $schedule_timezone_options as $timezone_option ) : ?>
+										<option value="<?php echo esc_attr( $timezone_option ); ?>" <?php selected( $selected_schedule_timezone_str, $timezone_option ); ?>>
+											<?php echo esc_html( $format_timezone_label( $timezone_option ) ); ?>
+										</option>
+									<?php endforeach; ?>
+								</select>
+							</label>
+							<button type="submit"><?php esc_html_e( 'Apply', 'wpfaevent' ); ?></button>
+						</form>
+					</div>
+				<?php endif; ?>
 			</div>
-			<?php if ( ! empty( $schedule_events ) ) : ?>
-				<form class="wpfa-event-timezone-form" action="<?php echo esc_url( $schedule_page_url ); ?>" method="get">
-					<label for="wpfa-schedule-timezone">
-						<span><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></span>
-						<select id="wpfa-schedule-timezone" class="wpfa-event-timezone-select" name="schedule_tz">
-							<?php foreach ( $schedule_timezone_options as $timezone_option ) : ?>
-								<option value="<?php echo esc_attr( $timezone_option ); ?>" <?php selected( $selected_schedule_timezone_str, $timezone_option ); ?>>
-									<?php echo esc_html( $format_timezone_label( $timezone_option ) ); ?>
-								</option>
+
+			<?php if ( $is_event_schedule ) : ?>
+				<?php if ( ! empty( $event_session_schedule['groups'] ) ) : ?>
+					<?php if ( 'calendar' === $current_view ) : ?>
+						<div class="wpfa-schedule-calendar" role="list">
+							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading">
+									<header class="wpfa-schedule-calendar-day-head">
+										<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading"><?php echo esc_html( $day_label ); ?></h2>
+										<span>
+											<?php
+											printf(
+												/* translators: %d: number of sessions on this day. */
+												esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+												absint( count( $day_sessions ) )
+											);
+											?>
+										</span>
+									</header>
+									<div class="wpfa-schedule-calendar-slots">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-calendar-slot">
+												<?php if ( ! empty( $item['time_label'] ) ) : ?>
+													<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+												<?php endif; ?>
+												<h3><?php echo esc_html( $item['title'] ); ?></h3>
+												<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+													<ul class="wpfa-schedule-calendar-meta">
+														<?php if ( ! empty( $item['speakers'] ) ) : ?>
+															<li><?php echo esc_html( $item['speakers'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['room'] ) ) : ?>
+															<li><?php echo esc_html( $item['room'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['track'] ) ) : ?>
+															<li><?php echo esc_html( $item['track'] ); ?></li>
+														<?php endif; ?>
+													</ul>
+												<?php endif; ?>
+												<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+													<?php
+													$session_calendar_label = sprintf(
+														/* translators: %s: session title. */
+														__( 'Add %s to Google Calendar', 'wpfaevent' ),
+														$item['title']
+													);
+													?>
+													<a
+														class="wpfa-schedule-session-calendar"
+														href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+														target="_blank"
+														rel="noopener"
+														aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+													>
+														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+													</a>
+												<?php endif; ?>
+											</article>
+										<?php endforeach; ?>
+									</div>
+								</section>
 							<?php endforeach; ?>
-						</select>
-					</label>
-					<button type="submit"><?php esc_html_e( 'Convert', 'wpfaevent' ); ?></button>
-				</form>
+						</div>
+					<?php else : ?>
+						<div class="wpfa-schedule-program">
+							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+									<header class="wpfa-schedule-day-head">
+										<div>
+											<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h2>
+											<p>
+												<?php
+												printf(
+													/* translators: %d: number of sessions on this day. */
+													esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+													absint( count( $day_sessions ) )
+												);
+												?>
+											</p>
+										</div>
+									</header>
+
+									<div class="wpfa-schedule-day-sessions" role="list">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-session" role="listitem">
+												<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+													<?php if ( ! empty( $item['time_start'] ) ) : ?>
+														<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+															<?php echo esc_html( $item['time_start'] ); ?>
+														</time>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['time_end'] ) ) : ?>
+														<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
+													<?php endif; ?>
+												</div>
+
+												<div class="wpfa-schedule-session-main">
+													<h3 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h3>
+
+													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+														<dl class="wpfa-schedule-session-details">
+															<?php if ( ! empty( $item['speakers'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Speaker', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['speakers'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['room'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Room', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['room'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['track'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Track', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['track'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+														</dl>
+													<?php endif; ?>
+
+													<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+														<?php
+														$session_calendar_label = sprintf(
+															/* translators: %s: session title. */
+															__( 'Add %s to Google Calendar', 'wpfaevent' ),
+															$item['title']
+														);
+														?>
+														<a
+															class="wpfa-schedule-session-calendar"
+															href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+															target="_blank"
+															rel="noopener"
+															aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+														>
+															<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+														</a>
+													<?php endif; ?>
+												</div>
+											</article>
+										<?php endforeach; ?>
+									</div>
+								</section>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+				<?php else : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
+				<?php endif; ?>
+			<?php elseif ( $groups ) : ?>
+				<?php if ( 'calendar' === $current_view ) : ?>
+					<div class="wpfa-schedule-calendar" role="list">
+						<?php foreach ( $groups as $group ) : ?>
+							<section class="wpfa-schedule-calendar-day" role="listitem">
+								<header class="wpfa-schedule-calendar-day-head">
+									<h2><?php echo esc_html( $group['date'] ); ?></h2>
+									<span>
+										<?php
+										printf(
+											/* translators: %d: number of events on this day. */
+											esc_html( _n( '%d event', '%d events', count( $group['events'] ), 'wpfaevent' ) ),
+											absint( count( $group['events'] ) )
+										);
+										?>
+									</span>
+								</header>
+								<div class="wpfa-schedule-calendar-slots">
+									<?php foreach ( $group['events'] as $schedule_event ) : ?>
+										<article class="wpfa-schedule-calendar-slot">
+											<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
+												<time><?php echo esc_html( $schedule_event['time_label'] ); ?></time>
+											<?php endif; ?>
+											<h3>
+												<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
+													<?php echo esc_html( $schedule_event['title'] ); ?>
+												</a>
+											</h3>
+											<?php if ( ! empty( $schedule_event['location'] ) || ! empty( $schedule_event['language_label'] ) ) : ?>
+												<ul class="wpfa-schedule-calendar-meta">
+													<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
+														<li><?php echo esc_html( $schedule_event['location'] ); ?></li>
+													<?php endif; ?>
+													<?php if ( ! empty( $schedule_event['language_label'] ) ) : ?>
+														<li><?php echo esc_html( $schedule_event['language_label'] ); ?></li>
+													<?php endif; ?>
+												</ul>
+											<?php endif; ?>
+											<div class="wpfa-schedule-calendar-actions">
+												<a href="<?php echo esc_url( $schedule_event['schedule_url'] ); ?>"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></a>
+												<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
+													<?php
+													$calendar_label = sprintf(
+														/* translators: %s: event title. */
+														__( 'Add %s to Google Calendar', 'wpfaevent' ),
+														$schedule_event['title']
+													);
+													?>
+													<a
+														href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
+														target="_blank"
+														rel="noopener"
+														aria-label="<?php echo esc_attr( $calendar_label ); ?>"
+													>
+														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+													</a>
+												<?php endif; ?>
+											</div>
+										</article>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endforeach; ?>
+					</div>
+				<?php else : ?>
+					<?php foreach ( $groups as $group ) : ?>
+						<section class="wpfa-schedule-group">
+							<h2 class="wpfa-schedule-date"><?php echo esc_html( $group['date'] ); ?></h2>
+							<ul class="wpfa-schedule-items">
+								<?php foreach ( $group['events'] as $schedule_event ) : ?>
+									<li class="wpfa-schedule-item">
+										<strong>
+											<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
+												<?php echo esc_html( $schedule_event['title'] ); ?>
+											</a>
+										</strong>
+										<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
+											<span class="wpfa-schedule-time"><?php echo esc_html( $schedule_event['time_label'] ); ?></span>
+										<?php endif; ?>
+										<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
+											<span class="wpfa-schedule-location"><?php echo esc_html( $schedule_event['location'] ); ?></span>
+										<?php endif; ?>
+										<?php if ( ! empty( $schedule_event['language_label'] ) ) : ?>
+											<span class="wpfa-schedule-language"><?php echo esc_html( $schedule_event['language_label'] ); ?></span>
+										<?php endif; ?>
+										<span class="wpfa-schedule-actions">
+											<a href="<?php echo esc_url( $schedule_event['schedule_url'] ); ?>"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></a>
+										</span>
+										<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
+											<?php
+											$calendar_label = sprintf(
+												/* translators: %s: event title. */
+												__( 'Add %s to Google Calendar', 'wpfaevent' ),
+												$schedule_event['title']
+											);
+											?>
+											<a
+												class="wpfa-calendar-action"
+												href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
+												target="_blank"
+												rel="noopener"
+												aria-label="<?php echo esc_attr( $calendar_label ); ?>"
+											>
+												<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+											</a>
+										<?php endif; ?>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+						</section>
+					<?php endforeach; ?>
+				<?php endif; ?>
+
+				<?php
+				$total           = max( 1, (int) ceil( $total_events / $events_per_page ) );
+				$pagination_args = array();
+				if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $site_timezone_string ) {
+					$pagination_args['schedule_tz'] = $selected_schedule_timezone_str;
+				}
+				if ( $current_language ) {
+					$pagination_args['language'] = $current_language;
+				}
+				if ( 'calendar' === $current_view ) {
+					$pagination_args['view'] = 'calendar';
+				}
+				wpfa_render_pagination( $total, $current_page, __( 'Schedule pagination', 'wpfaevent' ), $pagination_args );
+				?>
+			<?php else : ?>
+				<p><?php esc_html_e( 'No schedule entries yet.', 'wpfaevent' ); ?></p>
 			<?php endif; ?>
 		</div>
-
-		<?php if ( $groups ) : ?>
-			<?php foreach ( $groups as $group ) : ?>
-				<section class="wpfa-schedule-group">
-					<h2 class="wpfa-schedule-date"><?php echo esc_html( $group['date'] ); ?></h2>
-					<ul class="wpfa-schedule-items">
-						<?php foreach ( $group['events'] as $schedule_event ) : ?>
-							<li class="wpfa-schedule-item">
-								<strong>
-									<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
-										<?php echo esc_html( $schedule_event['title'] ); ?>
-									</a>
-								</strong>
-								<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
-									<span class="wpfa-schedule-time"><?php echo esc_html( $schedule_event['time_label'] ); ?></span>
-								<?php endif; ?>
-								<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
-									<span class="wpfa-schedule-location"><?php echo esc_html( $schedule_event['location'] ); ?></span>
-								<?php endif; ?>
-								<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
-									<?php
-									$calendar_label = sprintf(
-										/* translators: %s: event title. */
-										__( 'Add %s to Google Calendar', 'wpfaevent' ),
-										$schedule_event['title']
-									);
-									?>
-									<a
-										class="wpfa-calendar-action"
-										href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
-										target="_blank"
-										rel="noopener"
-										aria-label="<?php echo esc_attr( $calendar_label ); ?>"
-									>
-										<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-									</a>
-								<?php endif; ?>
-							</li>
-						<?php endforeach; ?>
-					</ul>
-				</section>
-			<?php endforeach; ?>
-
-			<?php
-			$total           = max( 1, (int) ceil( $total_events / $events_per_page ) );
-			$pagination_args = array();
-			if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $site_timezone_string ) {
-				$pagination_args['schedule_tz'] = $selected_schedule_timezone_str;
-			}
-			wpfa_render_pagination( $total, $current_page, __( 'Schedule pagination', 'wpfaevent' ), $pagination_args );
-			?>
-		<?php else : ?>
-			<p><?php esc_html_e( 'No schedule entries yet.', 'wpfaevent' ); ?></p>
-		<?php endif; ?>
-	</div>
 <?php if ( $wpfaevent_is_embed ) : ?>
-</section>
+	</section>
 <?php else : ?>
-</main>
-<?php endif; ?>
-
-<?php if ( ! $wpfaevent_is_embed && ! $wpfaevent_use_theme_layout ) : ?>
-	<?php require WPFAEVENT_PATH . 'public/partials/footer.php'; ?>
+	</main>
 </div>
 
 	<?php wp_footer(); ?>
 </body>
 </html>
-<?php elseif ( $wpfaevent_use_theme_layout ) : ?>
-	<?php get_footer(); ?>
 <?php endif; ?>

--- a/public/templates/page-speakers.php
+++ b/public/templates/page-speakers.php
@@ -24,59 +24,212 @@ $wpfaevent_is_embed = ! empty( $GLOBALS['wpfaevent_template_embed'] );
 $current_page = max( 1, (int) get_query_var( 'paged', 1 ) );
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end search filtering via query args.
 $search_term = isset( $_GET['q'] ) ? sanitize_text_field( wp_unslash( $_GET['q'] ) ) : '';
-
-// Query speakers from the CPT.
-$speakers_per_page = max( 1, (int) apply_filters( 'wpfa_speakers_per_page', 24 ) );
-$args              = array(
-	'post_type'      => 'wpfa_speaker',
-	'post_status'    => 'publish',
-	'posts_per_page' => $speakers_per_page,
-	'paged'          => $current_page,
-	'orderby'        => 'title',
-	'order'          => 'ASC',
-	's'              => $search_term,
-	'fields'         => 'ids',
-);
-
-// Add the category filter if it is set.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end category filtering via query args.
-if ( isset( $_GET['category'] ) && ! empty( $_GET['category'] ) ) {
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end category filtering via query args.
-	$category = sanitize_text_field( wp_unslash( $_GET['category'] ) );
-	if ( 'all' !== $category ) {
-		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Required to filter speakers by selected taxonomy term.
-		$args['tax_query'] = array(
-			array(
-				'taxonomy' => 'wpfa_speaker_category',
-				'field'    => 'slug',
-				'terms'    => sanitize_title( $category ),
-			),
-		);
+$current_category = isset( $_GET['category'] ) ? sanitize_title( wp_unslash( $_GET['category'] ) ) : 'all';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end event filtering via query args.
+$current_event_filter = isset( $_GET['event'] ) ? sanitize_text_field( wp_unslash( $_GET['event'] ) ) : '';
+
+$speakers_per_page = max( 1, (int) apply_filters( 'wpfa_speakers_per_page', 24 ) );
+
+$read_dashboard_json = static function ( $filename, $fallback ) {
+	$upload_dir = wp_upload_dir();
+
+	if ( ! empty( $upload_dir['error'] ) ) {
+		return $fallback;
+	}
+
+	$path = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/' . sanitize_file_name( $filename );
+
+	if ( ! file_exists( $path ) || ! is_readable( $path ) ) {
+		return $fallback;
+	}
+
+	$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading plugin-managed JSON from uploads.
+	if ( false === $contents || '' === trim( $contents ) ) {
+		return $fallback;
+	}
+
+	$decoded = json_decode( $contents, true );
+
+	return ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) ? $decoded : $fallback;
+};
+
+$normalize_post_id_list = static function ( $post_ids ) {
+	if ( ! is_array( $post_ids ) ) {
+		return array();
+	}
+
+	$post_ids = array_map( 'absint', $post_ids );
+	$post_ids = array_filter( $post_ids );
+
+	return array_values( array_unique( $post_ids ) );
+};
+
+$get_event_speaker_ids = static function ( $event_id ) use ( $normalize_post_id_list ) {
+	$event_id = absint( $event_id );
+
+	if ( ! $event_id ) {
+		return array();
+	}
+
+	if ( class_exists( 'Wpfaevent_Meta_Event' ) ) {
+		return Wpfaevent_Meta_Event::get_admin_event_speaker_ids( $event_id );
+	}
+
+	return $normalize_post_id_list( get_post_meta( $event_id, 'wpfa_event_speakers', true ) );
+};
+
+$selected_event_id = 0;
+if ( '' !== trim( $current_event_filter ) ) {
+	if ( is_numeric( $current_event_filter ) ) {
+		$candidate_event_id = absint( $current_event_filter );
+		if ( $candidate_event_id && 'wpfa_event' === get_post_type( $candidate_event_id ) ) {
+			$selected_event_id = $candidate_event_id;
+		}
+	} else {
+		$candidate_event = get_page_by_path( sanitize_title( $current_event_filter ), OBJECT, 'wpfa_event' );
+		if ( $candidate_event instanceof WP_Post ) {
+			$selected_event_id = absint( $candidate_event->ID );
+		}
 	}
 }
 
-$speakers_query = new WP_Query( $args );
+$event_filter_posts = get_posts(
+	array(
+		'post_type'      => 'wpfa_event',
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'orderby'        => 'title',
+		'order'          => 'ASC',
+		'no_found_rows'  => true,
+	)
+);
 
-// Get all categories, including empty ones for admin filtering.
-$categories = array();
-if ( taxonomy_exists( 'wpfa_speaker_category' ) ) {
-	$terms = get_terms(
-		array(
-			'taxonomy'   => 'wpfa_speaker_category',
-			'hide_empty' => false, // Show all categories for admin filtering.
-			'orderby'    => 'name',
-			'order'      => 'ASC',
+$dashboard_speakers = $selected_event_id ? $read_dashboard_json( 'speakers-' . absint( $selected_event_id ) . '.json', array() ) : array();
+
+if ( $selected_event_id ) {
+	$speaker_ids = $get_event_speaker_ids( $selected_event_id );
+	$speaker_ids = array_values(
+		array_filter(
+			$speaker_ids,
+			static function ( $speaker_id ) use ( $search_term ) {
+				if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) || 'publish' !== get_post_status( $speaker_id ) ) {
+					return false;
+				}
+
+				if ( '' === trim( $search_term ) ) {
+					return true;
+				}
+
+				$haystack = get_the_title( $speaker_id ) . ' ' . get_post_field( 'post_content', $speaker_id );
+
+				return false !== stripos( $haystack, $search_term );
+			}
 		)
 	);
 
-	if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
-		$categories = $terms;
+	usort(
+		$speaker_ids,
+		static function ( $speaker_a, $speaker_b ) {
+			return strcasecmp( get_the_title( $speaker_a ), get_the_title( $speaker_b ) );
+		}
+	);
+} else {
+	$speaker_ids = array();
+}
+
+$featured_speaker_ids = array();
+if ( $selected_event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$featured_speaker_ids = Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $selected_event_id, $speaker_ids, $dashboard_speakers );
+	$featured_speaker_ids = array_values( array_intersect( $featured_speaker_ids, $speaker_ids ) );
+}
+
+$category_source_speaker_ids = $speaker_ids;
+
+if ( 'all' !== $current_category && taxonomy_exists( 'wpfa_speaker_category' ) ) {
+	$speaker_ids = array_values(
+		array_filter(
+			$speaker_ids,
+			static function ( $speaker_id ) use ( $current_category ) {
+				return has_term( $current_category, 'wpfa_speaker_category', $speaker_id );
+			}
+		)
+	);
+}
+
+$featured_speaker_ids = array_values( array_intersect( $featured_speaker_ids, $speaker_ids ) );
+
+if ( ! empty( $featured_speaker_ids ) ) {
+	usort(
+		$speaker_ids,
+		static function ( $speaker_a, $speaker_b ) use ( $featured_speaker_ids ) {
+			$speaker_a_is_featured = in_array( absint( $speaker_a ), $featured_speaker_ids, true );
+			$speaker_b_is_featured = in_array( absint( $speaker_b ), $featured_speaker_ids, true );
+
+			if ( $speaker_a_is_featured !== $speaker_b_is_featured ) {
+				return $speaker_a_is_featured ? -1 : 1;
+			}
+
+			return strcasecmp( get_the_title( $speaker_a ), get_the_title( $speaker_b ) );
+		}
+	);
+}
+
+$total_speakers = count( $speaker_ids );
+
+// Event speaker lists should show everyone; the event page keeps a smaller preview set.
+if ( $selected_event_id ) {
+	$paged_speaker_ids = $speaker_ids;
+} else {
+	$speaker_offset    = ( $current_page - 1 ) * $speakers_per_page;
+	$paged_speaker_ids = array_slice( $speaker_ids, $speaker_offset, $speakers_per_page );
+}
+
+$featured_display_speaker_ids = array_values( array_intersect( $paged_speaker_ids, $featured_speaker_ids ) );
+$regular_display_speaker_ids  = array_values( array_diff( $paged_speaker_ids, $featured_display_speaker_ids ) );
+
+// Get categories; when an event is selected, keep category counts event-specific.
+$categories           = array();
+$category_term_counts = array();
+if ( taxonomy_exists( 'wpfa_speaker_category' ) ) {
+	if ( $selected_event_id ) {
+		foreach ( $category_source_speaker_ids as $speaker_id ) {
+			$terms = wp_get_post_terms( $speaker_id, 'wpfa_speaker_category' );
+
+			if ( is_wp_error( $terms ) || empty( $terms ) ) {
+				continue;
+			}
+
+			foreach ( $terms as $speaker_term ) {
+				$category_term_counts[ $speaker_term->term_id ] = isset( $category_term_counts[ $speaker_term->term_id ] ) ? $category_term_counts[ $speaker_term->term_id ] + 1 : 1;
+			}
+		}
+
+		if ( ! empty( $category_term_counts ) ) {
+			$terms = get_terms(
+				array(
+					'taxonomy'   => 'wpfa_speaker_category',
+					'include'    => array_keys( $category_term_counts ),
+					'hide_empty' => false,
+					'orderby'    => 'name',
+					'order'      => 'ASC',
+				)
+			);
+
+			if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+				$categories = $terms;
+			}
+		}
 	}
 }
 
-// Get the current category from the URL.
-// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end category filtering via query args.
-$current_category = isset( $_GET['category'] ) ? sanitize_title( wp_unslash( $_GET['category'] ) ) : 'all';
+$selected_event_slug      = $selected_event_id ? get_post_field( 'post_name', $selected_event_id ) : '';
+$selected_event_title     = $selected_event_id ? get_the_title( $selected_event_id ) : '';
+$selected_event_permalink = $selected_event_id ? get_permalink( $selected_event_id ) : home_url( '/events/' );
+$selected_event_url       = $selected_event_id ? get_post_meta( $selected_event_id, 'wpfa_event_url', true ) : '';
+$selected_event_url       = $selected_event_url ? $selected_event_url : $selected_event_permalink;
+$speakers_base_url        = get_post_type_archive_link( 'wpfa_speaker' );
+$speakers_base_url        = $speakers_base_url ? $speakers_base_url : home_url( '/speakers/' );
 
 // Get the site logo.
 $site_logo_url = get_option( 'wpfa_site_logo_url', '' );
@@ -86,14 +239,14 @@ if ( empty( $site_logo_url ) ) {
 $site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
 
 // Set up header variables for the partial.
-$register_button_url = get_option( 'wpfa_register_button_url', 'https://eventyay.com/e/4c0e0c27' );
+$register_button_url = $selected_event_id ? $selected_event_url : get_option( 'wpfa_register_button_url', 'https://eventyay.com/e/4c0e0c27' );
 $register_button_url = apply_filters( 'wpfa_register_button_url', $register_button_url );
 $header_vars         = array(
 	'site_logo_url'        => $site_logo_url,
-	'event_page_url'       => home_url( '/events/' ),
+	'event_page_url'       => $selected_event_permalink,
 	'show_back_button'     => true,
 	'show_register_button' => true,
-	'back_button_text'     => __( 'Back to Event', 'wpfaevent' ),
+	'back_button_text'     => $selected_event_id ? __( 'Back to Event', 'wpfaevent' ) : __( 'Back to Events', 'wpfaevent' ),
 	'register_button_url'  => $register_button_url,
 	'register_button_text' => __( 'Register', 'wpfaevent' ),
 );
@@ -110,74 +263,139 @@ $header_vars         = array(
 <body <?php body_class( 'wpfaevent' ); ?>>
 	<?php wp_body_open(); ?>
 
-		<div id="page" class="site">
-		<?php
-		// Load the shared navigation header.
-		$site_logo_url        = $header_vars['site_logo_url'];
-		$event_page_url       = $header_vars['event_page_url'];
-		$show_back_button     = $header_vars['show_back_button'];
-		$show_register_button = $header_vars['show_register_button'];
-		$back_button_text     = $header_vars['back_button_text'];
-		$register_button_url  = $header_vars['register_button_url'];
-		$register_button_text = $header_vars['register_button_text'];
+<div id="page" class="site">
+	<?php
+	// Load the shared navigation header.
+	$site_logo_url        = $header_vars['site_logo_url'];
+	$event_page_url       = $header_vars['event_page_url'];
+	$show_back_button     = $header_vars['show_back_button'];
+	$show_register_button = $header_vars['show_register_button'];
+	$back_button_text     = $header_vars['back_button_text'];
+	$register_button_url  = $header_vars['register_button_url'];
+	$register_button_text = $header_vars['register_button_text'];
 
-		$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
-		if ( file_exists( $nav_partial ) ) {
-			include $nav_partial;
-		}
-		?>
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
 <?php endif; ?>
 
-	<?php if ( $wpfaevent_is_embed ) : ?>
+<?php if ( $wpfaevent_is_embed ) : ?>
 	<section class="wpfa-speakers">
-	<?php else : ?>
+<?php else : ?>
 	<main class="wpfa-speakers">
-	<?php endif; ?>
+<?php endif; ?>
 		<section class="wpfa-speakers-hero">
 			<div class="container">
-				<h1><?php echo esc_html( apply_filters( 'wpfa_speakers_title', __( 'FOSSASIA Summit Speakers', 'wpfaevent' ) ) ); ?></h1>
-				<p><?php echo esc_html( apply_filters( 'wpfa_speakers_subtitle', __( 'Discover all the amazing speakers joining us at FOSSASIA Summit', 'wpfaevent' ) ) ); ?></p>
-
-				<form class="wpfa-speakers-search" method="get" action="<?php echo esc_url( get_permalink() ); ?>">
-					<label for="wpfa-speaker-search" class="screen-reader-text">
-						<?php esc_html_e( 'Search speakers', 'wpfaevent' ); ?>
-					</label>
-					<input
-						type="search"
-						id="wpfa-speaker-search"
-						name="q"
+				<h1>
+					<?php
+					echo esc_html(
+						$selected_event_id
+							? sprintf(
+								/* translators: %s: Event title. */
+								__( '%s Speakers', 'wpfaevent' ),
+								$selected_event_title
+							)
+							: apply_filters( 'wpfa_speakers_title', __( 'Event Speakers', 'wpfaevent' ) )
+					);
+					?>
+				</h1>
+				<p>
+					<?php
+					echo esc_html(
+						$selected_event_id
+							? __( 'Speakers linked to this event.', 'wpfaevent' )
+							: apply_filters( 'wpfa_speakers_subtitle', __( 'Choose an event to view its separate speaker list.', 'wpfaevent' ) )
+					);
+					?>
+					</p>
+					<?php if ( $selected_event_id ) : ?>
+					<form class="wpfa-speakers-search" method="get" action="<?php echo esc_url( $speakers_base_url ); ?>">
+						<label for="wpfa-speaker-search" class="screen-reader-text">
+							<?php esc_html_e( 'Search speakers', 'wpfaevent' ); ?>
+						</label>
+						<input
+							type="search"
+							id="wpfa-speaker-search"
+							name="q"
 							value="<?php echo esc_attr( $search_term ); ?>"
-						placeholder="<?php esc_attr_e( 'Search speakers...', 'wpfaevent' ); ?>"
-					/>
-					<button type="submit">
-						<span class="screen-reader-text"><?php esc_html_e( 'Search', 'wpfaevent' ); ?></span>
-						🔍
-					</button>
-					<input type="hidden" name="category" value="<?php echo esc_attr( $current_category ); ?>">
-				</form>
+							placeholder="<?php esc_attr_e( 'Search speakers...', 'wpfaevent' ); ?>"
+						/>
+						<button type="submit">
+							<span class="screen-reader-text"><?php esc_html_e( 'Search', 'wpfaevent' ); ?></span>
+							🔍
+						</button>
+						<input type="hidden" name="category" value="<?php echo esc_attr( $current_category ); ?>">
+						<input type="hidden" name="event" value="<?php echo esc_attr( $selected_event_slug ); ?>">
+					</form>
+				<?php endif; ?>
+
+				<?php if ( ! empty( $event_filter_posts ) ) : ?>
+					<div class="wpfa-speakers-filters wpfa-event-filters" aria-label="<?php esc_attr_e( 'Filter speakers by event', 'wpfaevent' ); ?>">
+						<a href="<?php echo esc_url( $speakers_base_url ); ?>"
+							class="wpfa-filter-btn <?php echo esc_attr( $selected_event_id ? '' : 'active' ); ?>">
+							<?php esc_html_e( 'Choose Event', 'wpfaevent' ); ?>
+						</a>
+						<?php foreach ( $event_filter_posts as $event_filter_post ) : ?>
+							<?php
+							$event_filter_slug = get_post_field( 'post_name', $event_filter_post->ID );
+							$event_filter_args = array(
+								'event' => $event_filter_slug,
+							);
+							if ( $search_term ) {
+								$event_filter_args['q'] = $search_term;
+							}
+							$event_filter_url = add_query_arg( $event_filter_args, $speakers_base_url );
+							?>
+							<a href="<?php echo esc_url( $event_filter_url ); ?>"
+								class="wpfa-filter-btn <?php echo esc_attr( absint( $event_filter_post->ID ) === $selected_event_id ? 'active' : '' ); ?>">
+								<?php echo esc_html( get_the_title( $event_filter_post->ID ) ); ?>
+							</a>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
 
 				<?php if ( ! empty( $categories ) ) : ?>
 				<div class="wpfa-speakers-filters">
-					<a href="<?php echo esc_url( add_query_arg( array( 'category' => 'all' ), remove_query_arg( 'category' ) ) ); ?>"
-							class="wpfa-filter-btn <?php echo esc_attr( 'all' === $current_category ? 'active' : '' ); ?>"
+					<?php
+					$category_base_args = array(
+						'category' => 'all',
+					);
+					if ( $search_term ) {
+						$category_base_args['q'] = $search_term;
+					}
+					if ( $selected_event_slug ) {
+						$category_base_args['event'] = $selected_event_slug;
+					}
+					?>
+					<a href="<?php echo esc_url( add_query_arg( $category_base_args, $speakers_base_url ) ); ?>"
+						class="wpfa-filter-btn <?php echo esc_attr( 'all' === $current_category ? 'active' : '' ); ?>"
 						data-filter="all">
 						<?php esc_html_e( 'All Speakers', 'wpfaevent' ); ?>
 					</a>
 					<?php
 					foreach ( $categories as $category_term ) :
 						$category_slug = $category_term->slug;
-							$is_active = $current_category === $category_slug;
-						$category_url  = add_query_arg(
-							array( 'category' => $category_slug ),
-							remove_query_arg( array( 'paged', 'category' ) )
+						$is_active     = $current_category === $category_slug;
+						$category_args = array(
+							'category' => $category_slug,
 						);
+						if ( $search_term ) {
+							$category_args['q'] = $search_term;
+						}
+						if ( $selected_event_slug ) {
+							$category_args['event'] = $selected_event_slug;
+						}
+						$category_url   = add_query_arg( $category_args, $speakers_base_url );
+						$category_count = isset( $category_term_counts[ $category_term->term_id ] ) ? absint( $category_term_counts[ $category_term->term_id ] ) : absint( $category_term->count );
 						?>
 						<a href="<?php echo esc_url( $category_url ); ?>"
-							class="wpfa-filter-btn <?php echo $is_active ? 'active' : ''; ?>"
+							class="wpfa-filter-btn <?php echo esc_attr( $is_active ? 'active' : '' ); ?>"
 							data-filter="<?php echo esc_attr( $category_slug ); ?>">
 							<?php echo esc_html( $category_term->name ); ?>
-							<?php if ( $category_term->count > 0 ) : ?>
-								<span class="wpfa-filter-count">(<?php echo intval( $category_term->count ); ?>)</span>
+							<?php if ( $category_count > 0 ) : ?>
+								<span class="wpfa-filter-count">(<?php echo absint( $category_count ); ?>)</span>
 							<?php endif; ?>
 						</a>
 					<?php endforeach; ?>
@@ -186,58 +404,96 @@ $header_vars         = array(
 			</div>
 		</section>
 
-		<div class="container">
-			<div class="wpfa-results-info">
-				<?php
-				printf(
-						/* translators: 1: number of speakers shown, 2: total number of speakers. */
-					esc_html__( 'Showing %1$d of %2$d speakers', 'wpfaevent' ),
-					count( $speakers_query->posts ),
-					absint( $speakers_query->found_posts )
-				);
-				?>
-			</div>
+			<div class="container">
+				<div class="wpfa-results-info">
+					<?php
+					if ( $selected_event_id ) {
+						printf(
+							/* translators: 1: number of speakers shown, 2: event title. */
+							esc_html__( 'Showing %1$d speakers for %2$s', 'wpfaevent' ),
+							absint( $total_speakers ),
+							esc_html( $selected_event_title )
+						);
+					} else {
+						esc_html_e( 'Select an event to view its speaker list.', 'wpfaevent' );
+					}
+					?>
+					</div>
 
-				<?php if ( ! $speakers_query->have_posts() ) : ?>
-				<div class="wpfa-no-results">
-					<h3><?php esc_html_e( 'No speakers found', 'wpfaevent' ); ?></h3>
-					<p><?php esc_html_e( 'Try adjusting your search or filters', 'wpfaevent' ); ?></p>
-				</div>
-			<?php else : ?>
-				<div class="wpfa-speakers-grid" id="wpfa-speakers-grid">
-						<?php foreach ( $speakers_query->posts as $sid ) : ?>
-							<?php include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php'; ?>
-					<?php endforeach; ?>
-				</div>
+					<?php if ( empty( $paged_speaker_ids ) ) : ?>
+						<div class="wpfa-no-results">
+							<h3><?php esc_html_e( 'No speakers found', 'wpfaevent' ); ?></h3>
+							<p>
+								<?php
+								echo esc_html(
+									$selected_event_id
+										? __( 'No speakers are linked to this event yet.', 'wpfaevent' )
+										: __( 'Choose an event above to see that event\'s speakers.', 'wpfaevent' )
+								);
+								?>
+							</p>
+						</div>
+					<?php else : ?>
+					<div class="wpfa-speakers-list" id="wpfa-speakers-grid">
+						<?php $wpfa_featured_speaker_ids = $featured_speaker_ids; ?>
+						<?php if ( ! empty( $featured_display_speaker_ids ) ) : ?>
+							<section class="wpfa-speaker-group wpfa-featured-speaker-group" aria-labelledby="wpfa-featured-speakers-title">
+								<div class="wpfa-speaker-group-head">
+									<h2 id="wpfa-featured-speakers-title"><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h2>
+								</div>
+								<div class="wpfa-speakers-grid wpfa-featured-speakers-grid">
+									<?php foreach ( $featured_display_speaker_ids as $sid ) : ?>
+										<?php include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php'; ?>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endif; ?>
 
-				<?php
-					// Pagination.
-					$total           = max( 1, (int) ceil( $speakers_query->found_posts / $speakers_per_page ) );
-					$pagination_args = array();
-				if ( $search_term ) {
-					$pagination_args['q'] = $search_term;
-				}
-				if ( 'all' !== $current_category ) {
-					$pagination_args['category'] = $current_category;
-				}
+						<?php if ( ! empty( $regular_display_speaker_ids ) ) : ?>
+							<section class="wpfa-speaker-group wpfa-regular-speaker-group" aria-labelledby="wpfa-regular-speakers-title">
+								<?php if ( ! empty( $featured_display_speaker_ids ) ) : ?>
+									<div class="wpfa-speaker-group-head">
+										<h2 id="wpfa-regular-speakers-title"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h2>
+									</div>
+								<?php endif; ?>
+								<div class="wpfa-speakers-grid">
+									<?php foreach ( $regular_display_speaker_ids as $sid ) : ?>
+										<?php include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php'; ?>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endif; ?>
+						<?php unset( $wpfa_featured_speaker_ids ); ?>
+					</div>
 
-				wpfa_render_pagination(
-					$total,
-					$current_page,
-					__( 'Speakers pagination', 'wpfaevent' ),
-					$pagination_args
-				);
-				?>
+						<?php
+						if ( ! $selected_event_id ) {
+							// Pagination is only used for the generic chooser state.
+							$total           = max( 1, (int) ceil( $total_speakers / $speakers_per_page ) );
+							$pagination_args = array();
+							if ( $search_term ) {
+								$pagination_args['q'] = $search_term;
+							}
+							if ( 'all' !== $current_category ) {
+								$pagination_args['category'] = $current_category;
+							}
+
+							wpfa_render_pagination(
+								$total,
+								$current_page,
+								__( 'Speakers pagination', 'wpfaevent' ),
+								$pagination_args
+							);
+						}
+						?>
 			<?php endif; ?>
 			<?php wp_reset_postdata(); ?>
 		</div>
-	<?php if ( $wpfaevent_is_embed ) : ?>
+<?php if ( $wpfaevent_is_embed ) : ?>
 	</section>
-	<?php else : ?>
+<?php else : ?>
 	</main>
-	<?php endif; ?>
 
-<?php if ( ! $wpfaevent_is_embed ) : ?>
 	<footer class="wpfa-footer">
 		<div class="container">
 			<small>
@@ -257,7 +513,7 @@ $header_vars         = array(
 
 <?php
 // Load admin modals if the user is an admin.
-if ( current_user_can( 'manage_options' ) ) :
+if ( Wpfaevent_Roles::current_user_can_manage_dashboard() ) :
 	$modal_partial = WPFAEVENT_PATH . 'public/partials/speakers/speaker-modal.php';
 	if ( file_exists( $modal_partial ) ) {
 		include $modal_partial;

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -2,6 +2,8 @@
 /**
  * Single Event Template.
  *
+ * Displays imported Eventyay event data, event-specific speakers, and schedule.
+ *
  * @package    Wpfaevent
  * @subpackage Wpfaevent/public/templates
  * @since      1.0.0
@@ -17,9 +19,75 @@ if ( ! $event_id || 'wpfa_event' !== get_post_type( $event_id ) ) {
 	return;
 }
 
-if ( have_posts() ) {
-	the_post();
-}
+$read_dashboard_json = static function ( $filename, $fallback ) {
+	$upload_dir = wp_upload_dir();
+
+	if ( ! empty( $upload_dir['error'] ) ) {
+		return $fallback;
+	}
+
+	$path = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/' . sanitize_file_name( $filename );
+
+	if ( ! file_exists( $path ) || ! is_readable( $path ) ) {
+		return $fallback;
+	}
+
+	$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading plugin-managed JSON from uploads.
+	if ( false === $contents || '' === trim( $contents ) ) {
+		return $fallback;
+	}
+
+	$decoded = json_decode( $contents, true );
+
+	return ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) ? $decoded : $fallback;
+};
+
+$normalize_post_id_list = static function ( $post_ids ) {
+	if ( ! is_array( $post_ids ) ) {
+		return array();
+	}
+
+	$post_ids = array_map( 'absint', $post_ids );
+	$post_ids = array_filter( $post_ids );
+
+	return array_values( array_unique( $post_ids ) );
+};
+
+$get_linked_speaker_ids = static function ( $current_event_id ) use ( $normalize_post_id_list ) {
+	$current_event_id = absint( $current_event_id );
+	$speaker_ids      = $normalize_post_id_list( get_post_meta( $current_event_id, 'wpfa_event_speakers', true ) );
+
+	$reverse_speaker_ids = get_posts(
+		array(
+			'post_type'      => 'wpfa_speaker',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored as post meta.
+			'meta_query'     => array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'wpfa_speaker_events',
+					'value'   => 'i:' . $current_event_id . ';',
+					'compare' => 'LIKE',
+				),
+				array(
+					'key'     => 'wpfa_speaker_events',
+					'value'   => '"' . $current_event_id . '"',
+					'compare' => 'LIKE',
+				),
+				array(
+					'key'     => 'wpfa_speaker_events',
+					'value'   => (string) $current_event_id,
+					'compare' => '=',
+				),
+			),
+		)
+	);
+
+	return $normalize_post_id_list( array_merge( $speaker_ids, $reverse_speaker_ids ) );
+};
 
 $format_event_date = static function ( $date ) {
 	$date = trim( (string) $date );
@@ -28,49 +96,568 @@ $format_event_date = static function ( $date ) {
 		return '';
 	}
 
-	$timestamp = strtotime( $date );
-
-	if ( false === $timestamp ) {
+	try {
+		$datetime = new DateTimeImmutable( $date, wp_timezone() );
+	} catch ( Exception $exception ) {
 		return $date;
 	}
 
-	return date_i18n( get_option( 'date_format' ), $timestamp );
+	return wp_date( get_option( 'date_format' ), $datetime->getTimestamp(), wp_timezone() );
 };
 
-$site_logo_url = get_option( 'wpfa_site_logo_url', WPFAEVENT_URL . 'assets/images/logo.png' );
-$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+$get_timezone_object = static function ( $timezone_string, $fallback_timezone ) {
+	try {
+		return new DateTimeZone( $timezone_string );
+	} catch ( Exception $exception ) {
+		return $fallback_timezone;
+	}
+};
 
-$start_date       = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
-$end_date         = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
-$event_time       = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_time', true ) );
-$event_location   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
-$lead_text        = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) );
-$event_url        = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_url', true ) );
-$registration_url = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_registration_link', true ) );
-$cfs_url          = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_cfs_link', true ) );
-$image_url        = get_the_post_thumbnail_url( $event_id, 'large' );
+$site_timezone        = wp_timezone();
+$site_timezone_string = wp_timezone_string();
 
-$start_label = $format_event_date( $start_date );
-$end_label   = $format_event_date( $end_date );
-$date_label  = $start_label;
+if ( '' === trim( (string) $site_timezone_string ) ) {
+	$site_timezone_string = $site_timezone->getName();
+}
 
-if ( $start_label && $end_label && $end_label !== $start_label ) {
-	$date_label = sprintf(
-		/* translators: 1: event start date, 2: event end date. */
-		__( '%1$s - %2$s', 'wpfaevent' ),
-		$start_label,
-		$end_label
+$event_timezone_string = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_timezone_string( $event_id ) : $site_timezone_string;
+$event_timezone        = $get_timezone_object( $event_timezone_string, $site_timezone );
+
+$selected_schedule_timezone_string = $event_timezone_string;
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only timezone converter for the public schedule.
+if ( isset( $_GET['schedule_tz'] ) ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized immediately before validation.
+	$requested_schedule_timezone = sanitize_text_field( wp_unslash( $_GET['schedule_tz'] ) );
+
+	if ( '' !== $requested_schedule_timezone ) {
+		try {
+			new DateTimeZone( $requested_schedule_timezone );
+			$selected_schedule_timezone_string = $requested_schedule_timezone;
+		} catch ( Exception $exception ) {
+			$selected_schedule_timezone_string = $event_timezone_string;
+		}
+	}
+}
+
+$selected_schedule_timezone = $get_timezone_object( $selected_schedule_timezone_string, $site_timezone );
+$schedule_timezone_options  = array_values(
+	array_unique(
+		array_merge(
+			array(
+				$event_timezone_string,
+				$site_timezone_string,
+				'UTC',
+			),
+			DateTimeZone::listIdentifiers()
+		)
+	)
+);
+
+$current_schedule_view = 'list';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only schedule view toggle.
+if ( isset( $_GET['schedule_view'] ) ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized before validation.
+	$requested_schedule_view = sanitize_title( wp_unslash( $_GET['schedule_view'] ) );
+
+	if ( in_array( $requested_schedule_view, array( 'list', 'calendar' ), true ) ) {
+		$current_schedule_view = $requested_schedule_view;
+	}
+}
+
+$format_timezone_label = static function ( $timezone_string ) use ( $event_timezone_string, $site_timezone_string ) {
+	$label = str_replace( '_', ' ', $timezone_string );
+
+	if ( $timezone_string === $event_timezone_string ) {
+		return sprintf(
+			/* translators: %s: event timezone. */
+			__( 'Event timezone (%s)', 'wpfaevent' ),
+			$label
+		);
+	}
+
+	if ( $timezone_string === $site_timezone_string ) {
+		return sprintf(
+			/* translators: %s: WordPress site timezone. */
+			__( 'Site timezone (%s)', 'wpfaevent' ),
+			$label
+		);
+	}
+
+	return $label;
+};
+
+$format_datetime_value = static function ( $value, $format, $timezone ) {
+	$value = trim( (string) $value );
+
+	if ( '' === $value ) {
+		return '';
+	}
+
+	try {
+		$datetime = new DateTimeImmutable( $value );
+	} catch ( Exception $exception ) {
+		return '';
+	}
+
+	return wp_date( $format, $datetime->getTimestamp(), $timezone );
+};
+
+$split_schedule_time_range = static function ( $time ) {
+	$parts = explode( ' - ', trim( (string) $time ), 2 );
+
+	if ( 2 !== count( $parts ) ) {
+		$parts = explode( '-', trim( (string) $time ), 2 );
+	}
+
+	$end_time = 2 === count( $parts ) ? trim( $parts[1] ) : '';
+
+	return array(
+		trim( $parts[0] ),
+		$end_time,
+	);
+};
+
+$build_schedule_fallback_datetime = static function ( $date, $time, $source_timezone ) use ( $split_schedule_time_range ) {
+	$date = trim( (string) $date );
+	$time = trim( (string) $time );
+
+	if ( '' === $date ) {
+		return null;
+	}
+
+	if ( '' !== $time ) {
+		$time_parts = $split_schedule_time_range( $time );
+		$time       = $time_parts[0];
+	}
+
+	$value = trim( $date . ' ' . $time );
+
+	try {
+		return new DateTimeImmutable( $value, $source_timezone );
+	} catch ( Exception $exception ) {
+		return null;
+	}
+};
+
+$format_schedule_date = static function ( $start_datetime, $fallback_date, $fallback_time ) use ( $format_datetime_value, $build_schedule_fallback_datetime, $selected_schedule_timezone, $event_timezone ) {
+	if ( $start_datetime ) {
+		$formatted_date = $format_datetime_value( $start_datetime, get_option( 'date_format' ), $selected_schedule_timezone );
+
+		if ( $formatted_date ) {
+			return $formatted_date;
+		}
+	}
+
+	$fallback_datetime = $build_schedule_fallback_datetime( $fallback_date, $fallback_time, $event_timezone );
+
+	return $fallback_datetime ? wp_date( get_option( 'date_format' ), $fallback_datetime->getTimestamp(), $selected_schedule_timezone ) : $fallback_date;
+};
+
+$format_schedule_time = static function ( $start_datetime, $end_datetime, $fallback_date, $fallback_time ) use ( $format_datetime_value, $build_schedule_fallback_datetime, $selected_schedule_timezone, $event_timezone, $split_schedule_time_range ) {
+	$start_label = $start_datetime ? $format_datetime_value( $start_datetime, get_option( 'time_format' ), $selected_schedule_timezone ) : '';
+	$end_label   = $end_datetime ? $format_datetime_value( $end_datetime, get_option( 'time_format' ), $selected_schedule_timezone ) : '';
+
+	if ( ! $start_label && $fallback_time ) {
+		$time_parts        = $split_schedule_time_range( $fallback_time );
+		$fallback_start    = $build_schedule_fallback_datetime( $fallback_date, $time_parts[0], $event_timezone );
+		$fallback_end_time = $time_parts[1];
+		$fallback_end      = $fallback_end_time ? $build_schedule_fallback_datetime( $fallback_date, $fallback_end_time, $event_timezone ) : null;
+		$start_label       = $fallback_start ? wp_date( get_option( 'time_format' ), $fallback_start->getTimestamp(), $selected_schedule_timezone ) : '';
+		$end_label         = $fallback_end ? wp_date( get_option( 'time_format' ), $fallback_end->getTimestamp(), $selected_schedule_timezone ) : '';
+	}
+
+	if ( $start_label && $end_label && $start_label !== $end_label ) {
+		return $start_label . ' - ' . $end_label;
+	}
+
+	return $start_label ? $start_label : $fallback_time;
+};
+
+$parse_schedule_datetime = static function ( $datetime ) {
+	$datetime = trim( (string) $datetime );
+
+	if ( '' === $datetime ) {
+		return null;
+	}
+
+	try {
+		return new DateTimeImmutable( $datetime );
+	} catch ( Exception $exception ) {
+		return null;
+	}
+};
+
+$site_settings      = $read_dashboard_json( 'site-settings-' . absint( $event_id ) . '.json', array() );
+$dashboard_speakers = $read_dashboard_json( 'speakers-' . absint( $event_id ) . '.json', array() );
+$schedule_table     = $read_dashboard_json( 'schedule-' . absint( $event_id ) . '.json', array() );
+$sponsor_groups     = $read_dashboard_json( 'sponsors-' . absint( $event_id ) . '.json', array() );
+$exhibitors         = $read_dashboard_json( 'exhibitors-' . absint( $event_id ) . '.json', array() );
+$section_visibility = isset( $site_settings['section_visibility'] ) && is_array( $site_settings['section_visibility'] ) ? $site_settings['section_visibility'] : array();
+
+$event_title          = get_the_title( $event_id );
+$start_date           = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
+$end_date             = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
+$location             = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+$venue_information    = trim( (string) get_post_meta( $event_id, 'wpfa_event_venue_information', true ) );
+$custom_tabs          = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_custom_tabs( get_post_meta( $event_id, 'wpfa_event_custom_tabs', true ) ) : array();
+$event_languages      = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_language_list( get_post_meta( $event_id, 'wpfa_event_languages', true ) ) : array();
+$event_language_label = implode( ', ', $event_languages );
+$event_url            = get_post_meta( $event_id, 'wpfa_event_url', true );
+$event_url            = $event_url ? esc_url_raw( $event_url ) : '';
+$about_content        = isset( $site_settings['about_section_content'] ) ? trim( (string) $site_settings['about_section_content'] ) : '';
+$post_content         = trim( (string) get_post_field( 'post_content', $event_id ) );
+$event_lead           = trim( (string) get_post_meta( $event_id, '_event_lead_text', true ) );
+
+$main_speaker_limit             = absint( apply_filters( 'wpfa_event_main_speaker_limit', 20, $event_id ) );
+$main_speaker_limit             = $main_speaker_limit ? $main_speaker_limit : 20;
+$speaker_ids                    = $get_linked_speaker_ids( $event_id );
+$featured_speaker_ids           = class_exists( 'Wpfaevent_Meta_Event' )
+	? Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers )
+	: array();
+$regular_speaker_ids            = array_values( array_diff( $speaker_ids, $featured_speaker_ids ) );
+$main_speaker_ids               = array_slice( $speaker_ids, 0, $main_speaker_limit );
+$main_regular_speaker_ids       = array_slice( $regular_speaker_ids, 0, $main_speaker_limit );
+$main_speaker_overflow_count    = max( 0, count( $speaker_ids ) - count( $main_speaker_ids ) );
+$regular_speaker_overflow_count = max( 0, count( $regular_speaker_ids ) - count( $main_regular_speaker_ids ) );
+
+$event_slug              = get_post_field( 'post_name', $event_id );
+$speaker_placeholder_url = WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
+$speakers_url            = add_query_arg( 'event', $event_slug, home_url( '/speakers/' ) );
+$schedule_page_url       = class_exists( 'Wpfaevent_Schedule_Helper' ) ? Wpfaevent_Schedule_Helper::get_schedule_page_url() : home_url( '/full-schedule/' );
+$event_schedule_args     = array(
+	'event' => $event_slug,
+);
+
+if ( 'calendar' === $current_schedule_view ) {
+	$event_schedule_args['view'] = 'calendar';
+}
+
+if ( $selected_schedule_timezone_string && $selected_schedule_timezone_string !== $event_timezone_string ) {
+	$event_schedule_args['schedule_tz'] = $selected_schedule_timezone_string;
+}
+
+$event_schedule_url   = add_query_arg( $event_schedule_args, $schedule_page_url );
+$additional_page_url  = class_exists( 'Wpfaevent_Additional_Information_Helper' ) ? Wpfaevent_Additional_Information_Helper::get_additional_information_page_url() : home_url( '/additional-information/' );
+$event_additional_url = add_query_arg( 'event', $event_slug, $additional_page_url );
+
+$build_event_schedule_view_url = static function ( $view ) use ( $event_id, $event_timezone_string, $selected_schedule_timezone_string ) {
+	$args = array();
+
+	if ( $selected_schedule_timezone_string && $selected_schedule_timezone_string !== $event_timezone_string ) {
+		$args['schedule_tz'] = $selected_schedule_timezone_string;
+	}
+
+	if ( 'calendar' === $view ) {
+		$args['schedule_view'] = 'calendar';
+	}
+
+	return add_query_arg( $args, get_permalink( $event_id ) ) . '#wpfa-event-schedule-title';
+};
+
+$register_text = ! empty( $site_settings['reg_button_text'] ) ? sanitize_text_field( $site_settings['reg_button_text'] ) : __( 'Get Tickets', 'wpfaevent' );
+$register_url  = ! empty( $site_settings['reg_button_link'] ) ? esc_url_raw( $site_settings['reg_button_link'] ) : $event_url;
+
+$event_calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
+$event_calendar_data = is_wp_error( $event_calendar_data ) ? array() : $event_calendar_data;
+$event_calendar_url  = ! empty( $event_calendar_data ) && class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_ics_url( $event_id ) : '';
+$event_google_url    = ! empty( $event_calendar_data ) && class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::build_google_calendar_url( $event_calendar_data ) : '';
+
+$show_about             = ! array_key_exists( 'about', $section_visibility ) || ! empty( $section_visibility['about'] );
+$show_speakers          = ! array_key_exists( 'speakers', $section_visibility ) || ! empty( $section_visibility['speakers'] );
+$show_schedule          = ! array_key_exists( 'schedule', $section_visibility ) || ! empty( $section_visibility['schedule'] );
+$show_sponsors          = ! array_key_exists( 'sponsors', $section_visibility ) || ! empty( $section_visibility['sponsors'] );
+$show_exhibitors        = ! array_key_exists( 'exhibitors', $section_visibility ) || ! empty( $section_visibility['exhibitors'] );
+$schedule_rows          = isset( $schedule_table['data'] ) && is_array( $schedule_table['data'] ) ? $schedule_table['data'] : array();
+$schedule_meta          = isset( $schedule_table['sessions'] ) && is_array( $schedule_table['sessions'] ) ? $schedule_table['sessions'] : array();
+$schedule_head          = ! empty( $schedule_rows[0] ) && is_array( $schedule_rows[0] ) ? $schedule_rows[0] : array();
+$schedule_body          = ! empty( $schedule_head ) ? array_slice( $schedule_rows, 1 ) : $schedule_rows;
+$speaker_count          = count( $speaker_ids );
+$featured_speaker_count = count( $featured_speaker_ids );
+$visible_sponsor_groups = array();
+$sponsor_count          = 0;
+$visible_exhibitors     = array();
+$event_colors           = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_colors( $event_id ) : array();
+$event_color_var_map    = array(
+	'wpfa_event_primary_color'          => '--event-primary',
+	'wpfa_event_hover_button_color'     => '--event-primary-dark',
+	'wpfa_event_theme_background_color' => '--event-soft',
+	'wpfa_event_theme_success_color'    => '--event-success',
+	'wpfa_event_theme_danger_color'     => '--event-danger',
+);
+$event_style_vars       = array();
+
+foreach ( $event_color_var_map as $meta_key => $css_var ) {
+	if ( ! empty( $event_colors[ $meta_key ] ) ) {
+		$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+	}
+}
+
+$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+
+foreach ( $sponsor_groups as $sponsor_group ) {
+	if ( ! is_array( $sponsor_group ) ) {
+		continue;
+	}
+
+	$group_sponsors         = isset( $sponsor_group['sponsors'] ) && is_array( $sponsor_group['sponsors'] ) ? $sponsor_group['sponsors'] : array();
+	$visible_group_sponsors = array();
+
+	foreach ( $group_sponsors as $sponsor ) {
+		if ( ! is_array( $sponsor ) || ( empty( $sponsor['name'] ) && empty( $sponsor['image'] ) ) ) {
+			continue;
+		}
+
+		$visible_group_sponsors[] = $sponsor;
+	}
+
+	if ( empty( $visible_group_sponsors ) ) {
+		continue;
+	}
+
+	$sponsor_group['sponsors'] = $visible_group_sponsors;
+	$visible_sponsor_groups[]  = $sponsor_group;
+	$sponsor_count            += count( $visible_group_sponsors );
+}
+
+foreach ( $exhibitors as $exhibitor ) {
+	if ( ! is_array( $exhibitor ) || empty( $exhibitor['name'] ) ) {
+		continue;
+	}
+
+	$visible_exhibitors[] = $exhibitor;
+}
+
+$dashboard_featured_speakers = array();
+$dashboard_regular_speakers  = array();
+
+foreach ( $dashboard_speakers as $dashboard_speaker ) {
+	if ( ! is_array( $dashboard_speaker ) || empty( $dashboard_speaker['name'] ) ) {
+		continue;
+	}
+
+	if ( ! empty( $dashboard_speaker['featured'] ) ) {
+		$dashboard_featured_speakers[] = $dashboard_speaker;
+		continue;
+	}
+
+	$dashboard_regular_speakers[] = $dashboard_speaker;
+}
+
+$main_dashboard_speakers                  = array_slice( $dashboard_speakers, 0, $main_speaker_limit );
+$main_dashboard_regular_speakers          = array_slice( $dashboard_regular_speakers, 0, $main_speaker_limit );
+$dashboard_speaker_overflow_count         = max( 0, count( $dashboard_speakers ) - count( $main_dashboard_speakers ) );
+$dashboard_regular_speaker_overflow_count = max( 0, count( $dashboard_regular_speakers ) - count( $main_dashboard_regular_speakers ) );
+
+if ( ! empty( $dashboard_featured_speakers ) ) {
+	usort(
+		$dashboard_featured_speakers,
+		static function ( $speaker_a, $speaker_b ) {
+			$order_a = isset( $speaker_a['featured_order'] ) ? absint( $speaker_a['featured_order'] ) : 0;
+			$order_b = isset( $speaker_b['featured_order'] ) ? absint( $speaker_b['featured_order'] ) : 0;
+
+			if ( $order_a && $order_b && $order_a !== $order_b ) {
+				return $order_a <=> $order_b;
+			}
+
+			if ( $order_a !== $order_b ) {
+				return $order_a ? -1 : 1;
+			}
+
+			return strcasecmp( $speaker_a['name'] ?? '', $speaker_b['name'] ?? '' );
+		}
 	);
 }
+
+if ( '' === $about_content ) {
+	$about_content = '' !== $post_content ? $post_content : $event_lead;
+}
+
+$date_label           = ! empty( $event_calendar_data['date_label'] ) ? sanitize_text_field( $event_calendar_data['date_label'] ) : $format_event_date( $start_date );
+$event_time_label     = ! empty( $event_calendar_data['time_label'] ) ? sanitize_text_field( $event_calendar_data['time_label'] ) : '';
+$event_timezone_label = ! empty( $event_calendar_data['timezone_label'] ) ? sanitize_text_field( $event_calendar_data['timezone_label'] ) : str_replace( '_', ' ', $event_timezone_string );
+$event_start_content  = ! empty( $event_calendar_data['start_content'] ) ? sanitize_text_field( $event_calendar_data['start_content'] ) : $start_date;
+$event_end_content    = ! empty( $event_calendar_data['end_content'] ) ? sanitize_text_field( $event_calendar_data['end_content'] ) : $end_date;
+
+if ( empty( $event_calendar_data['date_label'] ) && $end_date && $end_date !== $start_date ) {
+	$date_label .= $date_label ? ' - ' . $format_event_date( $end_date ) : $format_event_date( $end_date );
+}
+
+$build_schedule_calendar_url = static function ( $item ) use ( $build_schedule_fallback_datetime, $event_timezone, $event_timezone_string, $event_title, $event_url, $location, $parse_schedule_datetime, $split_schedule_time_range ) {
+	if ( ! class_exists( 'Wpfaevent_Calendar' ) ) {
+		return '';
+	}
+
+	$title      = ! empty( $item['title'] ) ? $item['title'] : $event_title;
+	$time_parts = $split_schedule_time_range( isset( $item['time'] ) ? $item['time'] : '' );
+	$start      = $parse_schedule_datetime( isset( $item['start_datetime'] ) ? $item['start_datetime'] : '' );
+	$end        = $parse_schedule_datetime( isset( $item['end_datetime'] ) ? $item['end_datetime'] : '' );
+	$all_day    = false;
+	$start_date = '';
+	$end_date   = '';
+
+	if ( ! $start ) {
+		$start = $build_schedule_fallback_datetime(
+			isset( $item['date'] ) ? $item['date'] : '',
+			$time_parts[0],
+			$event_timezone
+		);
+	}
+
+	if ( $start && ! $end && ! empty( $time_parts[1] ) ) {
+		$end = $build_schedule_fallback_datetime( isset( $item['date'] ) ? $item['date'] : '', $time_parts[1], $event_timezone );
+	}
+
+	if ( $start && $end && $end <= $start ) {
+		$end = $end->modify( '+1 day' );
+	}
+
+	if ( ! $start && empty( $time_parts[0] ) ) {
+		$start_date = class_exists( 'Wpfaevent_Meta_Event' )
+			? Wpfaevent_Meta_Event::sanitize_date_value( isset( $item['date'] ) ? $item['date'] : '' )
+			: '';
+		$end_date   = $start_date;
+		$all_day    = '' !== $start_date;
+	}
+
+	if ( ! $start && ! $all_day ) {
+		return '';
+	}
+
+	$details = array_filter(
+		array(
+			$event_title ? sprintf(
+				/* translators: %s: event title. */
+				__( 'Event: %s', 'wpfaevent' ),
+				$event_title
+			) : '',
+			! empty( $item['speakers'] ) ? sprintf(
+				/* translators: %s: speaker names. */
+				__( 'Speakers: %s', 'wpfaevent' ),
+				$item['speakers']
+			) : '',
+			! empty( $item['track'] ) ? sprintf(
+				/* translators: %s: session track. */
+				__( 'Track: %s', 'wpfaevent' ),
+				$item['track']
+			) : '',
+			! empty( $item['room'] ) ? sprintf(
+				/* translators: %s: session room. */
+				__( 'Room: %s', 'wpfaevent' ),
+				$item['room']
+			) : '',
+		)
+	);
+
+	$session_location = ! empty( $item['room'] ) ? $item['room'] : $location;
+
+	return Wpfaevent_Calendar::build_google_calendar_url(
+		array(
+			'title'           => $title,
+			'description'     => implode( "\n", $details ),
+			'location'        => $session_location,
+			'url'             => $event_url,
+			'timezone_string' => $event_timezone_string,
+			'all_day'         => $all_day,
+			'start_date'      => $start_date,
+			'end_date'        => $end_date,
+			'start_datetime'  => $all_day ? null : $start,
+			'end_datetime'    => $all_day ? null : $end,
+		)
+	);
+};
+
+$schedule_items = array();
+foreach ( $schedule_body as $row_index => $row ) {
+	if ( ! is_array( $row ) ) {
+		continue;
+	}
+
+	$row_meta       = isset( $schedule_meta[ $row_index ] ) && is_array( $schedule_meta[ $row_index ] ) ? $schedule_meta[ $row_index ] : array();
+	$start_datetime = isset( $row_meta['starts_at'] ) ? sanitize_text_field( $row_meta['starts_at'] ) : '';
+	$end_datetime   = isset( $row_meta['ends_at'] ) ? sanitize_text_field( $row_meta['ends_at'] ) : '';
+	$row_date       = isset( $row[0] ) ? sanitize_text_field( $row[0] ) : '';
+	$row_time       = isset( $row[1] ) ? sanitize_text_field( $row[1] ) : '';
+
+	$schedule_item = array(
+		'date'           => $row_date,
+		'date_label'     => $format_schedule_date( $start_datetime, $row_date, $row_time ),
+		'time'           => $row_time,
+		'time_label'     => $format_schedule_time( $start_datetime, $end_datetime, $row_date, $row_time ),
+		'title'          => ! empty( $row[2] ) ? sanitize_text_field( $row[2] ) : $event_title,
+		'speakers'       => isset( $row[3] ) ? sanitize_text_field( $row[3] ) : '',
+		'track'          => isset( $row[4] ) ? sanitize_text_field( $row[4] ) : '',
+		'room'           => isset( $row[5] ) ? sanitize_text_field( $row[5] ) : '',
+		'start_datetime' => $start_datetime,
+		'end_datetime'   => $end_datetime,
+	);
+
+	$schedule_item['calendar_url'] = $build_schedule_calendar_url( $schedule_item );
+
+	$time_parts                  = preg_split( '/\s*-\s*/', $schedule_item['time_label'], 2 );
+	$schedule_item['time_start'] = isset( $time_parts[0] ) ? trim( $time_parts[0] ) : $schedule_item['time_label'];
+	$schedule_item['time_end']   = isset( $time_parts[1] ) ? trim( $time_parts[1] ) : '';
+
+	$schedule_items[] = $schedule_item;
+}
+
+$schedule_preview_limit      = absint( apply_filters( 'wpfa_event_schedule_preview_limit', 3, $event_id ) );
+$schedule_preview_items      = $schedule_preview_limit ? array_slice( $schedule_items, 0, $schedule_preview_limit ) : $schedule_items;
+$schedule_preview_day_groups = array();
+
+foreach ( $schedule_preview_items as $schedule_item ) {
+	$day_key = ! empty( $schedule_item['date_label'] ) ? $schedule_item['date_label'] : __( 'TBD', 'wpfaevent' );
+
+	if ( ! isset( $schedule_preview_day_groups[ $day_key ] ) ) {
+		$schedule_preview_day_groups[ $day_key ] = array();
+	}
+
+	$schedule_preview_day_groups[ $day_key ][] = $schedule_item;
+}
+
+$schedule_hidden_count = max( 0, count( $schedule_items ) - count( $schedule_preview_items ) );
+$first_schedule        = ! empty( $schedule_items[0] ) ? $schedule_items[0] : array();
+$custom_sections       = array();
+
+foreach ( $custom_tabs as $custom_tab ) {
+	if ( empty( $custom_tab['slug'] ) || empty( $custom_tab['title'] ) || empty( $custom_tab['content'] ) ) {
+		continue;
+	}
+
+	$custom_sections[ $custom_tab['slug'] ] = $custom_tab['title'];
+}
+
+$wpfa_event_nav_context = array(
+	'show_about'      => $show_about,
+	'show_speakers'   => $show_speakers,
+	'show_schedule'   => $show_schedule,
+	'show_sponsors'   => $show_sponsors,
+	'show_exhibitors' => $show_exhibitors,
+	'has_about'       => $show_about && '' !== trim( $about_content ),
+	'has_speakers'    => $show_speakers && ( ! empty( $speaker_ids ) || ! empty( $dashboard_speakers ) ),
+	'has_schedule'    => $show_schedule && ! empty( $schedule_items ),
+	'has_sponsors'    => $show_sponsors && ! empty( $visible_sponsor_groups ),
+	'has_exhibitors'  => $show_exhibitors && ! empty( $visible_exhibitors ),
+	'has_venue'       => '' !== trim( wp_strip_all_tags( $venue_information ) ),
+	'custom_sections' => $custom_sections,
+);
+$wpfa_event_nav_items   = class_exists( 'Wpfaevent_Event_Navigation_Helper' )
+	? Wpfaevent_Event_Navigation_Helper::build_nav_items( $wpfa_event_nav_context )
+	: array();
+
+$site_logo_url = get_option( 'wpfa_site_logo_url', '' );
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
 
 $header_vars = array(
 	'site_logo_url'        => $site_logo_url,
 	'event_page_url'       => home_url( '/events/' ),
 	'show_back_button'     => true,
-	'show_register_button' => ! empty( $registration_url ),
-	'back_button_text'     => __( 'Back to Events', 'wpfaevent' ),
-	'register_button_url'  => $registration_url,
-	'register_button_text' => __( 'Register', 'wpfaevent' ),
+	'show_register_button' => ! empty( $register_url ),
+	'back_button_text'     => __( 'All Events', 'wpfaevent' ),
+	'register_button_url'  => $register_url,
+	'register_button_text' => $register_text,
 );
 ?>
 <!DOCTYPE html>
@@ -80,8 +667,8 @@ $header_vars = array(
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<?php wp_head(); ?>
 </head>
-<body <?php body_class( 'wpfaevent wpfa-single-event-template' ); ?>>
-	<?php wp_body_open(); ?>
+<body <?php body_class( 'wpfaevent wpfa-event-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
+<?php wp_body_open(); ?>
 
 <div id="page" class="site">
 	<?php
@@ -99,91 +686,653 @@ $header_vars = array(
 	}
 	?>
 
-	<main class="wpfa-single-event">
-		<header class="page-hero wpfa-single-event-hero">
-			<div class="hero-bg" aria-hidden="true"></div>
-			<div class="container">
-				<h1><?php echo esc_html( get_the_title( $event_id ) ); ?></h1>
-
-				<?php if ( ! empty( $lead_text ) ) : ?>
-					<p><?php echo esc_html( $lead_text ); ?></p>
-				<?php elseif ( has_excerpt( $event_id ) ) : ?>
-					<p><?php echo esc_html( get_the_excerpt( $event_id ) ); ?></p>
-				<?php endif; ?>
-
-				<?php if ( ! empty( $registration_url ) || ! empty( $event_url ) || ! empty( $cfs_url ) ) : ?>
-					<div class="wpfa-single-event-actions">
-						<?php if ( ! empty( $registration_url ) ) : ?>
-							<a class="btn btn-primary" href="<?php echo esc_url( $registration_url ); ?>" target="_blank" rel="noopener">
-								<?php esc_html_e( 'Register', 'wpfaevent' ); ?>
-							</a>
+	<main class="wpfa-event-detail" itemscope itemtype="https://schema.org/Event">
+		<section class="wpfa-event-hero">
+			<div class="container wpfa-event-hero-inner">
+				<div class="wpfa-event-hero-copy">
+					<p class="wpfa-event-kicker"><?php esc_html_e( 'Eventyay Event', 'wpfaevent' ); ?></p>
+					<h1 itemprop="name"><?php echo esc_html( $event_title ); ?></h1>
+						<div class="wpfa-event-meta-list">
+							<?php if ( $date_label ) : ?>
+								<span itemprop="startDate" content="<?php echo esc_attr( $event_start_content ); ?>"><?php echo esc_html( $date_label ); ?></span>
+								<?php if ( $event_end_content ) : ?>
+									<meta itemprop="endDate" content="<?php echo esc_attr( $event_end_content ); ?>">
+								<?php endif; ?>
+							<?php endif; ?>
+							<?php if ( $event_time_label ) : ?>
+								<span><?php echo esc_html( $event_time_label ); ?></span>
+							<?php endif; ?>
+							<?php if ( $location ) : ?>
+								<span itemprop="location"><?php echo esc_html( $location ); ?></span>
 						<?php endif; ?>
-
-						<?php if ( ! empty( $event_url ) ) : ?>
-							<a class="btn btn-secondary" href="<?php echo esc_url( $event_url ); ?>" target="_blank" rel="noopener">
-								<?php esc_html_e( 'Event Website', 'wpfaevent' ); ?>
-							</a>
+						<?php if ( $event_language_label ) : ?>
+							<span><?php echo esc_html( $event_language_label ); ?></span>
 						<?php endif; ?>
-
-						<?php if ( ! empty( $cfs_url ) ) : ?>
-							<a class="btn btn-secondary" href="<?php echo esc_url( $cfs_url ); ?>" target="_blank" rel="noopener">
-								<?php esc_html_e( 'Call for Speakers', 'wpfaevent' ); ?>
-							</a>
+						<?php if ( ! empty( $schedule_items ) ) : ?>
+							<span>
+								<?php
+								printf(
+									/* translators: %d: number of schedule sessions. */
+									esc_html( _n( '%d session', '%d sessions', count( $schedule_items ), 'wpfaevent' ) ),
+									absint( count( $schedule_items ) )
+								);
+								?>
+							</span>
 						<?php endif; ?>
 					</div>
-				<?php endif; ?>
-			</div>
-		</header>
-
-		<div class="container">
-			<div class="wpfa-single-event-layout">
-				<article class="wpfa-single-event-content">
-					<?php if ( ! empty( $image_url ) ) : ?>
-						<figure class="wpfa-single-event-image">
-							<img src="<?php echo esc_url( $image_url ); ?>" alt="<?php echo esc_attr( get_the_title( $event_id ) ); ?>">
-						</figure>
+					<?php if ( '' !== trim( $about_content ) ) : ?>
+						<div class="wpfa-event-hero-text">
+							<?php echo wp_kses_post( wpautop( wp_trim_words( wp_strip_all_tags( $about_content ), 34 ) ) ); ?>
+						</div>
 					<?php endif; ?>
+				</div>
 
-					<div class="wpfa-single-event-body">
-						<?php
-						echo wp_kses_post(
-							apply_filters( 'the_content', get_post_field( 'post_content', $event_id ) )
-						);
-						?>
+				<aside class="wpfa-event-ticket-panel" aria-label="<?php esc_attr_e( 'Event details', 'wpfaevent' ); ?>">
+					<div class="wpfa-event-ticket-head">
+						<p><?php esc_html_e( 'Registration', 'wpfaevent' ); ?></p>
+						<strong><?php esc_html_e( 'Open', 'wpfaevent' ); ?></strong>
 					</div>
-				</article>
-
-				<aside class="wpfa-single-event-details" aria-label="<?php esc_attr_e( 'Event details', 'wpfaevent' ); ?>">
-					<h2><?php esc_html_e( 'Event Details', 'wpfaevent' ); ?></h2>
-
-					<?php if ( ! empty( $date_label ) ) : ?>
-						<div class="wpfa-single-event-detail">
-							<strong><?php esc_html_e( 'Date', 'wpfaevent' ); ?></strong>
-							<span><?php echo esc_html( $date_label ); ?></span>
-						</div>
+					<?php if ( $register_url ) : ?>
+						<a class="wpfa-event-register" href="<?php echo esc_url( $register_url ); ?>" target="_blank" rel="noopener">
+							<?php echo esc_html( $register_text ); ?>
+						</a>
 					<?php endif; ?>
-
-					<?php if ( ! empty( $event_time ) ) : ?>
-						<div class="wpfa-single-event-detail">
-							<strong><?php esc_html_e( 'Time', 'wpfaevent' ); ?></strong>
-							<span><?php echo esc_html( $event_time ); ?></span>
-						</div>
+					<?php if ( $event_google_url ) : ?>
+						<a class="wpfa-event-calendar-link" href="<?php echo esc_url( $event_google_url ); ?>" target="_blank" rel="noopener">
+							<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+						</a>
 					<?php endif; ?>
-
-					<?php if ( ! empty( $event_location ) ) : ?>
-						<div class="wpfa-single-event-detail">
-							<strong><?php esc_html_e( 'Location', 'wpfaevent' ); ?></strong>
-							<span><?php echo esc_html( $event_location ); ?></span>
-						</div>
+					<?php if ( $event_calendar_url ) : ?>
+						<a class="wpfa-event-calendar-download" href="<?php echo esc_url( $event_calendar_url ); ?>">
+							<?php esc_html_e( 'Download .ics', 'wpfaevent' ); ?>
+						</a>
 					<?php endif; ?>
+					<dl class="wpfa-event-facts">
+							<?php if ( $date_label ) : ?>
+								<div>
+									<dt><?php esc_html_e( 'When', 'wpfaevent' ); ?></dt>
+									<dd><?php echo esc_html( $date_label ); ?></dd>
+								</div>
+							<?php endif; ?>
+							<?php if ( $event_time_label ) : ?>
+								<div>
+									<dt><?php esc_html_e( 'Time', 'wpfaevent' ); ?></dt>
+									<dd><?php echo esc_html( $event_time_label ); ?></dd>
+								</div>
+							<?php endif; ?>
+							<?php if ( $event_timezone_label ) : ?>
+								<div>
+									<dt><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></dt>
+									<dd><?php echo esc_html( $event_timezone_label ); ?></dd>
+								</div>
+							<?php endif; ?>
+							<?php if ( $location ) : ?>
+								<div>
+								<dt><?php esc_html_e( 'Where', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( $location ); ?></dd>
+							</div>
+						<?php endif; ?>
+						<?php if ( $event_language_label ) : ?>
+							<div>
+								<dt><?php esc_html_e( 'Languages', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( $event_language_label ); ?></dd>
+							</div>
+						<?php endif; ?>
+						<div>
+							<dt><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></dt>
+							<dd><?php echo esc_html( number_format_i18n( $speaker_count ) ); ?></dd>
+						</div>
+						<?php if ( $sponsor_count ) : ?>
+							<div>
+								<dt><?php esc_html_e( 'Sponsors', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( number_format_i18n( $sponsor_count ) ); ?></dd>
+							</div>
+						<?php endif; ?>
+						<?php if ( ! empty( $visible_exhibitors ) ) : ?>
+							<div>
+								<dt><?php esc_html_e( 'Exhibitors', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( number_format_i18n( count( $visible_exhibitors ) ) ); ?></dd>
+							</div>
+						<?php endif; ?>
+						<?php if ( ! empty( $first_schedule['time_label'] ) ) : ?>
+							<div>
+								<dt><?php esc_html_e( 'Starts', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( $first_schedule['time_label'] ); ?></dd>
+							</div>
+						<?php endif; ?>
+					</dl>
 				</aside>
 			</div>
-		</div>
+		</section>
+
+		<?php if ( ! empty( $wpfa_event_nav_items ) ) : ?>
+			<?php include WPFAEVENT_PATH . 'public/partials/event-section-nav.php'; ?>
+		<?php endif; ?>
+
+		<?php if ( $show_about && '' !== trim( $about_content ) ) : ?>
+			<section id="about" class="wpfa-event-section wpfa-event-about" aria-labelledby="wpfa-event-about-title">
+				<div class="container">
+					<div class="wpfa-event-section-layout">
+						<header class="wpfa-event-section-label">
+							<p><?php esc_html_e( 'Overview', 'wpfaevent' ); ?></p>
+							<h2 id="wpfa-event-about-title"><?php esc_html_e( 'About this event', 'wpfaevent' ); ?></h2>
+						</header>
+						<div class="wpfa-event-rich-text" itemprop="description">
+							<?php echo wp_kses_post( wpautop( $about_content ) ); ?>
+						</div>
+					</div>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( $show_speakers ) : ?>
+			<section id="speakers" class="wpfa-event-section wpfa-event-speakers" aria-labelledby="wpfa-event-speakers-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-speakers-title"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'People linked to this event only.', 'wpfaevent' ); ?></p>
+						</div>
+						<a href="<?php echo esc_url( $speakers_url ); ?>"><?php esc_html_e( 'Open Event Speaker List', 'wpfaevent' ); ?></a>
+					</div>
+
+					<?php if ( ! empty( $speaker_ids ) ) : ?>
+						<?php if ( $featured_speaker_count ) : ?>
+							<div class="wpfa-event-featured-speakers">
+								<h3><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h3>
+								<div class="wpfa-speakers-grid wpfa-featured-speakers-grid">
+									<?php
+									$wpfa_hide_speaker_card_admin_actions = true;
+									$wpfa_schedule_display_timezone       = $selected_schedule_timezone;
+									$wpfa_featured_speaker_ids            = $featured_speaker_ids;
+									foreach ( $featured_speaker_ids as $sid ) :
+										if ( 'wpfa_speaker' !== get_post_type( $sid ) || 'publish' !== get_post_status( $sid ) ) {
+											continue;
+										}
+
+										include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php';
+									endforeach;
+									unset( $wpfa_hide_speaker_card_admin_actions );
+									unset( $wpfa_schedule_display_timezone );
+									unset( $wpfa_featured_speaker_ids );
+									?>
+								</div>
+							</div>
+						<?php endif; ?>
+
+						<?php if ( ! empty( $regular_speaker_ids ) ) : ?>
+							<div class="wpfa-event-regular-speakers">
+								<h3><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h3>
+								<div class="wpfa-speakers-grid">
+									<?php
+									$wpfa_hide_speaker_card_admin_actions = true;
+									$wpfa_schedule_display_timezone       = $selected_schedule_timezone;
+									foreach ( $main_regular_speaker_ids as $sid ) :
+										if ( 'wpfa_speaker' !== get_post_type( $sid ) || 'publish' !== get_post_status( $sid ) ) {
+											continue;
+										}
+
+										include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php';
+									endforeach;
+									unset( $wpfa_hide_speaker_card_admin_actions );
+									unset( $wpfa_schedule_display_timezone );
+									?>
+								</div>
+								<?php if ( $regular_speaker_overflow_count ) : ?>
+									<p class="wpfa-event-speaker-limit-note">
+										<?php
+										printf(
+											/* translators: 1: shown speaker count, 2: total speaker count. */
+											esc_html__( 'Showing the main %1$d of %2$d speakers. Open the full event speaker list to view everyone.', 'wpfaevent' ),
+											absint( count( $main_regular_speaker_ids ) ),
+											absint( count( $regular_speaker_ids ) )
+										);
+										?>
+									</p>
+								<?php endif; ?>
+							</div>
+						<?php endif; ?>
+					<?php elseif ( ! empty( $dashboard_speakers ) ) : ?>
+						<?php if ( ! empty( $dashboard_featured_speakers ) ) : ?>
+							<div class="wpfa-event-featured-speakers">
+								<h3><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h3>
+								<div class="wpfa-speakers-grid wpfa-featured-speakers-grid">
+									<?php foreach ( $dashboard_featured_speakers as $speaker ) : ?>
+										<?php
+										$wpfa_dashboard_speaker_is_featured = true;
+										include WPFAEVENT_PATH . 'public/partials/speakers/dashboard-speaker-card.php';
+										unset( $wpfa_dashboard_speaker_is_featured );
+										?>
+									<?php endforeach; ?>
+								</div>
+							</div>
+
+							<?php if ( ! empty( $dashboard_regular_speakers ) ) : ?>
+								<div class="wpfa-event-regular-speakers">
+									<h3><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h3>
+									<div class="wpfa-speakers-grid">
+										<?php foreach ( $main_dashboard_regular_speakers as $speaker ) : ?>
+											<?php include WPFAEVENT_PATH . 'public/partials/speakers/dashboard-speaker-card.php'; ?>
+										<?php endforeach; ?>
+									</div>
+									<?php if ( $dashboard_regular_speaker_overflow_count ) : ?>
+										<p class="wpfa-event-speaker-limit-note">
+											<?php
+											printf(
+												/* translators: 1: shown speaker count, 2: total speaker count. */
+												esc_html__( 'Showing the main %1$d of %2$d speakers. Open the full event speaker list to view everyone.', 'wpfaevent' ),
+												absint( count( $main_dashboard_regular_speakers ) ),
+												absint( count( $dashboard_regular_speakers ) )
+											);
+											?>
+										</p>
+									<?php endif; ?>
+								</div>
+							<?php endif; ?>
+						<?php else : ?>
+							<div class="wpfa-speakers-grid">
+								<?php foreach ( $main_dashboard_speakers as $speaker ) : ?>
+									<?php include WPFAEVENT_PATH . 'public/partials/speakers/dashboard-speaker-card.php'; ?>
+								<?php endforeach; ?>
+							</div>
+							<?php if ( $dashboard_speaker_overflow_count ) : ?>
+								<p class="wpfa-event-speaker-limit-note">
+									<?php
+									printf(
+										/* translators: 1: shown speaker count, 2: total speaker count. */
+										esc_html__( 'Showing the main %1$d of %2$d speakers. Open the full event speaker list to view everyone.', 'wpfaevent' ),
+										absint( count( $main_dashboard_speakers ) ),
+										absint( count( $dashboard_speakers ) )
+									);
+									?>
+								</p>
+							<?php endif; ?>
+						<?php endif; ?>
+					<?php else : ?>
+						<p class="wpfa-empty-state"><?php esc_html_e( 'No speakers have been imported for this event yet.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( $show_schedule ) : ?>
+			<section id="schedule-overview" class="wpfa-event-section wpfa-event-schedule" aria-labelledby="wpfa-event-schedule-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-schedule-title"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Times and rooms imported from Eventyay.', 'wpfaevent' ); ?></p>
+						</div>
+						<?php if ( ! empty( $schedule_items ) ) : ?>
+							<div class="wpfa-event-section-actions">
+								<nav class="wpfa-schedule-view-switch" aria-label="<?php esc_attr_e( 'Schedule view', 'wpfaevent' ); ?>">
+									<a
+										class="<?php echo esc_attr( 'list' === $current_schedule_view ? 'is-active' : '' ); ?>"
+										href="<?php echo esc_url( $build_event_schedule_view_url( 'list' ) ); ?>"
+										<?php if ( 'list' === $current_schedule_view ) : ?>
+											aria-current="page"
+										<?php endif; ?>
+									>
+										<?php esc_html_e( 'List', 'wpfaevent' ); ?>
+									</a>
+									<a
+										class="<?php echo esc_attr( 'calendar' === $current_schedule_view ? 'is-active' : '' ); ?>"
+										href="<?php echo esc_url( $build_event_schedule_view_url( 'calendar' ) ); ?>"
+										<?php if ( 'calendar' === $current_schedule_view ) : ?>
+											aria-current="page"
+										<?php endif; ?>
+									>
+										<?php esc_html_e( 'Calendar', 'wpfaevent' ); ?>
+									</a>
+								</nav>
+								<a href="<?php echo esc_url( $event_schedule_url ); ?>"><?php esc_html_e( 'Full Schedule', 'wpfaevent' ); ?></a>
+								<form class="wpfa-event-timezone-form" action="<?php echo esc_url( get_permalink( $event_id ) . '#wpfa-event-schedule-title' ); ?>" method="get">
+									<?php if ( 'calendar' === $current_schedule_view ) : ?>
+										<input type="hidden" name="schedule_view" value="calendar">
+									<?php endif; ?>
+									<label for="wpfa-event-schedule-timezone">
+										<span><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></span>
+										<select id="wpfa-event-schedule-timezone" class="wpfa-event-timezone-select" name="schedule_tz">
+											<?php foreach ( $schedule_timezone_options as $timezone_option ) : ?>
+												<option value="<?php echo esc_attr( $timezone_option ); ?>" <?php selected( $selected_schedule_timezone_string, $timezone_option ); ?>>
+													<?php echo esc_html( $format_timezone_label( $timezone_option ) ); ?>
+												</option>
+											<?php endforeach; ?>
+										</select>
+									</label>
+									<button type="submit"><?php esc_html_e( 'Convert', 'wpfaevent' ); ?></button>
+								</form>
+							</div>
+						<?php endif; ?>
+					</div>
+					<?php if ( ! empty( $schedule_preview_items ) ) : ?>
+						<?php if ( 'calendar' === $current_schedule_view ) : ?>
+							<div class="wpfa-schedule-calendar" role="list">
+								<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
+									<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading">
+										<header class="wpfa-schedule-calendar-day-head">
+											<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading"><?php echo esc_html( $day_label ); ?></h3>
+											<span>
+												<?php
+												printf(
+													/* translators: %d: number of sessions on this day. */
+													esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+													absint( count( $day_sessions ) )
+												);
+												?>
+											</span>
+										</header>
+										<div class="wpfa-schedule-calendar-slots">
+											<?php foreach ( $day_sessions as $item ) : ?>
+												<article class="wpfa-schedule-calendar-slot">
+													<?php if ( ! empty( $item['time_label'] ) ) : ?>
+														<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+													<?php endif; ?>
+													<h4><?php echo esc_html( $item['title'] ); ?></h4>
+													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+														<ul class="wpfa-schedule-calendar-meta">
+															<?php if ( ! empty( $item['speakers'] ) ) : ?>
+																<li><?php echo esc_html( $item['speakers'] ); ?></li>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['room'] ) ) : ?>
+																<li><?php echo esc_html( $item['room'] ); ?></li>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['track'] ) ) : ?>
+																<li><?php echo esc_html( $item['track'] ); ?></li>
+															<?php endif; ?>
+														</ul>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+														<?php
+														$session_calendar_label = sprintf(
+															/* translators: %s: session title. */
+															__( 'Add %s to Google Calendar', 'wpfaevent' ),
+															$item['title']
+														);
+														?>
+														<a
+															class="wpfa-schedule-session-calendar"
+															href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+															target="_blank"
+															rel="noopener"
+															aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+														>
+															<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+														</a>
+													<?php endif; ?>
+												</article>
+											<?php endforeach; ?>
+										</div>
+									</section>
+								<?php endforeach; ?>
+							</div>
+						<?php else : ?>
+							<div class="wpfa-schedule-program">
+								<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
+									<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+										<header class="wpfa-schedule-day-head">
+											<div>
+												<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h3>
+												<p>
+													<?php
+													printf(
+														/* translators: %d: number of sessions on this day. */
+														esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+														absint( count( $day_sessions ) )
+													);
+													?>
+												</p>
+											</div>
+										</header>
+
+										<div class="wpfa-schedule-day-sessions" role="list">
+											<?php foreach ( $day_sessions as $item ) : ?>
+												<article class="wpfa-schedule-session" role="listitem">
+													<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+														<?php if ( ! empty( $item['time_start'] ) ) : ?>
+															<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+																<?php echo esc_html( $item['time_start'] ); ?>
+															</time>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['time_end'] ) ) : ?>
+															<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
+														<?php endif; ?>
+													</div>
+
+													<div class="wpfa-schedule-session-main">
+														<h4 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h4>
+
+														<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+															<dl class="wpfa-schedule-session-details">
+																<?php if ( ! empty( $item['speakers'] ) ) : ?>
+																	<div class="wpfa-schedule-detail">
+																		<dt><?php esc_html_e( 'Speaker', 'wpfaevent' ); ?></dt>
+																		<dd><?php echo esc_html( $item['speakers'] ); ?></dd>
+																	</div>
+																<?php endif; ?>
+																<?php if ( ! empty( $item['room'] ) ) : ?>
+																	<div class="wpfa-schedule-detail">
+																		<dt><?php esc_html_e( 'Room', 'wpfaevent' ); ?></dt>
+																		<dd><?php echo esc_html( $item['room'] ); ?></dd>
+																	</div>
+																<?php endif; ?>
+																<?php if ( ! empty( $item['track'] ) ) : ?>
+																	<div class="wpfa-schedule-detail">
+																		<dt><?php esc_html_e( 'Track', 'wpfaevent' ); ?></dt>
+																		<dd><?php echo esc_html( $item['track'] ); ?></dd>
+																	</div>
+																<?php endif; ?>
+															</dl>
+														<?php endif; ?>
+
+														<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+															<?php
+															$session_calendar_label = sprintf(
+																/* translators: %s: session title. */
+																__( 'Add %s to Google Calendar', 'wpfaevent' ),
+																$item['title']
+															);
+															?>
+															<a
+																class="wpfa-schedule-session-calendar"
+																href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+																target="_blank"
+																rel="noopener"
+																aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+															>
+																<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+															</a>
+														<?php endif; ?>
+													</div>
+												</article>
+											<?php endforeach; ?>
+										</div>
+									</section>
+								<?php endforeach; ?>
+							</div>
+						<?php endif; ?>
+						<?php if ( $schedule_hidden_count ) : ?>
+							<p class="wpfa-event-schedule-preview-note">
+								<?php
+								printf(
+									/* translators: 1: shown session count, 2: total session count. */
+									esc_html__( 'Showing the first %1$d of %2$d sessions. Open the full schedule to view every session.', 'wpfaevent' ),
+									absint( count( $schedule_preview_items ) ),
+									absint( count( $schedule_items ) )
+								);
+								?>
+							</p>
+						<?php endif; ?>
+					<?php else : ?>
+						<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( '' !== trim( wp_strip_all_tags( $venue_information ) ) ) : ?>
+			<section id="venue" class="wpfa-event-section wpfa-event-venue" aria-labelledby="wpfa-event-venue-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-venue-title"><?php esc_html_e( 'Additional information', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Nearby hotels, transportation, parking, directions, and venue notes.', 'wpfaevent' ); ?></p>
+						</div>
+						<a href="<?php echo esc_url( $event_additional_url ); ?>"><?php esc_html_e( 'View Additional Information', 'wpfaevent' ); ?></a>
+					</div>
+					<div class="wpfa-event-rich-text wpfa-event-additional-preview">
+						<?php echo wp_kses_post( wpautop( $venue_information ) ); ?>
+					</div>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php foreach ( $custom_tabs as $custom_tab ) : ?>
+			<?php
+			if ( empty( $custom_tab['slug'] ) || empty( $custom_tab['title'] ) || empty( $custom_tab['content'] ) ) {
+				continue;
+			}
+
+			$custom_tab_title_id = 'wpfa-event-custom-tab-' . sanitize_html_class( $custom_tab['slug'] ) . '-title';
+			?>
+			<section id="custom-section-<?php echo esc_attr( $custom_tab['slug'] ); ?>" class="wpfa-event-section wpfa-event-custom-tab" aria-labelledby="<?php echo esc_attr( $custom_tab_title_id ); ?>">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="<?php echo esc_attr( $custom_tab_title_id ); ?>"><?php echo esc_html( $custom_tab['title'] ); ?></h2>
+						</div>
+					</div>
+					<div class="wpfa-event-rich-text wpfa-event-custom-tab-content">
+						<?php echo wp_kses_post( wpautop( $custom_tab['content'] ) ); ?>
+					</div>
+				</div>
+			</section>
+		<?php endforeach; ?>
+
+		<?php if ( $show_sponsors && ! empty( $visible_sponsor_groups ) ) : ?>
+			<section id="sponsors" class="wpfa-event-section wpfa-event-sponsors" aria-labelledby="wpfa-event-sponsors-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-sponsors-title"><?php esc_html_e( 'Sponsors', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Organizations supporting this event.', 'wpfaevent' ); ?></p>
+						</div>
+					</div>
+
+					<div class="wpfa-event-partner-groups">
+						<?php foreach ( $visible_sponsor_groups as $sponsor_group ) : ?>
+							<?php
+							$group_name = ! empty( $sponsor_group['group_name'] ) ? sanitize_text_field( $sponsor_group['group_name'] ) : __( 'Sponsors', 'wpfaevent' );
+							$logo_size  = ! empty( $sponsor_group['logo_size'] ) ? absint( $sponsor_group['logo_size'] ) : 160;
+							?>
+							<div class="wpfa-event-partner-group">
+								<h3><?php echo esc_html( $group_name ); ?></h3>
+								<div class="wpfa-event-partner-grid">
+									<?php foreach ( $sponsor_group['sponsors'] as $sponsor ) : ?>
+										<?php
+										$sponsor_name        = ! empty( $sponsor['name'] ) ? sanitize_text_field( $sponsor['name'] ) : '';
+										$sponsor_image       = ! empty( $sponsor['image'] ) ? esc_url_raw( $sponsor['image'] ) : '';
+										$sponsor_description = ! empty( $sponsor['description'] ) ? wp_kses_post( $sponsor['description'] ) : '';
+										$sponsor_detail_url  = class_exists( 'Wpfaevent_Partner_Helper' )
+											? Wpfaevent_Partner_Helper::get_partner_detail_url( $event_id, 'sponsor', $sponsor )
+											: '';
+										?>
+										<a class="wpfa-event-partner-card wpfa-event-partner-card-link" href="<?php echo esc_url( $sponsor_detail_url ? $sponsor_detail_url : '#' ); ?>">
+											<?php if ( $sponsor_image ) : ?>
+												<div class="wpfa-event-partner-logo" style="--partner-logo-size: <?php echo esc_attr( $logo_size ); ?>px;">
+													<img src="<?php echo esc_url( $sponsor_image ); ?>" alt="<?php echo esc_attr( $sponsor_name ); ?>" loading="lazy">
+												</div>
+											<?php endif; ?>
+											<div class="wpfa-event-partner-body">
+												<?php if ( $sponsor_name ) : ?>
+													<h4><?php echo esc_html( $sponsor_name ); ?></h4>
+												<?php endif; ?>
+												<?php if ( $sponsor_description ) : ?>
+													<div class="wpfa-event-partner-description"><?php echo wp_kses_post( wpautop( wp_trim_words( wp_strip_all_tags( $sponsor_description ), 24, '…' ) ) ); ?></div>
+												<?php endif; ?>
+												<span class="wpfa-event-partner-view-details"><?php esc_html_e( 'View details', 'wpfaevent' ); ?></span>
+											</div>
+										</a>
+									<?php endforeach; ?>
+								</div>
+							</div>
+						<?php endforeach; ?>
+					</div>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( $show_exhibitors && ! empty( $visible_exhibitors ) ) : ?>
+			<section id="exhibitors" class="wpfa-event-section wpfa-event-exhibitors" aria-labelledby="wpfa-event-exhibitors-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-exhibitors-title"><?php esc_html_e( 'Exhibitors', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Exhibitor booths and resources for this event.', 'wpfaevent' ); ?></p>
+						</div>
+					</div>
+
+					<div class="wpfa-event-exhibitor-grid">
+						<?php foreach ( $visible_exhibitors as $exhibitor ) : ?>
+							<?php
+							$exhibitor_name        = sanitize_text_field( $exhibitor['name'] );
+							$exhibitor_logo        = ! empty( $exhibitor['logo'] ) ? esc_url_raw( $exhibitor['logo'] ) : '';
+							$exhibitor_banner      = ! empty( $exhibitor['banner'] ) ? esc_url_raw( $exhibitor['banner'] ) : '';
+							$exhibitor_initial     = $exhibitor_name ? strtoupper( substr( $exhibitor_name, 0, 1 ) ) : '';
+							$exhibitor_card_class  = 'wpfa-event-exhibitor-card';
+							$exhibitor_card_class .= $exhibitor_banner ? ' has-banner' : ' no-banner';
+							$exhibitor_card_class .= $exhibitor_logo ? ' has-logo' : ' no-logo';
+							$exhibitor_detail_url  = class_exists( 'Wpfaevent_Partner_Helper' )
+								? Wpfaevent_Partner_Helper::get_partner_detail_url( $event_id, 'exhibitor', $exhibitor )
+								: '';
+							?>
+							<a class="<?php echo esc_attr( $exhibitor_card_class ); ?> wpfa-event-exhibitor-card-link" href="<?php echo esc_url( $exhibitor_detail_url ? $exhibitor_detail_url : '#' ); ?>">
+								<?php if ( $exhibitor_banner ) : ?>
+									<img class="wpfa-event-exhibitor-banner" src="<?php echo esc_url( $exhibitor_banner ); ?>" alt="<?php echo esc_attr( $exhibitor_name ); ?>" loading="lazy">
+								<?php endif; ?>
+								<span class="wpfa-event-exhibitor-summary">
+									<span class="wpfa-event-exhibitor-main">
+										<?php if ( $exhibitor_logo ) : ?>
+											<span class="wpfa-event-exhibitor-logo">
+												<img src="<?php echo esc_url( $exhibitor_logo ); ?>" alt="<?php echo esc_attr( $exhibitor_name ); ?>" loading="lazy">
+											</span>
+										<?php else : ?>
+											<span class="wpfa-event-exhibitor-placeholder" aria-hidden="true">
+												<?php echo esc_html( $exhibitor_initial ); ?>
+											</span>
+										<?php endif; ?>
+										<span class="wpfa-event-exhibitor-copy">
+											<span class="wpfa-event-exhibitor-eyebrow"><?php esc_html_e( 'Exhibitor', 'wpfaevent' ); ?></span>
+											<span class="wpfa-event-exhibitor-name"><?php echo esc_html( $exhibitor_name ); ?></span>
+										</span>
+									</span>
+									<span class="wpfa-event-exhibitor-toggle">
+										<span class="wpfa-event-exhibitor-toggle-closed"><?php esc_html_e( 'View details', 'wpfaevent' ); ?></span>
+									</span>
+								</span>
+							</a>
+						<?php endforeach; ?>
+					</div>
+				</div>
+			</section>
+		<?php endif; ?>
 	</main>
 
-	<?php require WPFAEVENT_PATH . 'public/partials/footer.php'; ?>
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
 </div>
 
-	<?php wp_footer(); ?>
+<?php wp_footer(); ?>
 </body>
 </html>

--- a/public/templates/single-wpfa-speaker.php
+++ b/public/templates/single-wpfa-speaker.php
@@ -20,21 +20,22 @@ if ( ! $speaker_id || 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
 	return;
 }
 
-$speaker_name  = get_the_title( $speaker_id );
-$position      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_position', true ) );
-$organization  = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_organization', true ) );
-$bio           = get_post_meta( $speaker_id, 'wpfa_speaker_bio', true );
-$photo_url     = get_post_meta( $speaker_id, 'wpfa_speaker_headshot_url', true );
-$linkedin      = get_post_meta( $speaker_id, 'wpfa_speaker_linkedin', true );
-$twitter       = get_post_meta( $speaker_id, 'wpfa_speaker_twitter', true );
-$github        = get_post_meta( $speaker_id, 'wpfa_speaker_github', true );
-$website       = get_post_meta( $speaker_id, 'wpfa_speaker_website', true );
-$talk_title    = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_title', true ) );
-$talk_date     = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_date', true ) );
-$talk_start    = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_time', true ) );
-$talk_end      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_end_time', true ) );
-$talk_abstract = get_post_meta( $speaker_id, 'wpfa_speaker_talk_abstract', true );
-$photo_alt     = sprintf(
+$speaker_name    = get_the_title( $speaker_id );
+$position        = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_position', true ) );
+$organization    = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_organization', true ) );
+$bio             = get_post_meta( $speaker_id, 'wpfa_speaker_bio', true );
+$photo_url       = get_post_meta( $speaker_id, 'wpfa_speaker_headshot_url', true );
+$placeholder_url = WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
+$linkedin        = get_post_meta( $speaker_id, 'wpfa_speaker_linkedin', true );
+$twitter         = get_post_meta( $speaker_id, 'wpfa_speaker_twitter', true );
+$github          = get_post_meta( $speaker_id, 'wpfa_speaker_github', true );
+$website         = get_post_meta( $speaker_id, 'wpfa_speaker_website', true );
+$talk_title      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_title', true ) );
+$talk_date       = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_date', true ) );
+$talk_start      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_time', true ) );
+$talk_end        = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_end_time', true ) );
+$talk_abstract   = get_post_meta( $speaker_id, 'wpfa_speaker_talk_abstract', true );
+$photo_alt       = sprintf(
 	/* translators: %s: Speaker name. */
 	__( 'Photo of %s', 'wpfaevent' ),
 	$speaker_name
@@ -68,52 +69,7 @@ if ( $talk_start || $talk_end ) {
 
 $has_session_details = $talk_title || $talk_date || $talk_start || $talk_end || $talk_abstract;
 
-$stored_event_ids = get_post_meta( $speaker_id, 'wpfa_speaker_events', true );
-$stored_event_ids = is_array( $stored_event_ids ) ? array_map( 'absint', $stored_event_ids ) : array();
-$stored_event_ids = array_filter( $stored_event_ids );
-
-$relationship_event_ids = array();
-if ( empty( $stored_event_ids ) ) {
-	$relationship_event_ids = get_posts(
-		array(
-			'post_type'      => 'wpfa_event',
-			'post_status'    => 'publish',
-			'posts_per_page' => -1,
-			'fields'         => 'ids',
-			'no_found_rows'  => true,
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
-			'meta_query'     => array(
-				'relation' => 'OR',
-				array(
-					'key'     => 'wpfa_event_speakers',
-					'value'   => 'i:' . $speaker_id . ';',
-					'compare' => 'LIKE',
-				),
-				array(
-					'key'     => 'wpfa_event_speakers',
-					'value'   => '"' . $speaker_id . '"',
-					'compare' => 'LIKE',
-				),
-				array(
-					'key'     => 'wpfa_event_speakers',
-					'value'   => (string) $speaker_id,
-					'compare' => '=',
-				),
-			),
-		)
-	);
-}
-
-$linked_event_ids = array_values(
-	array_unique(
-		array_filter(
-			array_map(
-				'absint',
-				array_merge( $stored_event_ids, $relationship_event_ids )
-			)
-		)
-	)
-);
+$linked_event_ids = Wpfaevent_Meta_Speaker::get_events_linked_to_speaker( $speaker_id, 'publish' );
 
 usort(
 	$linked_event_ids,
@@ -194,26 +150,12 @@ $header_vars = array(
 							itemprop="image"
 						>
 					<?php else : ?>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 300 300"
-							class="wpfa-placeholder-svg"
-							role="img"
-							aria-label="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>"
+						<img
+							src="<?php echo esc_url( $placeholder_url ); ?>"
+							alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>"
+							class="wpfa-speaker-placeholder-img"
+							itemprop="image"
 						>
-							<rect width="100%" height="100%" fill="#eee" />
-							<text
-								x="50%"
-								y="50%"
-								dominant-baseline="middle"
-								text-anchor="middle"
-								font-family="sans-serif"
-								font-size="20"
-								fill="#999"
-							>
-								<?php esc_html_e( 'Speaker', 'wpfaevent' ); ?>
-							</text>
-						</svg>
 					<?php endif; ?>
 				</div>
 
@@ -287,67 +229,52 @@ $header_vars = array(
 								</a>
 							<?php endif; ?>
 						</div>
+					<?php endif; ?>
+				</div>
+			</div>
+		</section>
+
+		<?php if ( $has_session_details ) : ?>
+			<section class="wpfa-speaker-sessions" aria-labelledby="wpfa-speaker-sessions-title">
+				<div class="container">
+					<h2 id="wpfa-speaker-sessions-title"><?php esc_html_e( 'Sessions by this speaker', 'wpfaevent' ); ?></h2>
+
+					<article class="wpfa-speaker-session-card" itemprop="performerIn" itemscope itemtype="https://schema.org/Event">
+						<?php if ( $talk_title ) : ?>
+							<h3 itemprop="name"><?php echo esc_html( $talk_title ); ?></h3>
 						<?php endif; ?>
-					</div>
+
+						<?php if ( ! empty( $session_meta ) ) : ?>
+							<p class="wpfa-speaker-session-meta"><?php echo esc_html( implode( ' | ', $session_meta ) ); ?></p>
+						<?php endif; ?>
+
+						<?php if ( $talk_abstract ) : ?>
+							<div class="wpfa-speaker-session-abstract" itemprop="description">
+								<?php echo wp_kses_post( wpautop( $talk_abstract ) ); ?>
+							</div>
+						<?php endif; ?>
+					</article>
 				</div>
 			</section>
+		<?php endif; ?>
 
-			<?php if ( $has_session_details ) : ?>
-				<section class="wpfa-speaker-sessions" aria-labelledby="wpfa-speaker-sessions-title">
-					<div class="container">
-						<h2 id="wpfa-speaker-sessions-title"><?php esc_html_e( 'Sessions by this speaker', 'wpfaevent' ); ?></h2>
+		<section class="wpfa-linked-events" aria-labelledby="wpfa-linked-events-title">
+			<div class="container">
+				<h2 id="wpfa-linked-events-title"><?php esc_html_e( 'Linked Events', 'wpfaevent' ); ?></h2>
 
-						<article class="wpfa-speaker-session-card" itemprop="performerIn" itemscope itemtype="https://schema.org/Event">
-							<?php if ( $talk_title ) : ?>
-								<h3 itemprop="name"><?php echo esc_html( $talk_title ); ?></h3>
-							<?php endif; ?>
-
-							<?php if ( ! empty( $session_meta ) ) : ?>
-								<p class="wpfa-speaker-session-meta"><?php echo esc_html( implode( ' | ', $session_meta ) ); ?></p>
-							<?php endif; ?>
-
-							<?php if ( $talk_abstract ) : ?>
-								<div class="wpfa-speaker-session-abstract" itemprop="description">
-									<?php echo wp_kses_post( wpautop( $talk_abstract ) ); ?>
-								</div>
-							<?php endif; ?>
-						</article>
-					</div>
-				</section>
-			<?php endif; ?>
-
-			<section class="wpfa-linked-events" aria-labelledby="wpfa-linked-events-title">
-				<div class="container">
-					<h2 id="wpfa-linked-events-title"><?php esc_html_e( 'Linked Events', 'wpfaevent' ); ?></h2>
-
-					<?php if ( ! empty( $linked_event_ids ) ) : ?>
+				<?php if ( ! empty( $linked_event_ids ) ) : ?>
 					<div class="wpfa-linked-events-grid">
 						<?php foreach ( $linked_event_ids as $event_id ) : ?>
 							<?php
-							$event_title   = get_the_title( $event_id );
-							$event_start   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
-							$event_end     = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
-							$event_loc     = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
-							$event_url     = get_post_meta( $event_id, 'wpfa_event_url', true );
-							$event_url     = $event_url ? $event_url : get_permalink( $event_id );
-							$event_meta    = array();
-							$calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-							$calendar_data = is_wp_error( $calendar_data ) ? array() : $calendar_data;
+							$event_title = get_the_title( $event_id );
+							$event_start = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
+							$event_end   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
+							$event_loc   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+							$event_url   = get_post_meta( $event_id, 'wpfa_event_url', true );
+							$event_url   = $event_url ? $event_url : get_permalink( $event_id );
+							$event_meta  = array();
 
-							if ( ! empty( $calendar_data['date_label'] ) ) {
-								$date_time_label = sanitize_text_field( $calendar_data['date_label'] );
-								$time_label      = ! empty( $calendar_data['time_label'] ) ? sanitize_text_field( $calendar_data['time_label'] ) : '';
-
-								if ( $time_label ) {
-									$date_time_label .= ' | ' . $time_label;
-
-									if ( empty( $calendar_data['all_day'] ) && ! empty( $calendar_data['timezone_label'] ) ) {
-										$date_time_label .= ' (' . sanitize_text_field( $calendar_data['timezone_label'] ) . ')';
-									}
-								}
-
-								$event_meta[] = $date_time_label;
-							} elseif ( $event_start ) {
+							if ( $event_start ) {
 								$event_meta[] = $event_start . ( $event_end ? ' - ' . $event_end : '' );
 							}
 


### PR DESCRIPTION
## Summary

Split out from #81 as PR 3/3. This PR is stacked on #120 and adds the frontend surfaces for imported Eventyay data:

- render imported event details, schedule preview/full schedule, speaker sections, sponsors, and exhibitors on event pages
- add event archive filtering/search and imported event card metadata
- add event-filtered speaker views and featured speaker grouping
- add partner detail page and additional information page helpers/templates
- update public CSS/JS and template routing for the imported-data experience
- keep current calendar timezone output behavior while layering the #81 schedule display updates

## Stack

1. #119: Eventyay import core
2. #120: related Eventyay data import
3. This PR: frontend display

After #120 merges, this PR can be retargeted to `main`.

## Tests

- `php tests/calendar-test.php`
- `php tests/speaker-relationship-test.php`
- `composer phpcs`