### PR TITLE
ci: increase PHPStan analysis level from 4 to 5

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 4 # TODO: raise level incrementally as codebase is cleaned up
+    level: 5 # TODO: raise level incrementally as codebase is cleaned up
 
     # Target PHP 7.4 specifically to match the plugin's platform requirement
     phpVersion: 70400


### PR DESCRIPTION
## Description
The project currently runs PHPStan at level 4. To gradually improve static analysis coverage, catch type mismatches, and ensure better API consistency across our codebase, the configuration should be updated to level 5.

Level 5 introduces checking of types passed to methods and functions. This ensures that the arguments provided match the expected typehints defined in the method/function signatures or PHPDoc annotations.

## Expected Behavior
* Update the PHPStan configuration (`phpstan.neon` or `phpstan.neon.dist`) to use level 5.
* Resolve any newly reported issues regarding argument type mismatches, or add them to the baseline if appropriate.

## Benefits
* **Stronger type safety:** Ensures correct argument types are passed to functions and methods.
* **Identification of latent bugs:** Catches bugs caused by passing incompatible types that might slip past loose PHP types.
* **Safer refactoring:** Changing a method signature will immediately surface errors across the codebase.
* **Incremental progress:** Keeps us moving toward stricter PHPStan levels (targeting level 6 next).

## Reference
[PHPStan Rule Levels Documentation](https://phpstan.org/user-guide/rule-levels)

---

- Fixes: #115

## Summary by Sourcery

Raise PHPStan static analysis strictness level to improve type safety and catch additional issues during CI analysis.

CI:
- Update PHPStan configuration to run analysis at a stricter rule level.

Chores:
- Adjust static analysis configuration to support incremental tightening of type checks.