### PR TITLE
Split #81 (3b/4): Frontend templates and partials for Eventyay data display

### DIFF
--- a/public/partials/additional-information-page.php
+++ b/public/partials/additional-information-page.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Legacy proxy for the additional information page template.
+ *
+ * @package Wpfaevent
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$template = dirname( __DIR__ ) . '/templates/page-additional-information.php';
+
+if ( file_exists( $template ) ) {
+	include $template;
+}

--- a/public/partials/event-section-nav.php
+++ b/public/partials/event-section-nav.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Event section navigation partial.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/partials
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( empty( $wpfa_event_nav_items ) || ! is_array( $wpfa_event_nav_items ) ) {
+	return;
+}
+?>
+<nav class="wpfa-event-section-nav" aria-label="<?php esc_attr_e( 'Event sections', 'wpfaevent' ); ?>">
+	<div class="container">
+		<?php foreach ( $wpfa_event_nav_items as $nav_item ) : ?>
+			<?php
+			if ( empty( $nav_item['text'] ) ) {
+				continue;
+			}
+
+			$nav_type = isset( $nav_item['type'] ) ? (string) $nav_item['type'] : 'link';
+			?>
+			<?php if ( 'dropdown' === $nav_type && ! empty( $nav_item['items'] ) && is_array( $nav_item['items'] ) ) : ?>
+				<div class="wpfa-event-nav-dropdown nav-dropdown">
+					<button type="button" class="wpfa-event-nav-dropdown-toggle nav-dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+						<?php echo esc_html( $nav_item['text'] ); ?>
+					</button>
+					<div class="wpfa-event-nav-dropdown-content nav-dropdown-content">
+						<?php foreach ( $nav_item['items'] as $sub_item ) : ?>
+							<?php if ( empty( $sub_item['href'] ) || empty( $sub_item['text'] ) ) : ?>
+								<?php continue; ?>
+							<?php endif; ?>
+							<a href="<?php echo esc_url( $sub_item['href'] ); ?>"><?php echo esc_html( $sub_item['text'] ); ?></a>
+						<?php endforeach; ?>
+					</div>
+				</div>
+			<?php elseif ( ! empty( $nav_item['href'] ) ) : ?>
+				<a href="<?php echo esc_url( $nav_item['href'] ); ?>"><?php echo esc_html( $nav_item['text'] ); ?></a>
+			<?php endif; ?>
+		<?php endforeach; ?>
+	</div>
+</nav>

--- a/public/partials/events/event-card.php
+++ b/public/partials/events/event-card.php
@@ -30,34 +30,17 @@ $today = current_time( 'Y-m-d' );
 // Get meta data exactly as the main template does.
 $event_date        = get_post_meta( $event_id, 'wpfa_event_start_date', true );
 $event_end_date    = get_post_meta( $event_id, 'wpfa_event_end_date', true );
-$event_start_time  = get_post_meta( $event_id, 'wpfa_event_start_time', true );
-$event_end_time    = get_post_meta( $event_id, 'wpfa_event_end_time', true );
-$event_legacy_time = get_post_meta( $event_id, 'wpfa_event_time', true );
-$event_timezone    = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_timezone( $event_id ) : '';
-$event_all_day     = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_all_day( $event_id ) : false;
 $event_place       = get_post_meta( $event_id, 'wpfa_event_location', true );
 $event_description = get_the_excerpt( $event_id );
 $featured_img_url  = get_the_post_thumbnail_url( $event_id, 'large' ) ?? '';
-$event_time_value  = $event_start_time ? $event_start_time : $event_legacy_time;
-
-$event_calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-$event_calendar_data = is_wp_error( $event_calendar_data ) ? array() : $event_calendar_data;
 
 // Check if date is valid (Admin Warning Logic).
 $is_valid_date = ! empty( $event_date ) && strtotime( $event_date ) !== false;
 $is_past_event = $is_valid_date && strtotime( $event_date ) < strtotime( $today );
 
 // Format the date string.
-$formatted_date      = __( 'Date not set', 'wpfaevent' );
-$formatted_time_meta = '';
-if ( ! empty( $event_calendar_data['date_label'] ) ) {
-	$formatted_date      = sanitize_text_field( $event_calendar_data['date_label'] );
-	$formatted_time_meta = ! empty( $event_calendar_data['time_label'] ) ? sanitize_text_field( $event_calendar_data['time_label'] ) : '';
-
-	if ( $formatted_time_meta && empty( $event_calendar_data['all_day'] ) && ! empty( $event_calendar_data['timezone_label'] ) ) {
-		$formatted_time_meta .= ' (' . sanitize_text_field( $event_calendar_data['timezone_label'] ) . ')';
-	}
-} elseif ( $is_valid_date ) {
+$formatted_date = __( 'Date not set', 'wpfaevent' );
+if ( $is_valid_date ) {
 	if ( ! empty( $event_end_date ) && $event_end_date !== $event_date && strtotime( $event_end_date ) !== false ) {
 		$formatted_date = date_i18n( 'M j', strtotime( $event_date ) ) . ' - ' . date_i18n( 'M j, Y', strtotime( $event_end_date ) );
 	} else {
@@ -65,7 +48,10 @@ if ( ! empty( $event_calendar_data['date_label'] ) ) {
 	}
 }
 
-$is_admin = current_user_can( 'manage_options' );
+$can_manage_content  = Wpfaevent_Roles::current_user_can_manage_dashboard();
+$can_delete_content  = Wpfaevent_Roles::current_user_can_delete_content();
+$can_edit_this_event = $can_manage_content && current_user_can( 'edit_post', $event_id );
+$can_delete_event    = $can_delete_content && current_user_can( 'delete_post', $event_id );
 ?>
 
 <div class="event-card"
@@ -78,13 +64,9 @@ $is_admin = current_user_can( 'manage_options' );
 	data-lead-text="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) ); ?>"
 	data-registration-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_registration_link', true ) ); ?>"
 	data-cfs-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_cfs_link', true ) ); ?>"
-	data-start-time="<?php echo esc_attr( $event_time_value ); ?>"
-	data-end-time="<?php echo esc_attr( $event_end_time ); ?>"
-	data-timezone="<?php echo esc_attr( $event_timezone ); ?>"
-	data-all-day="<?php echo esc_attr( $event_all_day ? '1' : '0' ); ?>"
-	data-time="<?php echo esc_attr( $event_time_value ); ?>">
+	data-time="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_time', true ) ); ?>">
 
-	<?php if ( $is_admin && ( ! $is_valid_date || $is_past_event ) ) : ?>
+	<?php if ( $can_manage_content && ( ! $is_valid_date || $is_past_event ) ) : ?>
 		<div class="wpfaevent-admin-warning">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="wpfaevent-warning-icon" aria-hidden="true">
 				<path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>
@@ -101,27 +83,25 @@ $is_admin = current_user_can( 'manage_options' );
 		</div>
 	<?php endif; ?>
 
-	<?php if ( $is_admin ) : ?>
+	<?php if ( $can_edit_this_event ) : ?>
 	<div class="event-card-actions">
-			<button class="btn-edit-event"
-					data-post-id="<?php echo esc_attr( $event_id ); ?>"
-					data-name="<?php echo esc_attr( get_the_title( $event_id ) ); ?>"
-					data-date="<?php echo esc_attr( $event_date ); ?>"
-					data-end-date="<?php echo esc_attr( $event_end_date ); ?>"
-					data-place="<?php echo esc_attr( $event_place ); ?>"
-					data-description="<?php echo esc_attr( $event_description ); ?>"
-					data-lead-text="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) ); ?>"
-					data-registration-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_registration_link', true ) ); ?>"
-					data-cfs-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_cfs_link', true ) ); ?>"
-					data-start-time="<?php echo esc_attr( $event_time_value ); ?>"
-					data-end-time="<?php echo esc_attr( $event_end_time ); ?>"
-					data-timezone="<?php echo esc_attr( $event_timezone ); ?>"
-					data-all-day="<?php echo esc_attr( $event_all_day ? '1' : '0' ); ?>"
-					data-time="<?php echo esc_attr( $event_time_value ); ?>">
+		<button class="btn-edit-event"
+				data-post-id="<?php echo esc_attr( $event_id ); ?>"
+				data-name="<?php echo esc_attr( get_the_title( $event_id ) ); ?>"
+				data-date="<?php echo esc_attr( $event_date ); ?>"
+				data-end-date="<?php echo esc_attr( $event_end_date ); ?>"
+				data-place="<?php echo esc_attr( $event_place ); ?>"
+				data-description="<?php echo esc_attr( $event_description ); ?>"
+				data-lead-text="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) ); ?>"
+				data-registration-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_registration_link', true ) ); ?>"
+				data-cfs-link="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_cfs_link', true ) ); ?>"
+				data-time="<?php echo esc_attr( get_post_meta( $event_id, 'wpfa_event_time', true ) ); ?>">
 			<?php esc_html_e( 'Edit Details', 'wpfaevent' ); ?>
 		</button>
 		<a href="<?php echo esc_url( admin_url( 'post.php?post=' . $event_id . '&action=edit' ) ); ?>" class="btn-edit-content"><?php esc_html_e( 'Edit Content', 'wpfaevent' ); ?></a>
-		<button class="btn-delete-event"><?php esc_html_e( 'Delete', 'wpfaevent' ); ?></button>
+		<?php if ( $can_delete_event ) : ?>
+			<button class="btn-delete-event"><?php esc_html_e( 'Delete', 'wpfaevent' ); ?></button>
+		<?php endif; ?>
 	</div>
 	<?php endif; ?>
 
@@ -136,9 +116,6 @@ $is_admin = current_user_can( 'manage_options' );
 					<path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"></path>
 				</svg>
 				<?php echo esc_html( $formatted_date ); ?>
-				<?php if ( $formatted_time_meta ) : ?>
-					<span class="event-card-time"><?php echo esc_html( ' | ' . $formatted_time_meta ); ?></span>
-				<?php endif; ?>
 			</p>
 			<?php if ( ! empty( $event_place ) ) : ?>
 			<p>

--- a/public/partials/events/event-modal.php
+++ b/public/partials/events/event-modal.php
@@ -15,8 +15,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-
-$wpfaevent_default_timezone = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_timezone( 0 ) : wp_timezone_string();
 ?>
 
 <!-- Create Event Modal -->
@@ -35,26 +33,8 @@ $wpfaevent_default_timezone = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent
 			<label for="eventEndDate"><?php esc_html_e( 'Event End Date (optional):', 'wpfaevent' ); ?></label>
 			<input type="date" id="eventEndDate" name="end_date">
 
-			<label for="eventTimezone"><?php esc_html_e( 'Timezone:', 'wpfaevent' ); ?></label>
-			<select id="eventTimezone" name="timezone">
-				<?php echo wp_timezone_choice( $wpfaevent_default_timezone ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes timezone option markup. ?>
-			</select>
-
-			<label class="wpfaevent-checkbox-label" for="eventAllDay">
-				<input type="checkbox" id="eventAllDay" name="all_day" value="1">
-				<span><?php esc_html_e( 'All-day event', 'wpfaevent' ); ?></span>
-			</label>
-
-			<div class="wpfaevent-time-fields">
-				<div>
-					<label for="eventStartTime"><?php esc_html_e( 'Start Time:', 'wpfaevent' ); ?></label>
-					<input type="time" id="eventStartTime" name="start_time">
-				</div>
-				<div>
-					<label for="eventEndTime"><?php esc_html_e( 'End Time:', 'wpfaevent' ); ?></label>
-					<input type="time" id="eventEndTime" name="end_time">
-				</div>
-			</div>
+			<label for="eventTime"><?php esc_html_e( 'Event Time:', 'wpfaevent' ); ?></label>
+			<input type="time" id="eventTime" name="time" required>
 
 			<label for="eventPlace"><?php esc_html_e( 'Event Place:', 'wpfaevent' ); ?></label>
 			<input type="text" id="eventPlace" name="location" required>
@@ -98,26 +78,8 @@ $wpfaevent_default_timezone = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent
 			<label for="editEventEndDate"><?php esc_html_e( 'Event End Date (optional):', 'wpfaevent' ); ?></label>
 			<input type="date" id="editEventEndDate" name="end_date">
 
-			<label for="editEventTimezone"><?php esc_html_e( 'Timezone:', 'wpfaevent' ); ?></label>
-			<select id="editEventTimezone" name="timezone">
-				<?php echo wp_timezone_choice( $wpfaevent_default_timezone ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core escapes timezone option markup. ?>
-			</select>
-
-			<label class="wpfaevent-checkbox-label" for="editEventAllDay">
-				<input type="checkbox" id="editEventAllDay" name="all_day" value="1">
-				<span><?php esc_html_e( 'All-day event', 'wpfaevent' ); ?></span>
-			</label>
-
-			<div class="wpfaevent-time-fields">
-				<div>
-					<label for="editEventStartTime"><?php esc_html_e( 'Start Time:', 'wpfaevent' ); ?></label>
-					<input type="time" id="editEventStartTime" name="start_time">
-				</div>
-				<div>
-					<label for="editEventEndTime"><?php esc_html_e( 'End Time:', 'wpfaevent' ); ?></label>
-					<input type="time" id="editEventEndTime" name="end_time">
-				</div>
-			</div>
+			<label for="editEventTime"><?php esc_html_e( 'Event Time:', 'wpfaevent' ); ?></label>
+			<input type="time" id="editEventTime" name="time" required>
 
 			<label for="editEventPlace"><?php esc_html_e( 'Event Place:', 'wpfaevent' ); ?></label>
 			<input type="text" id="editEventPlace" name="location" required>

--- a/public/partials/footer.php
+++ b/public/partials/footer.php
@@ -23,7 +23,7 @@ if ( empty( $footer_text ) ) {
 }
 
 // Check if user is admin.
-$is_admin = current_user_can( 'manage_options' );
+$is_admin = Wpfaevent_Roles::current_user_can_manage_site_branding();
 ?>
 
 <!-- Main Site Footer -->

--- a/public/partials/speakers/dashboard-speaker-card.php
+++ b/public/partials/speakers/dashboard-speaker-card.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Dashboard Speaker Card Partial.
+ *
+ * Renders a speaker entry from imported dashboard JSON.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/partials/speakers
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! isset( $speaker ) || ! is_array( $speaker ) || empty( $speaker['name'] ) ) {
+	return;
+}
+
+$speaker_name        = sanitize_text_field( $speaker['name'] );
+$speaker_social      = isset( $speaker['social'] ) && is_array( $speaker['social'] ) ? $speaker['social'] : array();
+$session             = ! empty( $speaker['sessions'][0] ) && is_array( $speaker['sessions'][0] ) ? $speaker['sessions'][0] : array();
+$placeholder_url     = ! empty( $speaker_placeholder_url ) ? $speaker_placeholder_url : WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
+$is_featured_speaker = ! empty( $wpfa_dashboard_speaker_is_featured ) || ! empty( $speaker['featured'] );
+?>
+<article class="wpfa-speaker-card visible <?php echo esc_attr( $is_featured_speaker ? 'is-featured' : '' ); ?>">
+	<div class="wpfa-speaker-photo">
+		<?php if ( ! empty( $speaker['image'] ) ) : ?>
+			<?php /* translators: %s: Speaker name. */ ?>
+			<img src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy">
+		<?php else : ?>
+			<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img">
+		<?php endif; ?>
+	</div>
+	<div class="wpfa-speaker-meta">
+		<?php if ( $is_featured_speaker ) : ?>
+			<p class="wpfa-speaker-featured-badge"><?php esc_html_e( 'Featured Speaker', 'wpfaevent' ); ?></p>
+		<?php endif; ?>
+
+		<?php if ( ! empty( $speaker['category'] ) ) : ?>
+			<p class="pill"><?php echo esc_html( $speaker['category'] ); ?></p>
+		<?php endif; ?>
+
+		<h3 class="wpfa-speaker-name"><?php echo esc_html( $speaker_name ); ?></h3>
+		<?php if ( ! empty( $speaker['position'] ) || ! empty( $speaker['organization'] ) ) : ?>
+			<p class="wpfa-speaker-role">
+				<?php echo esc_html( trim( ( $speaker['position'] ?? '' ) . ( ! empty( $speaker['position'] ) && ! empty( $speaker['organization'] ) ? ' | ' : '' ) . ( $speaker['organization'] ?? '' ) ) ); ?>
+			</p>
+		<?php endif; ?>
+	</div>
+	<div class="wpfa-speaker-expand">
+		<?php if ( ! empty( $speaker['bio'] ) ) : ?>
+			<div class="wpfa-speaker-bio"><?php echo wp_kses_post( wpautop( $speaker['bio'] ) ); ?></div>
+		<?php endif; ?>
+		<?php if ( ! empty( $session['title'] ) ) : ?>
+			<div class="wpfa-speaker-session">
+				<h4><?php esc_html_e( 'Session Details', 'wpfaevent' ); ?></h4>
+				<p><strong><?php echo esc_html( $session['title'] ); ?></strong></p>
+			</div>
+		<?php endif; ?>
+		<?php if ( ! empty( $speaker_social ) ) : ?>
+			<div class="wpfa-speaker-social">
+				<?php foreach ( $speaker_social as $social_label => $social_url ) : ?>
+					<?php if ( $social_url ) : ?>
+						<a href="<?php echo esc_url( $social_url ); ?>" target="_blank" rel="noopener noreferrer" class="wpfa-social-link">
+							<?php echo esc_html( ucfirst( $social_label ) ); ?>
+						</a>
+					<?php endif; ?>
+				<?php endforeach; ?>
+			</div>
+		<?php endif; ?>
+	</div>
+</article>

--- a/public/partials/speakers/speaker-card.php
+++ b/public/partials/speakers/speaker-card.php
@@ -40,12 +40,23 @@ if ( empty( $sid ) || ! is_numeric( $sid ) ) {
 
 $sid = (int) $sid;
 
-$name         = get_the_title( $sid );
-$org          = sanitize_text_field( get_post_meta( $sid, 'wpfa_speaker_organization', true ) );
-$position     = sanitize_text_field( get_post_meta( $sid, 'wpfa_speaker_position', true ) );
-$photo_url    = get_post_meta( $sid, 'wpfa_speaker_headshot_url', true );
-$speaker_link = get_permalink( $sid );
-$is_admin     = current_user_can( 'manage_options' );
+$name                  = get_the_title( $sid );
+$org                   = sanitize_text_field( get_post_meta( $sid, 'wpfa_speaker_organization', true ) );
+$position              = sanitize_text_field( get_post_meta( $sid, 'wpfa_speaker_position', true ) );
+$photo_url             = get_post_meta( $sid, 'wpfa_speaker_headshot_url', true );
+$placeholder_url       = WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
+$speaker_link          = get_permalink( $sid );
+$hide_admin_actions    = ! empty( $wpfa_hide_speaker_card_admin_actions );
+$can_manage_content    = ! $hide_admin_actions && Wpfaevent_Roles::current_user_can_manage_dashboard();
+$can_delete_content    = ! $hide_admin_actions && Wpfaevent_Roles::current_user_can_delete_content();
+$can_edit_this_speaker = $can_manage_content && current_user_can( 'edit_post', $sid );
+$can_delete_speaker    = $can_delete_content && current_user_can( 'delete_post', $sid );
+$featured_speaker_ids  = isset( $wpfa_featured_speaker_ids ) && is_array( $wpfa_featured_speaker_ids ) ? array_map( 'absint', $wpfa_featured_speaker_ids ) : array();
+$is_featured_speaker   = in_array( $sid, $featured_speaker_ids, true );
+
+if ( empty( $photo_url ) && has_post_thumbnail( $sid ) ) {
+	$photo_url = get_the_post_thumbnail_url( $sid, 'medium_large' );
+}
 
 // Get categories from the taxonomy.
 $speaker_categories = array();
@@ -62,35 +73,75 @@ $talk_date     = get_post_meta( $sid, 'wpfa_speaker_talk_date', true );
 $talk_time     = get_post_meta( $sid, 'wpfa_speaker_talk_time', true );
 $talk_end_time = get_post_meta( $sid, 'wpfa_speaker_talk_end_time', true );
 $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
+
+$speaker_card_timezone = isset( $wpfa_schedule_display_timezone ) && $wpfa_schedule_display_timezone instanceof DateTimeZone ? $wpfa_schedule_display_timezone : wp_timezone();
+
+$format_speaker_talk_datetime = static function ( $date, $time, $format ) use ( $speaker_card_timezone ) {
+	$date = trim( (string) $date );
+	$time = trim( (string) $time );
+
+	if ( '' === $date ) {
+		return '';
+	}
+
+	$value = trim( $date . ' ' . $time );
+
+	try {
+		$datetime = new DateTimeImmutable( $value, wp_timezone() );
+	} catch ( Exception $exception ) {
+		return '';
+	}
+
+	return wp_date( $format, $datetime->getTimestamp(), $speaker_card_timezone );
+};
+
+$formatted_talk_date = $format_speaker_talk_datetime( $talk_date, '', get_option( 'date_format' ) );
+$formatted_talk_time = $format_speaker_talk_datetime( $talk_date, $talk_time, get_option( 'time_format' ) );
+$formatted_end_time  = $format_speaker_talk_datetime( $talk_date, $talk_end_time, get_option( 'time_format' ) );
+
+if ( ! $formatted_talk_date ) {
+	$formatted_talk_date = $talk_date;
+}
+
+if ( ! $formatted_talk_time ) {
+	$formatted_talk_time = $talk_time;
+}
+
+if ( ! $formatted_end_time ) {
+	$formatted_end_time = $talk_end_time;
+}
 ?>
-<article class="wpfa-speaker-card" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( $sid ); ?>">
+<article class="wpfa-speaker-card <?php echo esc_attr( $is_featured_speaker ? 'is-featured' : '' ); ?>" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( $sid ); ?>">
 	<a class="wpfa-speaker-photo" href="<?php echo esc_url( $speaker_link ); ?>">
-			<?php if ( $photo_url ) : ?>
-				<?php /* translators: %s: Speaker name. */ ?>
-				<img src="<?php echo esc_url( $photo_url ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $name ) ); ?>" loading="lazy" itemprop="image" />
+		<?php if ( $photo_url ) : ?>
+			<?php /* translators: %s: Speaker name. */ ?>
+			<img src="<?php echo esc_url( $photo_url ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $name ) ); ?>" loading="lazy" itemprop="image" />
 		<?php else : ?>
-			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" class="wpfa-placeholder-svg">
-				<rect width="100%" height="100%" fill="#eee" />
-				<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="20" fill="#999">Speaker</text>
-			</svg>
+			<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img" itemprop="image" />
 		<?php endif; ?>
 	</a>
 	<div class="wpfa-speaker-meta">
-		<?php if ( $is_admin ) : ?>
+		<?php if ( $can_edit_this_speaker ) : ?>
 			<button class="btn-edit-speaker" data-id="<?php echo esc_attr( $sid ); ?>" data-name="<?php echo esc_attr( $name ); ?>" title="<?php esc_attr_e( 'Edit Speaker', 'wpfaevent' ); ?>">
 				✎
 			</button>
+		<?php endif; ?>
+		<?php if ( $can_delete_speaker ) : ?>
 			<button class="btn-delete-speaker" data-id="<?php echo esc_attr( $sid ); ?>" data-name="<?php echo esc_attr( $name ); ?>" title="<?php esc_attr_e( 'Delete Speaker', 'wpfaevent' ); ?>">
 				×
 			</button>
 		<?php endif; ?>
-		
+
+		<?php if ( $is_featured_speaker ) : ?>
+			<p class="wpfa-speaker-featured-badge"><?php esc_html_e( 'Featured Speaker', 'wpfaevent' ); ?></p>
+		<?php endif; ?>
+
 		<?php if ( ! empty( $speaker_categories ) ) : ?>
 			<p class="pill">
 				<?php echo esc_html( $speaker_categories[0] ); ?>
 			</p>
 		<?php endif; ?>
-		
+
 		<h3 class="wpfa-speaker-name" itemprop="name"><a href="<?php echo esc_url( $speaker_link ); ?>"><?php echo esc_html( $name ); ?></a></h3>
 		<?php if ( $position || $org ) : ?>
 			<p class="wpfa-speaker-role"><?php echo esc_html( trim( $position . ( $position && $org ? ' · ' : '' ) . $org ) ); ?></p>
@@ -105,30 +156,31 @@ $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
 				<?php echo wp_kses_post( wpautop( $bio ) ); ?>
 			</div>
 		<?php endif; ?>
-		
+
 		<?php if ( $talk_title ) : ?>
 			<div class="wpfa-speaker-session">
 				<h4><?php esc_html_e( 'Session Details', 'wpfaevent' ); ?></h4>
 				<p><strong><?php echo esc_html( $talk_title ); ?></strong></p>
-				
+
 				<?php if ( $talk_date || $talk_time ) : ?>
 					<p>
 						<?php
 						$date_time = array();
-						if ( $talk_date ) {
-							$date_time[] = esc_html( $talk_date );
+						if ( $formatted_talk_date ) {
+							$date_time[] = esc_html( $formatted_talk_date );
 						}
-						if ( $talk_time ) {
-							$date_time[] = esc_html( $talk_time );
-							if ( $talk_end_time ) {
-								$date_time[] = esc_html( $talk_end_time );
+						if ( $formatted_talk_time ) {
+							$time_label = $formatted_talk_time;
+							if ( $formatted_end_time && $formatted_end_time !== $formatted_talk_time ) {
+								$time_label .= ' - ' . $formatted_end_time;
 							}
+							$date_time[] = esc_html( $time_label );
 						}
 						echo esc_html( implode( ' • ', $date_time ) );
 						?>
 					</p>
 				<?php endif; ?>
-				
+
 				<?php if ( $talk_abstract ) : ?>
 					<div class="wpfa-talk-abstract">
 						<?php echo wp_kses_post( wpautop( $talk_abstract ) ); ?>

--- a/public/templates/archive-wpfa-event.php
+++ b/public/templates/archive-wpfa-event.php
@@ -1,0 +1,666 @@
+<?php
+/**
+ * Event Archive Template.
+ *
+ * Displays a searchable and filterable directory of WPFA events.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/templates
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$archive_url = get_post_type_archive_link( 'wpfa_event' );
+if ( ! $archive_url ) {
+	$archive_url = home_url( '/events/' );
+}
+
+$read_filter_value = static function ( $key, $type = 'text' ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- These are read-only archive filters.
+	if ( ! isset( $_GET[ $key ] ) ) {
+		return '';
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized by type below.
+	$value = wp_unslash( $_GET[ $key ] );
+
+	if ( is_array( $value ) ) {
+		return '';
+	}
+
+	if ( 'key' === $type ) {
+		return sanitize_key( $value );
+	}
+
+	if ( 'slug' === $type ) {
+		return sanitize_title( $value );
+	}
+
+	if ( 'int' === $type ) {
+		return absint( $value );
+	}
+
+	return sanitize_text_field( $value );
+};
+
+$search_query     = $read_filter_value( 'q' );
+$current_track    = $read_filter_value( 'track', 'slug' );
+$current_tag      = $read_filter_value( 'tag', 'slug' );
+$current_when     = $read_filter_value( 'when', 'key' );
+$current_location = $read_filter_value( 'location', 'slug' );
+$current_language = $read_filter_value( 'language', 'slug' );
+$current_page     = max( 1, absint( get_query_var( 'paged', 1 ) ) );
+$query_page       = $read_filter_value( 'paged', 'int' );
+
+if ( $query_page ) {
+	$current_page = max( 1, $query_page );
+}
+
+if ( ! in_array( $current_when, array( 'all', 'upcoming', 'past' ), true ) ) {
+	$current_when = 'all';
+}
+
+$today           = current_time( 'Y-m-d' );
+$events_per_page = max( 1, absint( apply_filters( 'wpfa_event_archive_events_per_page', 12 ) ) );
+
+$format_event_date = static function ( $date ) {
+	$date = trim( (string) $date );
+
+	if ( '' === $date ) {
+		return '';
+	}
+
+	$timestamp = strtotime( $date );
+
+	return $timestamp ? date_i18n( get_option( 'date_format' ), $timestamp ) : $date;
+};
+
+$format_event_date_range = static function ( $start_date, $end_date ) use ( $format_event_date ) {
+	$start_label = $format_event_date( $start_date );
+	$end_label   = $format_event_date( $end_date );
+
+	if ( $start_label && $end_label && $start_label !== $end_label ) {
+		return $start_label . ' - ' . $end_label;
+	}
+
+	return $start_label ? $start_label : $end_label;
+};
+
+$normalize_event_date = static function ( $date ) {
+	$date = sanitize_text_field( $date );
+
+	if ( '' === $date ) {
+		return '';
+	}
+
+	$timestamp = strtotime( $date );
+
+	return $timestamp ? date_i18n( 'Y-m-d', $timestamp ) : '';
+};
+
+$format_language_label = static function ( $language ) {
+	$language = trim( (string) $language );
+
+	if ( '' === $language ) {
+		return '';
+	}
+
+	$normalized = strtolower( str_replace( '_', '-', $language ) );
+	$labels     = array(
+		'ar'          => __( 'Arabic', 'wpfaevent' ),
+		'bn'          => __( 'Bengali', 'wpfaevent' ),
+		'bg'          => __( 'Bulgarian', 'wpfaevent' ),
+		'ca'          => __( 'Catalan', 'wpfaevent' ),
+		'cs'          => __( 'Czech', 'wpfaevent' ),
+		'da'          => __( 'Danish', 'wpfaevent' ),
+		'de'          => __( 'German', 'wpfaevent' ),
+		'en'          => __( 'English', 'wpfaevent' ),
+		'en-ca'       => __( 'English (Canada)', 'wpfaevent' ),
+		'es'          => __( 'Spanish', 'wpfaevent' ),
+		'fr'          => __( 'French', 'wpfaevent' ),
+		'gu'          => __( 'Gujarati', 'wpfaevent' ),
+		'hi'          => __( 'Hindi', 'wpfaevent' ),
+		'it'          => __( 'Italian', 'wpfaevent' ),
+		'ja'          => __( 'Japanese', 'wpfaevent' ),
+		'ko'          => __( 'Korean', 'wpfaevent' ),
+		'nl'          => __( 'Dutch', 'wpfaevent' ),
+		'nl-informal' => __( 'Dutch (Informal)', 'wpfaevent' ),
+		'pt'          => __( 'Portuguese', 'wpfaevent' ),
+		'ru'          => __( 'Russian', 'wpfaevent' ),
+		'si'          => __( 'Sinhala', 'wpfaevent' ),
+		'ta'          => __( 'Tamil', 'wpfaevent' ),
+		'zh-hans'     => __( 'Chinese (Simplified)', 'wpfaevent' ),
+		'zh-hant'     => __( 'Chinese (Traditional)', 'wpfaevent' ),
+	);
+
+	if ( isset( $labels[ $normalized ] ) ) {
+		return $labels[ $normalized ];
+	}
+
+	if ( false === strpos( $language, ' ' ) && preg_match( '/^[a-z]{2,3}(?:[-_][a-z0-9]+)*$/i', $language ) ) {
+		return ucwords( str_replace( '-', ' ', $normalized ) );
+	}
+
+	return $language;
+};
+
+$get_event_terms = static function ( $event_id, $taxonomy ) {
+	$terms = get_the_terms( $event_id, $taxonomy );
+
+	if ( empty( $terms ) || is_wp_error( $terms ) ) {
+		return array();
+	}
+
+	return array_values( $terms );
+};
+
+$get_term_names = static function ( $terms ) {
+	return array_map(
+		static function ( $term ) {
+			return $term->name;
+		},
+		$terms
+	);
+};
+
+$get_term_slugs = static function ( $terms ) {
+	return array_map(
+		static function ( $term ) {
+			return $term->slug;
+		},
+		$terms
+	);
+};
+
+$build_event_excerpt = static function ( $event_id ) {
+	$excerpt = trim( (string) get_post_field( 'post_excerpt', $event_id ) );
+
+	if ( '' === $excerpt ) {
+		$content = wp_strip_all_tags( strip_shortcodes( get_post_field( 'post_content', $event_id ) ) );
+		$excerpt = wp_trim_words( $content, 28, '...' );
+	}
+
+	return $excerpt;
+};
+
+$event_ids = get_posts(
+	array(
+		'post_type'      => 'wpfa_event',
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	)
+);
+
+$events    = array();
+$locations = array();
+$languages = array();
+
+foreach ( $event_ids as $event_id ) {
+	$event_id        = absint( $event_id );
+	$event_title     = get_the_title( $event_id );
+	$start_date      = $normalize_event_date( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
+	$end_date        = $normalize_event_date( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
+	$location        = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+	$event_languages = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_language_list( get_post_meta( $event_id, 'wpfa_event_languages', true ) ) : array();
+	$language_labels = array_map( $format_language_label, $event_languages );
+	$event_url       = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_url', true ) );
+	$track_terms     = $get_event_terms( $event_id, 'wpfa_event_track' );
+	$tag_terms       = $get_event_terms( $event_id, 'wpfa_event_tag' );
+	$track_names     = $get_term_names( $track_terms );
+	$tag_names       = $get_term_names( $tag_terms );
+	$track_slugs     = $get_term_slugs( $track_terms );
+	$tag_slugs       = $get_term_slugs( $tag_terms );
+	$excerpt         = $build_event_excerpt( $event_id );
+	$image_url       = get_the_post_thumbnail_url( $event_id, 'large' );
+	$date_key        = $end_date ? $end_date : $start_date;
+	$event_status    = ( $date_key && $date_key < $today ) ? 'past' : 'upcoming';
+	$sort_date       = $start_date ? $start_date : $end_date;
+	$sort_time       = $sort_date ? strtotime( $sort_date ) : PHP_INT_MAX;
+	$speaker_ids     = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_admin_event_speaker_ids( $event_id ) : array();
+	$event_slug      = get_post_field( 'post_name', $event_id );
+
+	if ( $location ) {
+		$locations[ sanitize_title( $location ) ] = $location;
+	}
+
+	foreach ( $event_languages as $language ) {
+		$languages[ sanitize_title( $language ) ] = $format_language_label( $language );
+	}
+
+	$events[] = array(
+		'id'            => $event_id,
+		'title'         => $event_title,
+		'start_date'    => $start_date,
+		'end_date'      => $end_date,
+		'date_label'    => $format_event_date_range( $start_date, $end_date ),
+		'location'      => $location,
+		'location_key'  => sanitize_title( $location ),
+		'languages'     => $language_labels,
+		'language_keys' => array_map( 'sanitize_title', $event_languages ),
+		'event_url'     => $event_url,
+		'track_names'   => $track_names,
+		'track_slugs'   => $track_slugs,
+		'tag_names'     => $tag_names,
+		'tag_slugs'     => $tag_slugs,
+		'excerpt'       => $excerpt,
+		'image_url'     => $image_url,
+		'status'        => $event_status,
+		'sort_time'     => $sort_time,
+		'speaker_ids'   => $speaker_ids,
+		'speakers_url'  => add_query_arg( 'event', $event_slug, home_url( '/speakers/' ) ),
+	);
+}
+
+asort( $locations );
+asort( $languages );
+
+$tracks = get_terms(
+	array(
+		'taxonomy'   => 'wpfa_event_track',
+		'hide_empty' => true,
+	)
+);
+
+if ( is_wp_error( $tracks ) ) {
+	$tracks = array();
+}
+
+$tags = get_terms(
+	array(
+		'taxonomy'   => 'wpfa_event_tag',
+		'hide_empty' => true,
+	)
+);
+
+if ( is_wp_error( $tags ) ) {
+	$tags = array();
+}
+
+$filtered_events = array();
+
+foreach ( $events as $event ) {
+	if ( 'all' !== $current_when && $event['status'] !== $current_when ) {
+		continue;
+	}
+
+	if ( $current_track && ! in_array( $current_track, $event['track_slugs'], true ) ) {
+		continue;
+	}
+
+	if ( $current_tag && ! in_array( $current_tag, $event['tag_slugs'], true ) ) {
+		continue;
+	}
+
+	if ( $current_location && $current_location !== $event['location_key'] ) {
+		continue;
+	}
+
+	if ( $current_language && ! in_array( $current_language, $event['language_keys'], true ) ) {
+		continue;
+	}
+
+	if ( $search_query ) {
+		$searchable_text = implode(
+			' ',
+			array_merge(
+				array(
+					$event['title'],
+					$event['excerpt'],
+					$event['location'],
+					$event['date_label'],
+				),
+				$event['track_names'],
+				$event['tag_names'],
+				$event['languages']
+			)
+		);
+
+		if ( false === stripos( $searchable_text, $search_query ) ) {
+			continue;
+		}
+	}
+
+	$filtered_events[] = $event;
+}
+
+usort(
+	$filtered_events,
+	static function ( $event_a, $event_b ) use ( $current_when ) {
+		if ( $event_a['sort_time'] === $event_b['sort_time'] ) {
+			return strcasecmp( $event_a['title'], $event_b['title'] );
+		}
+
+		if ( 'past' === $current_when ) {
+			return ( $event_a['sort_time'] < $event_b['sort_time'] ) ? 1 : -1;
+		}
+
+		return ( $event_a['sort_time'] < $event_b['sort_time'] ) ? -1 : 1;
+	}
+);
+
+$total_events = count( $filtered_events );
+$total_pages  = max( 1, (int) ceil( $total_events / $events_per_page ) );
+$current_page = min( $current_page, $total_pages );
+$offset       = ( $current_page - 1 ) * $events_per_page;
+$paged_events = array_slice( $filtered_events, $offset, $events_per_page );
+
+$active_filter_args = array();
+
+if ( '' !== $search_query ) {
+	$active_filter_args['q'] = $search_query;
+}
+
+if ( '' !== $current_track ) {
+	$active_filter_args['track'] = $current_track;
+}
+
+if ( '' !== $current_tag ) {
+	$active_filter_args['tag'] = $current_tag;
+}
+
+if ( 'all' !== $current_when ) {
+	$active_filter_args['when'] = $current_when;
+}
+
+if ( '' !== $current_location ) {
+	$active_filter_args['location'] = $current_location;
+}
+
+if ( '' !== $current_language ) {
+	$active_filter_args['language'] = $current_language;
+}
+
+$has_active_filters = ! empty( $active_filter_args );
+$site_logo_url      = get_option( 'wpfa_site_logo_url', '' );
+
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class( 'wpfaevent wpfa-event-template wpfa-event-archive-page' ); ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+	<?php
+	$show_back_button     = false;
+	$show_register_button = false;
+
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
+
+	<main class="wpfa-event-archive">
+		<section class="wpfa-event-directory-hero">
+			<div class="container wpfa-event-directory-hero-inner">
+				<div>
+					<p class="wpfa-event-kicker"><?php esc_html_e( 'Event Directory', 'wpfaevent' ); ?></p>
+					<h1><?php esc_html_e( 'Open source events from the FOSSASIA community', 'wpfaevent' ); ?></h1>
+					<p class="wpfa-event-directory-lead">
+						<?php esc_html_e( 'Search by event name, topic, track, location, or date and find the right event faster.', 'wpfaevent' ); ?>
+					</p>
+				</div>
+				<div class="wpfa-event-directory-count" aria-label="<?php esc_attr_e( 'Event count', 'wpfaevent' ); ?>">
+					<strong><?php echo esc_html( number_format_i18n( count( $events ) ) ); ?></strong>
+					<span><?php esc_html_e( 'published events', 'wpfaevent' ); ?></span>
+				</div>
+			</div>
+		</section>
+
+		<section class="wpfa-event-directory-controls" aria-labelledby="wpfa-event-filter-title">
+			<div class="container">
+				<form class="wpfa-event-filter-form" action="<?php echo esc_url( $archive_url ); ?>" method="get">
+					<div class="wpfa-event-filter-head">
+						<div>
+							<h2 id="wpfa-event-filter-title"><?php esc_html_e( 'Find Events', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Filter events by name, topic, track, date, location, and language.', 'wpfaevent' ); ?></p>
+						</div>
+						<?php if ( $has_active_filters ) : ?>
+							<a class="wpfa-event-reset" href="<?php echo esc_url( $archive_url ); ?>">
+								<?php esc_html_e( 'Reset', 'wpfaevent' ); ?>
+							</a>
+						<?php endif; ?>
+					</div>
+
+					<div class="wpfa-event-filter-grid">
+						<label class="wpfa-event-field wpfa-event-field-search">
+							<span><?php esc_html_e( 'Search events', 'wpfaevent' ); ?></span>
+							<input type="search" name="q" value="<?php echo esc_attr( $search_query ); ?>" placeholder="<?php esc_attr_e( 'Search by event name or topic', 'wpfaevent' ); ?>">
+						</label>
+
+						<label class="wpfa-event-field">
+							<span><?php esc_html_e( 'Track', 'wpfaevent' ); ?></span>
+							<select name="track">
+								<option value=""><?php esc_html_e( 'All tracks', 'wpfaevent' ); ?></option>
+								<?php foreach ( $tracks as $track ) : ?>
+									<option value="<?php echo esc_attr( $track->slug ); ?>" <?php selected( $current_track, $track->slug ); ?>>
+										<?php echo esc_html( $track->name ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</label>
+
+						<label class="wpfa-event-field">
+							<span><?php esc_html_e( 'Topic', 'wpfaevent' ); ?></span>
+							<select name="tag">
+								<option value=""><?php esc_html_e( 'All topics', 'wpfaevent' ); ?></option>
+								<?php foreach ( $tags as $event_tag ) : ?>
+									<option value="<?php echo esc_attr( $event_tag->slug ); ?>" <?php selected( $current_tag, $event_tag->slug ); ?>>
+										<?php echo esc_html( $event_tag->name ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</label>
+
+						<label class="wpfa-event-field">
+							<span><?php esc_html_e( 'Location', 'wpfaevent' ); ?></span>
+							<select name="location">
+								<option value=""><?php esc_html_e( 'All locations', 'wpfaevent' ); ?></option>
+								<?php foreach ( $locations as $location_key => $location_label ) : ?>
+									<option value="<?php echo esc_attr( $location_key ); ?>" <?php selected( $current_location, $location_key ); ?>>
+										<?php echo esc_html( $location_label ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</label>
+
+						<label class="wpfa-event-field">
+							<span><?php esc_html_e( 'Language', 'wpfaevent' ); ?></span>
+							<select name="language">
+								<option value=""><?php esc_html_e( 'All languages', 'wpfaevent' ); ?></option>
+								<?php foreach ( $languages as $language_key => $language_label ) : ?>
+									<option value="<?php echo esc_attr( $language_key ); ?>" <?php selected( $current_language, $language_key ); ?>>
+										<?php echo esc_html( $language_label ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</label>
+					</div>
+
+					<div class="wpfa-event-filter-bottom">
+						<fieldset class="wpfa-event-when-filter">
+							<legend><?php esc_html_e( 'Date', 'wpfaevent' ); ?></legend>
+							<label>
+								<input type="radio" name="when" value="all" <?php checked( $current_when, 'all' ); ?>>
+								<span><?php esc_html_e( 'All', 'wpfaevent' ); ?></span>
+							</label>
+							<label>
+								<input type="radio" name="when" value="upcoming" <?php checked( $current_when, 'upcoming' ); ?>>
+								<span><?php esc_html_e( 'Upcoming', 'wpfaevent' ); ?></span>
+							</label>
+							<label>
+								<input type="radio" name="when" value="past" <?php checked( $current_when, 'past' ); ?>>
+								<span><?php esc_html_e( 'Past', 'wpfaevent' ); ?></span>
+							</label>
+						</fieldset>
+
+						<button type="submit" class="wpfa-event-filter-submit">
+							<?php esc_html_e( 'Search Events', 'wpfaevent' ); ?>
+						</button>
+					</div>
+				</form>
+			</div>
+		</section>
+
+		<section class="wpfa-event-directory-results" aria-labelledby="wpfa-event-results-title">
+			<div class="container">
+				<div class="wpfa-event-results-head">
+					<div>
+						<h2 id="wpfa-event-results-title"><?php esc_html_e( 'Events', 'wpfaevent' ); ?></h2>
+						<p>
+							<?php
+							printf(
+								/* translators: %1$d: number of shown events, %2$d: total matching events. */
+								esc_html__( 'Showing %1$d of %2$d matching events', 'wpfaevent' ),
+								absint( count( $paged_events ) ),
+								absint( $total_events )
+							);
+							?>
+						</p>
+					</div>
+				</div>
+
+				<?php if ( $paged_events ) : ?>
+					<div class="wpfa-event-card-grid">
+						<?php foreach ( $paged_events as $event ) : ?>
+							<?php
+							$event_date_card_label = $event['date_label'] ? $event['date_label'] : __( 'TBA', 'wpfaevent' );
+							$speaker_count         = count( $event['speaker_ids'] );
+							?>
+							<article class="wpfa-event-directory-card">
+								<a class="wpfa-event-directory-card-main" href="<?php echo esc_url( get_permalink( $event['id'] ) ); ?>">
+									<div class="wpfa-event-card-media">
+										<?php if ( $event['image_url'] ) : ?>
+											<img src="<?php echo esc_url( $event['image_url'] ); ?>" alt="<?php echo esc_attr( $event['title'] ); ?>" loading="lazy">
+										<?php else : ?>
+											<div class="wpfa-event-card-date">
+												<span><?php esc_html_e( 'Date', 'wpfaevent' ); ?></span>
+												<strong><?php echo esc_html( $event_date_card_label ); ?></strong>
+											</div>
+										<?php endif; ?>
+									</div>
+
+									<div class="wpfa-event-card-body">
+										<div class="wpfa-event-card-topline">
+											<span class="wpfa-event-status <?php echo esc_attr( 'is-' . $event['status'] ); ?>">
+												<?php echo esc_html( 'past' === $event['status'] ? __( 'Past', 'wpfaevent' ) : __( 'Upcoming', 'wpfaevent' ) ); ?>
+											</span>
+											<?php if ( $speaker_count ) : ?>
+												<span>
+													<?php
+													printf(
+														/* translators: %d: number of speakers. */
+														esc_html( _n( '%d speaker', '%d speakers', $speaker_count, 'wpfaevent' ) ),
+														absint( $speaker_count )
+													);
+													?>
+												</span>
+											<?php endif; ?>
+										</div>
+
+										<h3><?php echo esc_html( $event['title'] ); ?></h3>
+
+										<div class="wpfa-event-card-meta">
+											<?php if ( $event['date_label'] ) : ?>
+												<span><?php echo esc_html( $event['date_label'] ); ?></span>
+											<?php endif; ?>
+											<?php if ( $event['location'] ) : ?>
+												<span><?php echo esc_html( $event['location'] ); ?></span>
+											<?php endif; ?>
+										</div>
+
+										<?php if ( $event['excerpt'] ) : ?>
+											<p><?php echo esc_html( $event['excerpt'] ); ?></p>
+										<?php endif; ?>
+
+										<?php if ( ! empty( $event['track_names'] ) || ! empty( $event['tag_names'] ) || ! empty( $event['languages'] ) ) : ?>
+											<div class="wpfa-event-badges" aria-label="<?php esc_attr_e( 'Event categories', 'wpfaevent' ); ?>">
+												<?php foreach ( array_slice( array_merge( $event['track_names'], $event['tag_names'], $event['languages'] ), 0, 5 ) as $badge_label ) : ?>
+													<span><?php echo esc_html( $badge_label ); ?></span>
+												<?php endforeach; ?>
+											</div>
+										<?php endif; ?>
+									</div>
+								</a>
+
+								<div class="wpfa-event-card-actions">
+									<a href="<?php echo esc_url( get_permalink( $event['id'] ) ); ?>"><?php esc_html_e( 'View Event', 'wpfaevent' ); ?></a>
+									<?php if ( $speaker_count ) : ?>
+										<a href="<?php echo esc_url( $event['speakers_url'] ); ?>"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+									<?php if ( $event['event_url'] ) : ?>
+										<a href="<?php echo esc_url( $event['event_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Register', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+								</div>
+							</article>
+						<?php endforeach; ?>
+					</div>
+
+					<?php
+					if ( $total_pages > 1 ) {
+						$pagination_url   = ! empty( $active_filter_args ) ? add_query_arg( $active_filter_args, $archive_url ) : $archive_url;
+						$pagination_links = paginate_links(
+							array(
+								'base'      => esc_url_raw( add_query_arg( 'paged', '%#%', $pagination_url ) ),
+								'format'    => '',
+								'current'   => $current_page,
+								'total'     => $total_pages,
+								'prev_text' => __( 'Previous', 'wpfaevent' ),
+								'next_text' => __( 'Next', 'wpfaevent' ),
+								'type'      => 'array',
+							)
+						);
+
+						if ( $pagination_links ) {
+							echo '<nav class="wpfa-pagination" aria-label="' . esc_attr__( 'Events pagination', 'wpfaevent' ) . '">';
+							foreach ( $pagination_links as $pagination_link ) {
+								echo wp_kses_post( $pagination_link );
+							}
+							echo '</nav>';
+						}
+					}
+					?>
+				<?php else : ?>
+					<div class="wpfa-event-empty-state">
+						<h3><?php esc_html_e( 'No events matched your filters', 'wpfaevent' ); ?></h3>
+						<p><?php esc_html_e( 'Try a different search term or clear the filters to see every event.', 'wpfaevent' ); ?></p>
+						<a href="<?php echo esc_url( $archive_url ); ?>"><?php esc_html_e( 'Clear Filters', 'wpfaevent' ); ?></a>
+					</div>
+				<?php endif; ?>
+			</div>
+		</section>
+	</main>
+
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
+</div>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/public/templates/page-additional-information.php
+++ b/public/templates/page-additional-information.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Template Name: WPFA - Additional Information
+ *
+ * Displays event-specific attendee information such as nearby hotels,
+ * transportation, parking, directions, and venue notes.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/templates
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$additional_information_page_url = get_permalink();
+
+if ( ! $additional_information_page_url && class_exists( 'Wpfaevent_Additional_Information_Helper' ) ) {
+	$additional_information_page_url = Wpfaevent_Additional_Information_Helper::get_additional_information_page_url();
+}
+
+$read_filter_value = static function ( $key ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- These are read-only page filters.
+	if ( ! isset( $_GET[ $key ] ) ) {
+		return '';
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized below.
+	$value = wp_unslash( $_GET[ $key ] );
+
+	if ( is_array( $value ) ) {
+		return '';
+	}
+
+	return sanitize_text_field( $value );
+};
+
+$resolve_event_filter = static function ( $event_filter ) {
+	$event_filter = trim( (string) $event_filter );
+
+	if ( '' === $event_filter ) {
+		return 0;
+	}
+
+	if ( is_numeric( $event_filter ) ) {
+		$event_id = absint( $event_filter );
+
+		return ( $event_id && 'wpfa_event' === get_post_type( $event_id ) && 'publish' === get_post_status( $event_id ) ) ? $event_id : 0;
+	}
+
+	$events = get_posts(
+		array(
+			'name'           => sanitize_title( $event_filter ),
+			'post_type'      => 'wpfa_event',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		)
+	);
+
+	return ! empty( $events[0] ) ? absint( $events[0] ) : 0;
+};
+
+$current_event_filter = $read_filter_value( 'event' );
+$selected_event_id    = $resolve_event_filter( $current_event_filter );
+$selected_event_slug  = $selected_event_id ? get_post_field( 'post_name', $selected_event_id ) : '';
+$selected_event_title = $selected_event_id ? get_the_title( $selected_event_id ) : '';
+$selected_event_url   = $selected_event_id ? get_permalink( $selected_event_id ) : '';
+$venue_information    = $selected_event_id ? trim( (string) get_post_meta( $selected_event_id, 'wpfa_event_venue_information', true ) ) : '';
+$has_information      = '' !== trim( wp_strip_all_tags( $venue_information ) );
+$schedule_page_url    = class_exists( 'Wpfaevent_Schedule_Helper' ) ? Wpfaevent_Schedule_Helper::get_schedule_page_url() : home_url( '/full-schedule/' );
+$event_schedule_url   = $selected_event_id ? add_query_arg( 'event', $selected_event_slug, $schedule_page_url ) : $schedule_page_url;
+$event_additional_url = $selected_event_id ? add_query_arg( 'event', $selected_event_slug, $additional_information_page_url ) : $additional_information_page_url;
+$event_style_attr     = '';
+
+if ( $selected_event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$event_colors        = Wpfaevent_Meta_Event::get_event_colors( $selected_event_id );
+	$event_color_var_map = array(
+		'wpfa_event_primary_color'          => '--event-primary',
+		'wpfa_event_hover_button_color'     => '--event-primary-dark',
+		'wpfa_event_theme_background_color' => '--event-soft',
+		'wpfa_event_theme_success_color'    => '--event-success',
+		'wpfa_event_theme_danger_color'     => '--event-danger',
+	);
+	$event_style_vars    = array();
+
+	foreach ( $event_color_var_map as $meta_key => $css_var ) {
+		if ( ! empty( $event_colors[ $meta_key ] ) ) {
+			$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+		}
+	}
+
+	$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+}
+
+$site_logo_url = get_option( 'wpfa_site_logo_url', '' );
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+
+$header_vars = array(
+	'site_logo_url'        => $site_logo_url,
+	'event_page_url'       => $selected_event_url ? $selected_event_url : home_url( '/events/' ),
+	'show_back_button'     => true,
+	'show_register_button' => false,
+	'back_button_text'     => $selected_event_url ? __( 'Back to Event', 'wpfaevent' ) : __( 'Back to Events', 'wpfaevent' ),
+	'register_button_url'  => '',
+	'register_button_text' => __( 'Register', 'wpfaevent' ),
+);
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class( 'wpfaevent wpfa-event-template wpfa-additional-information-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+	<?php
+	$site_logo_url        = $header_vars['site_logo_url'];
+	$event_page_url       = $header_vars['event_page_url'];
+	$show_back_button     = $header_vars['show_back_button'];
+	$show_register_button = $header_vars['show_register_button'];
+	$back_button_text     = $header_vars['back_button_text'];
+	$register_button_url  = $header_vars['register_button_url'];
+	$register_button_text = $header_vars['register_button_text'];
+
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
+
+	<main class="wpfa-additional-information">
+		<section class="wpfa-additional-information-hero">
+			<div class="container">
+				<p class="wpfa-event-kicker"><?php esc_html_e( 'Venue and travel', 'wpfaevent' ); ?></p>
+				<h1><?php esc_html_e( 'Additional information', 'wpfaevent' ); ?></h1>
+				<p>
+					<?php
+					if ( $selected_event_title ) {
+						printf(
+							/* translators: %s: event title. */
+							esc_html__( 'Hotels, transportation, parking, directions, and other attendee details for %s.', 'wpfaevent' ),
+							esc_html( $selected_event_title )
+						);
+					} else {
+						esc_html_e( 'Hotels, transportation, parking, directions, and other attendee details for an event.', 'wpfaevent' );
+					}
+					?>
+				</p>
+			</div>
+		</section>
+
+		<section class="wpfa-event-section wpfa-additional-information-detail" aria-labelledby="wpfa-additional-information-title">
+			<div class="container">
+				<?php if ( $selected_event_id ) : ?>
+					<nav class="wpfa-schedule-tabs" aria-label="<?php esc_attr_e( 'Event detail navigation', 'wpfaevent' ); ?>">
+						<a href="<?php echo esc_url( $selected_event_url ); ?>"><?php esc_html_e( 'Info', 'wpfaevent' ); ?></a>
+						<a href="<?php echo esc_url( $event_schedule_url ); ?>"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></a>
+						<a class="is-active" href="<?php echo esc_url( $event_additional_url ); ?>"><?php esc_html_e( 'Additional Information', 'wpfaevent' ); ?></a>
+					</nav>
+				<?php endif; ?>
+
+				<div class="wpfa-event-section-head">
+					<div>
+						<h2 id="wpfa-additional-information-title">
+							<?php echo esc_html( $selected_event_title ? $selected_event_title : __( 'Additional information', 'wpfaevent' ) ); ?>
+						</h2>
+						<p><?php esc_html_e( 'Venue, hotel, and transportation notes for attendees.', 'wpfaevent' ); ?></p>
+					</div>
+				</div>
+
+				<?php if ( $selected_event_id && $has_information ) : ?>
+					<div class="wpfa-event-rich-text wpfa-additional-information-body">
+						<?php echo wp_kses_post( wpautop( $venue_information ) ); ?>
+					</div>
+				<?php elseif ( $selected_event_id ) : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'No additional information has been added for this event yet.', 'wpfaevent' ); ?></p>
+				<?php else : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'Open this page from an event to view event-specific additional information.', 'wpfaevent' ); ?></p>
+				<?php endif; ?>
+			</div>
+		</section>
+	</main>
+
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
+</div>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/public/templates/page-events.php
+++ b/public/templates/page-events.php
@@ -22,11 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$wpfaevent_is_embed = ! empty( $GLOBALS['wpfaevent_template_embed'] );
-$today              = current_time( 'Y-m-d' );
-$events_per_page    = max( 1, (int) apply_filters( 'wpfa_events_per_page', 10 ) );
-$current_page       = max( 1, (int) get_query_var( 'paged', 1 ) );
-$is_admin           = current_user_can( 'manage_options' );
+$wpfaevent_is_embed  = ! empty( $GLOBALS['wpfaevent_template_embed'] );
+$today               = current_time( 'Y-m-d' );
+$events_per_page     = max( 1, (int) apply_filters( 'wpfa_events_per_page', 10 ) );
+$current_page        = max( 1, (int) get_query_var( 'paged', 1 ) );
+$can_manage_content  = Wpfaevent_Roles::current_user_can_manage_dashboard();
+$can_publish_content = Wpfaevent_Roles::current_user_can_publish_content();
 
 // Pull all published event IDs to replicate upstream's data handling pattern.
 $args = array(
@@ -47,7 +48,7 @@ foreach ( $event_ids as $eid ) {
 	$is_valid = ! empty( $start );
 
 	// Admins can see items even if the start date metadata is missing or broken.
-	if ( ! $is_valid && $is_admin ) {
+	if ( ! $is_valid && $can_manage_content ) {
 		$upcoming_events[] = array(
 			'id'    => (int) $eid,
 			'start' => '',
@@ -178,7 +179,7 @@ $header_vars = array(
 				<div class="main-content">
 					<div class="main-content-header">
 						<h1><?php esc_html_e( 'Events', 'wpfaevent' ); ?></h1>
-						<?php if ( $is_admin ) : ?>
+						<?php if ( $can_publish_content ) : ?>
 							<button id="createEventBtn" class="btn btn-primary">
 								<?php esc_html_e( 'Create Custom Event', 'wpfaevent' ); ?>
 							</button>
@@ -245,20 +246,10 @@ $header_vars = array(
 									$event_description = get_the_excerpt( $event_id );
 									$thumbnail_raw     = get_the_post_thumbnail_url( $event_id, 'large' );
 									$featured_img_url  = ! empty( $thumbnail_raw ) ? $thumbnail_raw : '';
-									$calendar_data     = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-									$calendar_data     = is_wp_error( $calendar_data ) ? array() : $calendar_data;
 
 									// Format descriptive timeline layout markers.
-									$formatted_date      = __( 'Date not set', 'wpfaevent' );
-									$formatted_time_meta = '';
-									if ( ! empty( $calendar_data['date_label'] ) ) {
-										$formatted_date      = sanitize_text_field( $calendar_data['date_label'] );
-										$formatted_time_meta = ! empty( $calendar_data['time_label'] ) ? sanitize_text_field( $calendar_data['time_label'] ) : '';
-
-										if ( $formatted_time_meta && empty( $calendar_data['all_day'] ) && ! empty( $calendar_data['timezone_label'] ) ) {
-											$formatted_time_meta .= ' (' . sanitize_text_field( $calendar_data['timezone_label'] ) . ')';
-										}
-									} elseif ( ! empty( $event_date ) ) {
+									$formatted_date = __( 'Date not set', 'wpfaevent' );
+									if ( ! empty( $event_date ) ) {
 										if ( ! empty( $event_end_date ) && $event_end_date !== $event_date ) {
 											$formatted_date = date_i18n( 'M j', strtotime( $event_date ) ) . ' - ' . date_i18n( 'M j, Y', strtotime( $event_end_date ) );
 										} else {
@@ -284,12 +275,9 @@ $header_vars = array(
 												<p>
 													<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
 														<path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"></path>
-														</svg>
-														<?php echo esc_html( $formatted_date ); ?>
-														<?php if ( $formatted_time_meta ) : ?>
-															<span class="event-card-time"><?php echo esc_html( ' | ' . $formatted_time_meta ); ?></span>
-														<?php endif; ?>
-													</p>
+													</svg>
+													<?php echo esc_html( $formatted_date ); ?>
+												</p>
 												<?php if ( ! empty( $event_place ) ) : ?>
 												<p>
 													<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -329,7 +317,7 @@ $header_vars = array(
 					} else {
 						echo '<p class="news-loading-text">' . esc_html__( 'Latest news feed loading...', 'wpfaevent' ) . '</p>';
 
-						if ( current_user_can( 'manage_options' ) ) {
+						if ( $can_manage_content ) {
 							echo '<div class="wpfaevent-admin-warning">';
 								echo '<svg class="wpfaevent-warning-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">';
 									echo '<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>';
@@ -356,7 +344,7 @@ $header_vars = array(
 <?php endif; ?>
 
 <?php
-if ( $is_admin ) {
+if ( $can_manage_content ) {
 	include WPFAEVENT_PATH . 'public/partials/events/event-modal.php';
 }
 ?>

--- a/public/templates/page-partner.php
+++ b/public/templates/page-partner.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Template Name: WPFA - Partner
+ *
+ * Displays full sponsor or exhibitor details for an event.
+ *
+ * @package    Wpfaevent
+ * @subpackage Wpfaevent/public/templates
+ * @since      1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$partner_request = class_exists( 'Wpfaevent_Partner_Helper' )
+	? Wpfaevent_Partner_Helper::resolve_partner_request()
+	: array(
+		'event_id'      => 0,
+		'event_slug'    => '',
+		'event_title'   => '',
+		'event_url'     => '',
+		'type'          => '',
+		'partner_key'   => '',
+		'partner'       => array(),
+		'group_name'    => '',
+		'partner_label' => '',
+	);
+
+$event_id         = absint( $partner_request['event_id'] );
+$event_title      = $partner_request['event_title'];
+$event_url        = $partner_request['event_url'];
+$partner_type     = $partner_request['type'];
+$partner          = $partner_request['partner'];
+$group_name       = $partner_request['group_name'];
+$partner_label    = $partner_request['partner_label'];
+$has_partner      = ! empty( $partner['name'] );
+$partner_name     = $has_partner ? sanitize_text_field( $partner['name'] ) : '';
+$description      = ! empty( $partner['description'] ) ? wp_kses_post( $partner['description'] ) : '';
+$website_link     = ! empty( $partner['link'] ) ? esc_url_raw( $partner['link'] ) : '';
+$logo_url         = '';
+$banner_url       = '';
+$video_url        = ! empty( $partner['video'] ) ? esc_url_raw( $partner['video'] ) : '';
+$slides_url       = ! empty( $partner['slides'] ) ? esc_url_raw( $partner['slides'] ) : '';
+$contact_link     = ! empty( $partner['contact_link'] ) ? esc_url_raw( $partner['contact_link'] ) : '';
+$contact_email    = ! empty( $partner['contact_email'] ) ? sanitize_email( $partner['contact_email'] ) : '';
+$event_style_attr = '';
+
+if ( 'sponsor' === $partner_type ) {
+	$logo_url = ! empty( $partner['image'] ) ? esc_url_raw( $partner['image'] ) : '';
+} else {
+	$logo_url   = ! empty( $partner['logo'] ) ? esc_url_raw( $partner['logo'] ) : '';
+	$banner_url = ! empty( $partner['banner'] ) ? esc_url_raw( $partner['banner'] ) : '';
+}
+
+if ( $event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$event_colors        = Wpfaevent_Meta_Event::get_event_colors( $event_id );
+	$event_color_var_map = array(
+		'wpfa_event_primary_color'          => '--event-primary',
+		'wpfa_event_hover_button_color'     => '--event-primary-dark',
+		'wpfa_event_theme_background_color' => '--event-soft',
+		'wpfa_event_theme_success_color'    => '--event-success',
+		'wpfa_event_theme_danger_color'     => '--event-danger',
+	);
+	$event_style_vars    = array();
+
+	foreach ( $event_color_var_map as $meta_key => $css_var ) {
+		if ( ! empty( $event_colors[ $meta_key ] ) ) {
+			$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+		}
+	}
+
+	$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+}
+
+$site_logo_url = get_option( 'wpfa_site_logo_url', '' );
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+
+$back_url = $event_url ? $event_url . '#exhibitors' : home_url( '/events/' );
+if ( 'sponsor' === $partner_type && $event_url ) {
+	$back_url = $event_url . '#sponsors';
+}
+
+$header_vars = array(
+	'site_logo_url'        => $site_logo_url,
+	'event_page_url'       => $event_url ? $event_url : home_url( '/events/' ),
+	'show_back_button'     => true,
+	'show_register_button' => false,
+	'back_button_text'     => $event_url ? __( 'Back to Event', 'wpfaevent' ) : __( 'Back to Events', 'wpfaevent' ),
+	'register_button_url'  => '',
+	'register_button_text' => __( 'Register', 'wpfaevent' ),
+);
+
+$partner_initial = $partner_name ? strtoupper( substr( $partner_name, 0, 1 ) ) : '';
+$has_links       = $website_link || $video_url || $slides_url || $contact_link || $contact_email;
+$partner_classes = array(
+	'wpfa-partner-detail',
+	$partner_type ? 'is-' . sanitize_html_class( $partner_type ) : 'is-partner',
+	$logo_url ? 'has-logo' : 'no-logo',
+	$banner_url ? 'has-banner' : 'no-banner',
+	$has_links ? 'has-links' : 'no-links',
+);
+$partner_label   = $partner_label ? $partner_label : __( 'Partner', 'wpfaevent' );
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class( 'wpfaevent wpfa-event-template wpfa-partner-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+	<?php
+	$site_logo_url        = $header_vars['site_logo_url'];
+	$event_page_url       = $header_vars['event_page_url'];
+	$show_back_button     = $header_vars['show_back_button'];
+	$show_register_button = $header_vars['show_register_button'];
+	$back_button_text     = $header_vars['back_button_text'];
+	$register_button_url  = $header_vars['register_button_url'];
+	$register_button_text = $header_vars['register_button_text'];
+
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
+
+	<main class="<?php echo esc_attr( implode( ' ', $partner_classes ) ); ?>">
+		<section class="wpfa-partner-detail-hero">
+			<div class="container">
+				<div class="wpfa-partner-detail-hero-inner">
+					<div class="wpfa-partner-detail-hero-copy">
+						<p class="wpfa-event-kicker"><?php echo esc_html( $partner_label ); ?></p>
+						<h1><?php echo esc_html( $partner_name ? $partner_name : __( 'Partner', 'wpfaevent' ) ); ?></h1>
+						<?php if ( $event_title ) : ?>
+							<p class="wpfa-partner-detail-lead">
+								<?php
+								printf(
+									/* translators: %s: event title. */
+									esc_html__( 'Details for %s.', 'wpfaevent' ),
+									esc_html( $event_title )
+								);
+								?>
+							</p>
+						<?php endif; ?>
+					</div>
+					<?php if ( $has_partner ) : ?>
+						<div class="wpfa-partner-detail-hero-meta" aria-label="<?php esc_attr_e( 'Partner summary', 'wpfaevent' ); ?>">
+							<span><?php echo esc_html( $partner_label ); ?></span>
+							<strong><?php echo esc_html( $event_title ? $event_title : __( 'Event partner', 'wpfaevent' ) ); ?></strong>
+							<?php if ( $group_name ) : ?>
+								<em><?php echo esc_html( $group_name ); ?></em>
+							<?php endif; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			</div>
+		</section>
+
+		<section class="wpfa-event-section wpfa-partner-detail-body" aria-labelledby="wpfa-partner-detail-title">
+			<div class="container">
+				<?php if ( $has_partner ) : ?>
+					<div class="wpfa-partner-detail-card">
+						<div class="wpfa-partner-detail-media">
+							<?php if ( $banner_url ) : ?>
+								<img class="wpfa-partner-detail-banner" src="<?php echo esc_url( $banner_url ); ?>" alt="<?php echo esc_attr( $partner_name ); ?>" loading="lazy">
+							<?php endif; ?>
+
+							<div class="wpfa-partner-detail-identity">
+								<?php if ( $logo_url ) : ?>
+									<div class="wpfa-partner-detail-logo">
+										<img src="<?php echo esc_url( $logo_url ); ?>" alt="<?php echo esc_attr( $partner_name ); ?>" loading="lazy">
+									</div>
+								<?php else : ?>
+									<div class="wpfa-event-exhibitor-placeholder" aria-hidden="true">
+										<?php echo esc_html( $partner_initial ); ?>
+									</div>
+								<?php endif; ?>
+								<div class="wpfa-partner-detail-identity-copy">
+									<span><?php echo esc_html( $partner_label ); ?></span>
+									<strong><?php echo esc_html( $partner_name ); ?></strong>
+								</div>
+							</div>
+
+							<?php if ( $group_name ) : ?>
+								<p class="wpfa-partner-detail-group"><?php echo esc_html( $group_name ); ?></p>
+							<?php endif; ?>
+						</div>
+
+						<div class="wpfa-partner-detail-content">
+							<div class="wpfa-partner-detail-header">
+								<p class="wpfa-event-kicker"><?php esc_html_e( 'Profile', 'wpfaevent' ); ?></p>
+								<h2 id="wpfa-partner-detail-title"><?php echo esc_html( $partner_name ); ?></h2>
+								<?php if ( $group_name ) : ?>
+									<p class="wpfa-partner-detail-meta"><?php echo esc_html( $group_name ); ?></p>
+								<?php endif; ?>
+							</div>
+
+							<?php if ( $description ) : ?>
+								<div class="wpfa-event-rich-text wpfa-partner-detail-description">
+									<?php echo wp_kses_post( wpautop( $description ) ); ?>
+								</div>
+							<?php else : ?>
+								<p class="wpfa-partner-detail-empty"><?php esc_html_e( 'No profile details have been added yet.', 'wpfaevent' ); ?></p>
+							<?php endif; ?>
+
+							<?php if ( $has_links ) : ?>
+								<div class="wpfa-event-exhibitor-links wpfa-partner-detail-links">
+									<?php if ( $website_link ) : ?>
+										<a href="<?php echo esc_url( $website_link ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Website', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+									<?php if ( $video_url ) : ?>
+										<a href="<?php echo esc_url( $video_url ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Video', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+									<?php if ( $slides_url ) : ?>
+										<a href="<?php echo esc_url( $slides_url ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Slides', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+									<?php if ( $contact_link ) : ?>
+										<a href="<?php echo esc_url( $contact_link ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Contact', 'wpfaevent' ); ?></a>
+									<?php elseif ( $contact_email ) : ?>
+										<a href="<?php echo esc_url( 'mailto:' . $contact_email ); ?>"><?php esc_html_e( 'Contact', 'wpfaevent' ); ?></a>
+									<?php endif; ?>
+								</div>
+							<?php endif; ?>
+						</div>
+					</div>
+
+					<p class="wpfa-partner-detail-back">
+						<a href="<?php echo esc_url( $back_url ); ?>"><?php esc_html_e( 'Back to event partners', 'wpfaevent' ); ?></a>
+					</p>
+				<?php elseif ( $event_id ) : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'This partner could not be found for the selected event.', 'wpfaevent' ); ?></p>
+				<?php else : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'Open a partner card from an event page to view full details.', 'wpfaevent' ); ?></p>
+				<?php endif; ?>
+			</div>
+		</section>
+	</main>
+
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
+</div>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/public/templates/page-past-events.php
+++ b/public/templates/page-past-events.php
@@ -156,23 +156,13 @@ $header_vars = array(
 						$location      = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
 						$event_url_raw = get_post_meta( $event_id, 'wpfa_event_url', true );
 						$event_url     = $event_url_raw ? esc_url( $event_url_raw ) : get_permalink();
-						$calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-						$calendar_data = is_wp_error( $calendar_data ) ? array() : $calendar_data;
 
 						$image_url = get_the_post_thumbnail_url( $event_id, 'medium' );
 
 						// Format date for display.
-						$display_date      = '';
-						$display_time_meta = '';
+						$display_date = '';
 
-						if ( ! empty( $calendar_data['date_label'] ) ) {
-							$display_date      = sanitize_text_field( $calendar_data['date_label'] );
-							$display_time_meta = ! empty( $calendar_data['time_label'] ) ? sanitize_text_field( $calendar_data['time_label'] ) : '';
-
-							if ( $display_time_meta && empty( $calendar_data['all_day'] ) && ! empty( $calendar_data['timezone_label'] ) ) {
-								$display_time_meta .= ' (' . sanitize_text_field( $calendar_data['timezone_label'] ) . ')';
-							}
-						} elseif ( ! empty( $start_date ) ) {
+						if ( ! empty( $start_date ) ) {
 							$start_datetime = date_create( $start_date );
 
 							if ( $start_datetime instanceof DateTime ) {
@@ -237,9 +227,6 @@ $header_vars = array(
 													<path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"></path>
 												</svg>
 												<?php echo esc_html( $display_date ); ?>
-												<?php if ( $display_time_meta ) : ?>
-													<span class="wpfa-past-event-card-time"><?php echo esc_html( ' | ' . $display_time_meta ); ?></span>
-												<?php endif; ?>
 											</div>
 										<?php endif; ?>
 										<?php if ( $location ) : ?>

--- a/public/templates/page-schedule.php
+++ b/public/templates/page-schedule.php
@@ -23,20 +23,92 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$wpfaevent_is_embed         = ! empty( $GLOBALS['wpfaevent_template_embed'] );
-$wpfaevent_use_theme_layout = ! $wpfaevent_is_embed && ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() );
+$wpfaevent_is_embed = ! empty( $GLOBALS['wpfaevent_template_embed'] );
+$events_per_page    = max( 1, (int) apply_filters( 'wpfa_schedule_events_per_page', 20 ) );
+$current_page       = max( 1, (int) get_query_var( 'paged', 1 ) );
+$schedule_page_url  = get_permalink();
 
-if ( $wpfaevent_use_theme_layout ) {
-	get_header();
+if ( ! $schedule_page_url && class_exists( 'Wpfaevent_Schedule_Helper' ) ) {
+	$schedule_page_url = Wpfaevent_Schedule_Helper::get_schedule_page_url();
 }
 
-$events_per_page = max( 1, (int) apply_filters( 'wpfa_schedule_events_per_page', 20 ) );
-$current_page    = max( 1, (int) get_query_var( 'paged', 1 ) );
+$read_filter_value = static function ( $key, $type = 'text' ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- These are read-only schedule filters.
+	if ( ! isset( $_GET[ $key ] ) ) {
+		return '';
+	}
 
-$site_timezone_string           = wp_timezone_string();
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized by type below.
+	$value = wp_unslash( $_GET[ $key ] );
+
+	if ( is_array( $value ) ) {
+		return '';
+	}
+
+	if ( 'slug' === $type ) {
+		return sanitize_title( $value );
+	}
+
+	if ( 'int' === $type ) {
+		return absint( $value );
+	}
+
+	return sanitize_text_field( $value );
+};
+
+$current_language     = $read_filter_value( 'language', 'slug' );
+$current_event_filter = $read_filter_value( 'event' );
+$current_view         = $read_filter_value( 'view', 'slug' );
+$query_page           = $read_filter_value( 'paged', 'int' );
+
+if ( $query_page ) {
+	$current_page = max( 1, $query_page );
+}
+
+if ( ! in_array( $current_view, array( 'list', 'calendar' ), true ) ) {
+	$current_view = 'list';
+}
+
+$resolve_event_filter = static function ( $event_filter ) {
+	$event_filter = trim( (string) $event_filter );
+
+	if ( '' === $event_filter ) {
+		return 0;
+	}
+
+	if ( is_numeric( $event_filter ) ) {
+		$event_id = absint( $event_filter );
+
+		return ( $event_id && 'wpfa_event' === get_post_type( $event_id ) ) ? $event_id : 0;
+	}
+
+	$events = get_posts(
+		array(
+			'name'           => sanitize_title( $event_filter ),
+			'post_type'      => 'wpfa_event',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		)
+	);
+
+	return ! empty( $events[0] ) ? absint( $events[0] ) : 0;
+};
+
+$selected_event_id   = $resolve_event_filter( $current_event_filter );
+$selected_event_slug = $selected_event_id ? get_post_field( 'post_name', $selected_event_id ) : '';
+
+$site_timezone_string    = wp_timezone_string();
+$primary_timezone_string = $site_timezone_string;
+
+if ( $selected_event_id && class_exists( 'Wpfaevent_Calendar' ) ) {
+	$primary_timezone_string = Wpfaevent_Calendar::get_event_timezone_string( $selected_event_id );
+}
+
 $selected_schedule_timezone_str = class_exists( 'Wpfaevent_Schedule_Helper' )
-	? Wpfaevent_Schedule_Helper::get_selected_timezone_string( $site_timezone_string )
-	: $site_timezone_string;
+	? Wpfaevent_Schedule_Helper::get_selected_timezone_string( $primary_timezone_string )
+	: $primary_timezone_string;
 
 try {
 	$selected_schedule_timezone = new DateTimeZone( $selected_schedule_timezone_str );
@@ -46,16 +118,84 @@ try {
 }
 
 $schedule_timezone_options = class_exists( 'Wpfaevent_Schedule_Helper' )
-	? Wpfaevent_Schedule_Helper::get_timezone_options( $site_timezone_string )
-	: array( $site_timezone_string, 'UTC' );
+	? Wpfaevent_Schedule_Helper::get_timezone_options( $primary_timezone_string )
+	: array( $primary_timezone_string, 'UTC' );
 
-$format_timezone_label = static function ( $timezone_string ) use ( $site_timezone_string ) {
+$build_schedule_view_url = static function ( $view ) use ( $schedule_page_url, $selected_event_slug, $current_language, $selected_schedule_timezone_str, $primary_timezone_string ) {
+	$args = array();
+
+	if ( $selected_event_slug ) {
+		$args['event'] = $selected_event_slug;
+	}
+
+	if ( $current_language ) {
+		$args['language'] = $current_language;
+	}
+
+	if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $primary_timezone_string ) {
+		$args['schedule_tz'] = $selected_schedule_timezone_str;
+	}
+
+	if ( 'calendar' === $view ) {
+		$args['view'] = 'calendar';
+	}
+
+	return add_query_arg( $args, $schedule_page_url );
+};
+
+$format_timezone_label = static function ( $timezone_string ) use ( $primary_timezone_string ) {
 	return class_exists( 'Wpfaevent_Schedule_Helper' )
-		? Wpfaevent_Schedule_Helper::format_timezone_label( $timezone_string, $site_timezone_string )
+		? Wpfaevent_Schedule_Helper::format_timezone_label( $timezone_string, $primary_timezone_string )
 		: str_replace( '_', ' ', $timezone_string );
 };
 
-$event_ids       = get_posts(
+$format_language_label = static function ( $language ) {
+	$language = trim( (string) $language );
+
+	if ( '' === $language ) {
+		return '';
+	}
+
+	$normalized = strtolower( str_replace( '_', '-', $language ) );
+	$labels     = array(
+		'ar'          => __( 'Arabic', 'wpfaevent' ),
+		'bn'          => __( 'Bengali', 'wpfaevent' ),
+		'bg'          => __( 'Bulgarian', 'wpfaevent' ),
+		'ca'          => __( 'Catalan', 'wpfaevent' ),
+		'cs'          => __( 'Czech', 'wpfaevent' ),
+		'da'          => __( 'Danish', 'wpfaevent' ),
+		'de'          => __( 'German', 'wpfaevent' ),
+		'en'          => __( 'English', 'wpfaevent' ),
+		'en-ca'       => __( 'English (Canada)', 'wpfaevent' ),
+		'es'          => __( 'Spanish', 'wpfaevent' ),
+		'fr'          => __( 'French', 'wpfaevent' ),
+		'gu'          => __( 'Gujarati', 'wpfaevent' ),
+		'hi'          => __( 'Hindi', 'wpfaevent' ),
+		'it'          => __( 'Italian', 'wpfaevent' ),
+		'ja'          => __( 'Japanese', 'wpfaevent' ),
+		'ko'          => __( 'Korean', 'wpfaevent' ),
+		'nl'          => __( 'Dutch', 'wpfaevent' ),
+		'nl-informal' => __( 'Dutch (Informal)', 'wpfaevent' ),
+		'pt'          => __( 'Portuguese', 'wpfaevent' ),
+		'ru'          => __( 'Russian', 'wpfaevent' ),
+		'si'          => __( 'Sinhala', 'wpfaevent' ),
+		'ta'          => __( 'Tamil', 'wpfaevent' ),
+		'zh-hans'     => __( 'Chinese (Simplified)', 'wpfaevent' ),
+		'zh-hant'     => __( 'Chinese (Traditional)', 'wpfaevent' ),
+	);
+
+	if ( isset( $labels[ $normalized ] ) ) {
+		return $labels[ $normalized ];
+	}
+
+	if ( false === strpos( $language, ' ' ) && preg_match( '/^[a-z]{2,3}(?:[-_][a-z0-9]+)*$/i', $language ) ) {
+		return ucwords( str_replace( '-', ' ', $normalized ) );
+	}
+
+	return $language;
+};
+
+$event_ids              = get_posts(
 	array(
 		'post_type'      => 'wpfa_event',
 		'post_status'    => 'publish',
@@ -64,18 +204,54 @@ $event_ids       = get_posts(
 		'no_found_rows'  => true,
 	)
 );
-$schedule_events = array();
+$schedule_events        = array();
+$languages              = array();
+$filtered_event_ids     = array();
+$is_event_schedule      = (bool) $selected_event_id;
+$event_session_schedule = array(
+	'items'  => array(),
+	'groups' => array(),
+);
 
 foreach ( $event_ids as $event_id ) {
-	$entry = class_exists( 'Wpfaevent_Schedule_Helper' )
-		? Wpfaevent_Schedule_Helper::build_event_schedule_entry( $event_id, $selected_schedule_timezone )
-		: null;
+	$event_id        = absint( $event_id );
+	$event_languages = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_language_list( get_post_meta( $event_id, 'wpfa_event_languages', true ) ) : array();
+	$language_keys   = array_map( 'sanitize_title', $event_languages );
 
-	if ( ! $entry ) {
+	if ( $selected_event_id && $selected_event_id !== $event_id ) {
 		continue;
 	}
 
-	$schedule_events[] = $entry;
+	foreach ( $event_languages as $language ) {
+		$languages[ sanitize_title( $language ) ] = $format_language_label( $language );
+	}
+
+	if ( $current_language && ! in_array( $current_language, $language_keys, true ) ) {
+		continue;
+	}
+
+	$filtered_event_ids[] = $event_id;
+
+	if ( ! $is_event_schedule ) {
+		$entry = class_exists( 'Wpfaevent_Schedule_Helper' )
+			? Wpfaevent_Schedule_Helper::build_event_schedule_entry( $event_id, $selected_schedule_timezone )
+			: null;
+
+		if ( ! $entry ) {
+			continue;
+		}
+
+		$entry['languages']      = $event_languages;
+		$entry['language_keys']  = $language_keys;
+		$entry['language_label'] = implode( ', ', array_map( $format_language_label, $event_languages ) );
+		$schedule_events[]       = $entry;
+	}
+}
+
+asort( $languages );
+
+if ( $is_event_schedule && in_array( $selected_event_id, $filtered_event_ids, true ) && class_exists( 'Wpfaevent_Schedule_Helper' ) ) {
+	$event_session_schedule = Wpfaevent_Schedule_Helper::build_event_session_schedule( $selected_event_id, $selected_schedule_timezone );
 }
 
 usort(
@@ -111,6 +287,29 @@ foreach ( $paged_schedule_events as $schedule_event ) {
 	$groups[ $group_key ]['events'][] = $schedule_event;
 }
 
+$selected_event_title = $selected_event_id ? get_the_title( $selected_event_id ) : '';
+$event_style_attr     = '';
+
+if ( $selected_event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$event_colors        = Wpfaevent_Meta_Event::get_event_colors( $selected_event_id );
+	$event_color_var_map = array(
+		'wpfa_event_primary_color'          => '--event-primary',
+		'wpfa_event_hover_button_color'     => '--event-primary-dark',
+		'wpfa_event_theme_background_color' => '--event-soft',
+		'wpfa_event_theme_success_color'    => '--event-success',
+		'wpfa_event_theme_danger_color'     => '--event-danger',
+	);
+	$event_style_vars    = array();
+
+	foreach ( $event_color_var_map as $meta_key => $css_var ) {
+		if ( ! empty( $event_colors[ $meta_key ] ) ) {
+			$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+		}
+	}
+
+	$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+}
+
 $site_logo_url = get_option( 'wpfa_site_logo_url', '' );
 if ( empty( $site_logo_url ) ) {
 	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
@@ -127,9 +326,12 @@ $header_vars = array(
 	'register_button_text' => __( 'Register', 'wpfaevent' ),
 );
 
-$schedule_page_url = get_permalink();
+$filter_form_classes = 'wpfa-schedule-filter-form';
+if ( ! empty( $languages ) ) {
+	$filter_form_classes .= ' has-language-filter';
+}
 ?>
-<?php if ( ! $wpfaevent_is_embed && ! $wpfaevent_use_theme_layout ) : ?>
+<?php if ( ! $wpfaevent_is_embed ) : ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
@@ -137,7 +339,7 @@ $schedule_page_url = get_permalink();
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<?php wp_head(); ?>
 </head>
-<body <?php body_class( 'wpfaevent wpfa-schedule-template' ); ?>>
+<body <?php body_class( 'wpfaevent wpfa-schedule-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
 	<?php wp_body_open(); ?>
 
 <div id="page" class="site">
@@ -158,100 +360,367 @@ $schedule_page_url = get_permalink();
 <?php endif; ?>
 
 <?php if ( $wpfaevent_is_embed ) : ?>
-<section class="wpfa-schedule">
+	<section class="wpfa-schedule">
 <?php else : ?>
-<main class="wpfa-schedule">
+	<main class="wpfa-schedule">
 <?php endif; ?>
-	<div class="container">
-		<div class="wpfa-schedule-head">
-			<div>
-				<h1><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></h1>
-				<p><?php esc_html_e( 'Upcoming events grouped by start date.', 'wpfaevent' ); ?></p>
+		<div class="container">
+			<div class="wpfa-schedule-head">
+				<div>
+					<?php if ( $is_event_schedule && $selected_event_title ) : ?>
+						<h1><?php echo esc_html( $selected_event_title ); ?></h1>
+						<p><?php esc_html_e( 'Event schedule grouped by session date.', 'wpfaevent' ); ?></p>
+					<?php else : ?>
+						<h1><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></h1>
+						<p><?php esc_html_e( 'Upcoming events grouped by start date.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</div>
+				<?php if ( ! empty( $event_ids ) ) : ?>
+					<div class="wpfa-schedule-controls">
+						<nav class="wpfa-schedule-view-switch" aria-label="<?php esc_attr_e( 'Schedule view', 'wpfaevent' ); ?>">
+							<a
+								class="<?php echo esc_attr( 'list' === $current_view ? 'is-active' : '' ); ?>"
+								href="<?php echo esc_url( $build_schedule_view_url( 'list' ) ); ?>"
+								<?php if ( 'list' === $current_view ) : ?>
+									aria-current="page"
+								<?php endif; ?>
+							>
+								<?php esc_html_e( 'List', 'wpfaevent' ); ?>
+							</a>
+							<a
+								class="<?php echo esc_attr( 'calendar' === $current_view ? 'is-active' : '' ); ?>"
+								href="<?php echo esc_url( $build_schedule_view_url( 'calendar' ) ); ?>"
+								<?php if ( 'calendar' === $current_view ) : ?>
+									aria-current="page"
+								<?php endif; ?>
+							>
+								<?php esc_html_e( 'Calendar', 'wpfaevent' ); ?>
+							</a>
+						</nav>
+						<form class="<?php echo esc_attr( $filter_form_classes ); ?>" action="<?php echo esc_url( $schedule_page_url ); ?>" method="get">
+							<?php if ( $selected_event_slug ) : ?>
+								<input type="hidden" name="event" value="<?php echo esc_attr( $selected_event_slug ); ?>">
+							<?php endif; ?>
+							<?php if ( 'calendar' === $current_view ) : ?>
+								<input type="hidden" name="view" value="calendar">
+							<?php endif; ?>
+							<?php if ( ! empty( $languages ) ) : ?>
+								<label for="wpfa-schedule-language">
+									<span><?php esc_html_e( 'Language', 'wpfaevent' ); ?></span>
+									<select id="wpfa-schedule-language" name="language">
+										<option value=""><?php esc_html_e( 'All languages', 'wpfaevent' ); ?></option>
+										<?php foreach ( $languages as $language_key => $language_label ) : ?>
+											<option value="<?php echo esc_attr( $language_key ); ?>" <?php selected( $current_language, $language_key ); ?>>
+												<?php echo esc_html( $language_label ); ?>
+											</option>
+										<?php endforeach; ?>
+									</select>
+								</label>
+							<?php endif; ?>
+							<label for="wpfa-schedule-timezone">
+								<span><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></span>
+								<select id="wpfa-schedule-timezone" class="wpfa-event-timezone-select" name="schedule_tz">
+									<?php foreach ( $schedule_timezone_options as $timezone_option ) : ?>
+										<option value="<?php echo esc_attr( $timezone_option ); ?>" <?php selected( $selected_schedule_timezone_str, $timezone_option ); ?>>
+											<?php echo esc_html( $format_timezone_label( $timezone_option ) ); ?>
+										</option>
+									<?php endforeach; ?>
+								</select>
+							</label>
+							<button type="submit"><?php esc_html_e( 'Apply', 'wpfaevent' ); ?></button>
+						</form>
+					</div>
+				<?php endif; ?>
 			</div>
-			<?php if ( ! empty( $schedule_events ) ) : ?>
-				<form class="wpfa-event-timezone-form" action="<?php echo esc_url( $schedule_page_url ); ?>" method="get">
-					<label for="wpfa-schedule-timezone">
-						<span><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></span>
-						<select id="wpfa-schedule-timezone" class="wpfa-event-timezone-select" name="schedule_tz">
-							<?php foreach ( $schedule_timezone_options as $timezone_option ) : ?>
-								<option value="<?php echo esc_attr( $timezone_option ); ?>" <?php selected( $selected_schedule_timezone_str, $timezone_option ); ?>>
-									<?php echo esc_html( $format_timezone_label( $timezone_option ) ); ?>
-								</option>
+
+			<?php if ( $is_event_schedule ) : ?>
+				<?php if ( ! empty( $event_session_schedule['groups'] ) ) : ?>
+					<?php if ( 'calendar' === $current_view ) : ?>
+						<div class="wpfa-schedule-calendar" role="list">
+							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading">
+									<header class="wpfa-schedule-calendar-day-head">
+										<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading"><?php echo esc_html( $day_label ); ?></h2>
+										<span>
+											<?php
+											printf(
+												/* translators: %d: number of sessions on this day. */
+												esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+												absint( count( $day_sessions ) )
+											);
+											?>
+										</span>
+									</header>
+									<div class="wpfa-schedule-calendar-slots">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-calendar-slot">
+												<?php if ( ! empty( $item['time_label'] ) ) : ?>
+													<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+												<?php endif; ?>
+												<h3><?php echo esc_html( $item['title'] ); ?></h3>
+												<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+													<ul class="wpfa-schedule-calendar-meta">
+														<?php if ( ! empty( $item['speakers'] ) ) : ?>
+															<li><?php echo esc_html( $item['speakers'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['room'] ) ) : ?>
+															<li><?php echo esc_html( $item['room'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['track'] ) ) : ?>
+															<li><?php echo esc_html( $item['track'] ); ?></li>
+														<?php endif; ?>
+													</ul>
+												<?php endif; ?>
+												<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+													<?php
+													$session_calendar_label = sprintf(
+														/* translators: %s: session title. */
+														__( 'Add %s to Google Calendar', 'wpfaevent' ),
+														$item['title']
+													);
+													?>
+													<a
+														class="wpfa-schedule-session-calendar"
+														href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+														target="_blank"
+														rel="noopener"
+														aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+													>
+														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+													</a>
+												<?php endif; ?>
+											</article>
+										<?php endforeach; ?>
+									</div>
+								</section>
 							<?php endforeach; ?>
-						</select>
-					</label>
-					<button type="submit"><?php esc_html_e( 'Convert', 'wpfaevent' ); ?></button>
-				</form>
+						</div>
+					<?php else : ?>
+						<div class="wpfa-schedule-program">
+							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+									<header class="wpfa-schedule-day-head">
+										<div>
+											<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h2>
+											<p>
+												<?php
+												printf(
+													/* translators: %d: number of sessions on this day. */
+													esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+													absint( count( $day_sessions ) )
+												);
+												?>
+											</p>
+										</div>
+									</header>
+
+									<div class="wpfa-schedule-day-sessions" role="list">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-session" role="listitem">
+												<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+													<?php if ( ! empty( $item['time_start'] ) ) : ?>
+														<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+															<?php echo esc_html( $item['time_start'] ); ?>
+														</time>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['time_end'] ) ) : ?>
+														<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
+													<?php endif; ?>
+												</div>
+
+												<div class="wpfa-schedule-session-main">
+													<h3 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h3>
+
+													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+														<dl class="wpfa-schedule-session-details">
+															<?php if ( ! empty( $item['speakers'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Speaker', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['speakers'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['room'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Room', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['room'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['track'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Track', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['track'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+														</dl>
+													<?php endif; ?>
+
+													<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+														<?php
+														$session_calendar_label = sprintf(
+															/* translators: %s: session title. */
+															__( 'Add %s to Google Calendar', 'wpfaevent' ),
+															$item['title']
+														);
+														?>
+														<a
+															class="wpfa-schedule-session-calendar"
+															href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+															target="_blank"
+															rel="noopener"
+															aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+														>
+															<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+														</a>
+													<?php endif; ?>
+												</div>
+											</article>
+										<?php endforeach; ?>
+									</div>
+								</section>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+				<?php else : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
+				<?php endif; ?>
+			<?php elseif ( $groups ) : ?>
+				<?php if ( 'calendar' === $current_view ) : ?>
+					<div class="wpfa-schedule-calendar" role="list">
+						<?php foreach ( $groups as $group ) : ?>
+							<section class="wpfa-schedule-calendar-day" role="listitem">
+								<header class="wpfa-schedule-calendar-day-head">
+									<h2><?php echo esc_html( $group['date'] ); ?></h2>
+									<span>
+										<?php
+										printf(
+											/* translators: %d: number of events on this day. */
+											esc_html( _n( '%d event', '%d events', count( $group['events'] ), 'wpfaevent' ) ),
+											absint( count( $group['events'] ) )
+										);
+										?>
+									</span>
+								</header>
+								<div class="wpfa-schedule-calendar-slots">
+									<?php foreach ( $group['events'] as $schedule_event ) : ?>
+										<article class="wpfa-schedule-calendar-slot">
+											<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
+												<time><?php echo esc_html( $schedule_event['time_label'] ); ?></time>
+											<?php endif; ?>
+											<h3>
+												<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
+													<?php echo esc_html( $schedule_event['title'] ); ?>
+												</a>
+											</h3>
+											<?php if ( ! empty( $schedule_event['location'] ) || ! empty( $schedule_event['language_label'] ) ) : ?>
+												<ul class="wpfa-schedule-calendar-meta">
+													<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
+														<li><?php echo esc_html( $schedule_event['location'] ); ?></li>
+													<?php endif; ?>
+													<?php if ( ! empty( $schedule_event['language_label'] ) ) : ?>
+														<li><?php echo esc_html( $schedule_event['language_label'] ); ?></li>
+													<?php endif; ?>
+												</ul>
+											<?php endif; ?>
+											<div class="wpfa-schedule-calendar-actions">
+												<a href="<?php echo esc_url( $schedule_event['schedule_url'] ); ?>"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></a>
+												<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
+													<?php
+													$calendar_label = sprintf(
+														/* translators: %s: event title. */
+														__( 'Add %s to Google Calendar', 'wpfaevent' ),
+														$schedule_event['title']
+													);
+													?>
+													<a
+														href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
+														target="_blank"
+														rel="noopener"
+														aria-label="<?php echo esc_attr( $calendar_label ); ?>"
+													>
+														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+													</a>
+												<?php endif; ?>
+											</div>
+										</article>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endforeach; ?>
+					</div>
+				<?php else : ?>
+					<?php foreach ( $groups as $group ) : ?>
+						<section class="wpfa-schedule-group">
+							<h2 class="wpfa-schedule-date"><?php echo esc_html( $group['date'] ); ?></h2>
+							<ul class="wpfa-schedule-items">
+								<?php foreach ( $group['events'] as $schedule_event ) : ?>
+									<li class="wpfa-schedule-item">
+										<strong>
+											<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
+												<?php echo esc_html( $schedule_event['title'] ); ?>
+											</a>
+										</strong>
+										<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
+											<span class="wpfa-schedule-time"><?php echo esc_html( $schedule_event['time_label'] ); ?></span>
+										<?php endif; ?>
+										<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
+											<span class="wpfa-schedule-location"><?php echo esc_html( $schedule_event['location'] ); ?></span>
+										<?php endif; ?>
+										<?php if ( ! empty( $schedule_event['language_label'] ) ) : ?>
+											<span class="wpfa-schedule-language"><?php echo esc_html( $schedule_event['language_label'] ); ?></span>
+										<?php endif; ?>
+										<span class="wpfa-schedule-actions">
+											<a href="<?php echo esc_url( $schedule_event['schedule_url'] ); ?>"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></a>
+										</span>
+										<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
+											<?php
+											$calendar_label = sprintf(
+												/* translators: %s: event title. */
+												__( 'Add %s to Google Calendar', 'wpfaevent' ),
+												$schedule_event['title']
+											);
+											?>
+											<a
+												class="wpfa-calendar-action"
+												href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
+												target="_blank"
+												rel="noopener"
+												aria-label="<?php echo esc_attr( $calendar_label ); ?>"
+											>
+												<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+											</a>
+										<?php endif; ?>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+						</section>
+					<?php endforeach; ?>
+				<?php endif; ?>
+
+				<?php
+				$total           = max( 1, (int) ceil( $total_events / $events_per_page ) );
+				$pagination_args = array();
+				if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $site_timezone_string ) {
+					$pagination_args['schedule_tz'] = $selected_schedule_timezone_str;
+				}
+				if ( $current_language ) {
+					$pagination_args['language'] = $current_language;
+				}
+				if ( 'calendar' === $current_view ) {
+					$pagination_args['view'] = 'calendar';
+				}
+				wpfa_render_pagination( $total, $current_page, __( 'Schedule pagination', 'wpfaevent' ), $pagination_args );
+				?>
+			<?php else : ?>
+				<p><?php esc_html_e( 'No schedule entries yet.', 'wpfaevent' ); ?></p>
 			<?php endif; ?>
 		</div>
-
-		<?php if ( $groups ) : ?>
-			<?php foreach ( $groups as $group ) : ?>
-				<section class="wpfa-schedule-group">
-					<h2 class="wpfa-schedule-date"><?php echo esc_html( $group['date'] ); ?></h2>
-					<ul class="wpfa-schedule-items">
-						<?php foreach ( $group['events'] as $schedule_event ) : ?>
-							<li class="wpfa-schedule-item">
-								<strong>
-									<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
-										<?php echo esc_html( $schedule_event['title'] ); ?>
-									</a>
-								</strong>
-								<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
-									<span class="wpfa-schedule-time"><?php echo esc_html( $schedule_event['time_label'] ); ?></span>
-								<?php endif; ?>
-								<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
-									<span class="wpfa-schedule-location"><?php echo esc_html( $schedule_event['location'] ); ?></span>
-								<?php endif; ?>
-								<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
-									<?php
-									$calendar_label = sprintf(
-										/* translators: %s: event title. */
-										__( 'Add %s to Google Calendar', 'wpfaevent' ),
-										$schedule_event['title']
-									);
-									?>
-									<a
-										class="wpfa-calendar-action"
-										href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
-										target="_blank"
-										rel="noopener"
-										aria-label="<?php echo esc_attr( $calendar_label ); ?>"
-									>
-										<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-									</a>
-								<?php endif; ?>
-							</li>
-						<?php endforeach; ?>
-					</ul>
-				</section>
-			<?php endforeach; ?>
-
-			<?php
-			$total           = max( 1, (int) ceil( $total_events / $events_per_page ) );
-			$pagination_args = array();
-			if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $site_timezone_string ) {
-				$pagination_args['schedule_tz'] = $selected_schedule_timezone_str;
-			}
-			wpfa_render_pagination( $total, $current_page, __( 'Schedule pagination', 'wpfaevent' ), $pagination_args );
-			?>
-		<?php else : ?>
-			<p><?php esc_html_e( 'No schedule entries yet.', 'wpfaevent' ); ?></p>
-		<?php endif; ?>
-	</div>
 <?php if ( $wpfaevent_is_embed ) : ?>
-</section>
+	</section>
 <?php else : ?>
-</main>
-<?php endif; ?>
-
-<?php if ( ! $wpfaevent_is_embed && ! $wpfaevent_use_theme_layout ) : ?>
-	<?php require WPFAEVENT_PATH . 'public/partials/footer.php'; ?>
+	</main>
 </div>
 
 	<?php wp_footer(); ?>
 </body>
 </html>
-<?php elseif ( $wpfaevent_use_theme_layout ) : ?>
-	<?php get_footer(); ?>
 <?php endif; ?>

--- a/public/templates/page-speakers.php
+++ b/public/templates/page-speakers.php
@@ -24,59 +24,212 @@ $wpfaevent_is_embed = ! empty( $GLOBALS['wpfaevent_template_embed'] );
 $current_page = max( 1, (int) get_query_var( 'paged', 1 ) );
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end search filtering via query args.
 $search_term = isset( $_GET['q'] ) ? sanitize_text_field( wp_unslash( $_GET['q'] ) ) : '';
-
-// Query speakers from the CPT.
-$speakers_per_page = max( 1, (int) apply_filters( 'wpfa_speakers_per_page', 24 ) );
-$args              = array(
-	'post_type'      => 'wpfa_speaker',
-	'post_status'    => 'publish',
-	'posts_per_page' => $speakers_per_page,
-	'paged'          => $current_page,
-	'orderby'        => 'title',
-	'order'          => 'ASC',
-	's'              => $search_term,
-	'fields'         => 'ids',
-);
-
-// Add the category filter if it is set.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end category filtering via query args.
-if ( isset( $_GET['category'] ) && ! empty( $_GET['category'] ) ) {
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end category filtering via query args.
-	$category = sanitize_text_field( wp_unslash( $_GET['category'] ) );
-	if ( 'all' !== $category ) {
-		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Required to filter speakers by selected taxonomy term.
-		$args['tax_query'] = array(
-			array(
-				'taxonomy' => 'wpfa_speaker_category',
-				'field'    => 'slug',
-				'terms'    => sanitize_title( $category ),
-			),
-		);
+$current_category = isset( $_GET['category'] ) ? sanitize_title( wp_unslash( $_GET['category'] ) ) : 'all';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end event filtering via query args.
+$current_event_filter = isset( $_GET['event'] ) ? sanitize_text_field( wp_unslash( $_GET['event'] ) ) : '';
+
+$speakers_per_page = max( 1, (int) apply_filters( 'wpfa_speakers_per_page', 24 ) );
+
+$read_dashboard_json = static function ( $filename, $fallback ) {
+	$upload_dir = wp_upload_dir();
+
+	if ( ! empty( $upload_dir['error'] ) ) {
+		return $fallback;
+	}
+
+	$path = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/' . sanitize_file_name( $filename );
+
+	if ( ! file_exists( $path ) || ! is_readable( $path ) ) {
+		return $fallback;
+	}
+
+	$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading plugin-managed JSON from uploads.
+	if ( false === $contents || '' === trim( $contents ) ) {
+		return $fallback;
+	}
+
+	$decoded = json_decode( $contents, true );
+
+	return ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) ? $decoded : $fallback;
+};
+
+$normalize_post_id_list = static function ( $post_ids ) {
+	if ( ! is_array( $post_ids ) ) {
+		return array();
+	}
+
+	$post_ids = array_map( 'absint', $post_ids );
+	$post_ids = array_filter( $post_ids );
+
+	return array_values( array_unique( $post_ids ) );
+};
+
+$get_event_speaker_ids = static function ( $event_id ) use ( $normalize_post_id_list ) {
+	$event_id = absint( $event_id );
+
+	if ( ! $event_id ) {
+		return array();
+	}
+
+	if ( class_exists( 'Wpfaevent_Meta_Event' ) ) {
+		return Wpfaevent_Meta_Event::get_admin_event_speaker_ids( $event_id );
+	}
+
+	return $normalize_post_id_list( get_post_meta( $event_id, 'wpfa_event_speakers', true ) );
+};
+
+$selected_event_id = 0;
+if ( '' !== trim( $current_event_filter ) ) {
+	if ( is_numeric( $current_event_filter ) ) {
+		$candidate_event_id = absint( $current_event_filter );
+		if ( $candidate_event_id && 'wpfa_event' === get_post_type( $candidate_event_id ) ) {
+			$selected_event_id = $candidate_event_id;
+		}
+	} else {
+		$candidate_event = get_page_by_path( sanitize_title( $current_event_filter ), OBJECT, 'wpfa_event' );
+		if ( $candidate_event instanceof WP_Post ) {
+			$selected_event_id = absint( $candidate_event->ID );
+		}
 	}
 }
 
-$speakers_query = new WP_Query( $args );
+$event_filter_posts = get_posts(
+	array(
+		'post_type'      => 'wpfa_event',
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'orderby'        => 'title',
+		'order'          => 'ASC',
+		'no_found_rows'  => true,
+	)
+);
 
-// Get all categories, including empty ones for admin filtering.
-$categories = array();
-if ( taxonomy_exists( 'wpfa_speaker_category' ) ) {
-	$terms = get_terms(
-		array(
-			'taxonomy'   => 'wpfa_speaker_category',
-			'hide_empty' => false, // Show all categories for admin filtering.
-			'orderby'    => 'name',
-			'order'      => 'ASC',
+$dashboard_speakers = $selected_event_id ? $read_dashboard_json( 'speakers-' . absint( $selected_event_id ) . '.json', array() ) : array();
+
+if ( $selected_event_id ) {
+	$speaker_ids = $get_event_speaker_ids( $selected_event_id );
+	$speaker_ids = array_values(
+		array_filter(
+			$speaker_ids,
+			static function ( $speaker_id ) use ( $search_term ) {
+				if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) || 'publish' !== get_post_status( $speaker_id ) ) {
+					return false;
+				}
+
+				if ( '' === trim( $search_term ) ) {
+					return true;
+				}
+
+				$haystack = get_the_title( $speaker_id ) . ' ' . get_post_field( 'post_content', $speaker_id );
+
+				return false !== stripos( $haystack, $search_term );
+			}
 		)
 	);
 
-	if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
-		$categories = $terms;
+	usort(
+		$speaker_ids,
+		static function ( $speaker_a, $speaker_b ) {
+			return strcasecmp( get_the_title( $speaker_a ), get_the_title( $speaker_b ) );
+		}
+	);
+} else {
+	$speaker_ids = array();
+}
+
+$featured_speaker_ids = array();
+if ( $selected_event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$featured_speaker_ids = Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $selected_event_id, $speaker_ids, $dashboard_speakers );
+	$featured_speaker_ids = array_values( array_intersect( $featured_speaker_ids, $speaker_ids ) );
+}
+
+$category_source_speaker_ids = $speaker_ids;
+
+if ( 'all' !== $current_category && taxonomy_exists( 'wpfa_speaker_category' ) ) {
+	$speaker_ids = array_values(
+		array_filter(
+			$speaker_ids,
+			static function ( $speaker_id ) use ( $current_category ) {
+				return has_term( $current_category, 'wpfa_speaker_category', $speaker_id );
+			}
+		)
+	);
+}
+
+$featured_speaker_ids = array_values( array_intersect( $featured_speaker_ids, $speaker_ids ) );
+
+if ( ! empty( $featured_speaker_ids ) ) {
+	usort(
+		$speaker_ids,
+		static function ( $speaker_a, $speaker_b ) use ( $featured_speaker_ids ) {
+			$speaker_a_is_featured = in_array( absint( $speaker_a ), $featured_speaker_ids, true );
+			$speaker_b_is_featured = in_array( absint( $speaker_b ), $featured_speaker_ids, true );
+
+			if ( $speaker_a_is_featured !== $speaker_b_is_featured ) {
+				return $speaker_a_is_featured ? -1 : 1;
+			}
+
+			return strcasecmp( get_the_title( $speaker_a ), get_the_title( $speaker_b ) );
+		}
+	);
+}
+
+$total_speakers = count( $speaker_ids );
+
+// Event speaker lists should show everyone; the event page keeps a smaller preview set.
+if ( $selected_event_id ) {
+	$paged_speaker_ids = $speaker_ids;
+} else {
+	$speaker_offset    = ( $current_page - 1 ) * $speakers_per_page;
+	$paged_speaker_ids = array_slice( $speaker_ids, $speaker_offset, $speakers_per_page );
+}
+
+$featured_display_speaker_ids = array_values( array_intersect( $paged_speaker_ids, $featured_speaker_ids ) );
+$regular_display_speaker_ids  = array_values( array_diff( $paged_speaker_ids, $featured_display_speaker_ids ) );
+
+// Get categories; when an event is selected, keep category counts event-specific.
+$categories           = array();
+$category_term_counts = array();
+if ( taxonomy_exists( 'wpfa_speaker_category' ) ) {
+	if ( $selected_event_id ) {
+		foreach ( $category_source_speaker_ids as $speaker_id ) {
+			$terms = wp_get_post_terms( $speaker_id, 'wpfa_speaker_category' );
+
+			if ( is_wp_error( $terms ) || empty( $terms ) ) {
+				continue;
+			}
+
+			foreach ( $terms as $speaker_term ) {
+				$category_term_counts[ $speaker_term->term_id ] = isset( $category_term_counts[ $speaker_term->term_id ] ) ? $category_term_counts[ $speaker_term->term_id ] + 1 : 1;
+			}
+		}
+
+		if ( ! empty( $category_term_counts ) ) {
+			$terms = get_terms(
+				array(
+					'taxonomy'   => 'wpfa_speaker_category',
+					'include'    => array_keys( $category_term_counts ),
+					'hide_empty' => false,
+					'orderby'    => 'name',
+					'order'      => 'ASC',
+				)
+			);
+
+			if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+				$categories = $terms;
+			}
+		}
 	}
 }
 
-// Get the current category from the URL.
-// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only front-end category filtering via query args.
-$current_category = isset( $_GET['category'] ) ? sanitize_title( wp_unslash( $_GET['category'] ) ) : 'all';
+$selected_event_slug      = $selected_event_id ? get_post_field( 'post_name', $selected_event_id ) : '';
+$selected_event_title     = $selected_event_id ? get_the_title( $selected_event_id ) : '';
+$selected_event_permalink = $selected_event_id ? get_permalink( $selected_event_id ) : home_url( '/events/' );
+$selected_event_url       = $selected_event_id ? get_post_meta( $selected_event_id, 'wpfa_event_url', true ) : '';
+$selected_event_url       = $selected_event_url ? $selected_event_url : $selected_event_permalink;
+$speakers_base_url        = get_post_type_archive_link( 'wpfa_speaker' );
+$speakers_base_url        = $speakers_base_url ? $speakers_base_url : home_url( '/speakers/' );
 
 // Get the site logo.
 $site_logo_url = get_option( 'wpfa_site_logo_url', '' );
@@ -86,14 +239,14 @@ if ( empty( $site_logo_url ) ) {
 $site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
 
 // Set up header variables for the partial.
-$register_button_url = get_option( 'wpfa_register_button_url', 'https://eventyay.com/e/4c0e0c27' );
+$register_button_url = $selected_event_id ? $selected_event_url : get_option( 'wpfa_register_button_url', 'https://eventyay.com/e/4c0e0c27' );
 $register_button_url = apply_filters( 'wpfa_register_button_url', $register_button_url );
 $header_vars         = array(
 	'site_logo_url'        => $site_logo_url,
-	'event_page_url'       => home_url( '/events/' ),
+	'event_page_url'       => $selected_event_permalink,
 	'show_back_button'     => true,
 	'show_register_button' => true,
-	'back_button_text'     => __( 'Back to Event', 'wpfaevent' ),
+	'back_button_text'     => $selected_event_id ? __( 'Back to Event', 'wpfaevent' ) : __( 'Back to Events', 'wpfaevent' ),
 	'register_button_url'  => $register_button_url,
 	'register_button_text' => __( 'Register', 'wpfaevent' ),
 );
@@ -110,74 +263,139 @@ $header_vars         = array(
 <body <?php body_class( 'wpfaevent' ); ?>>
 	<?php wp_body_open(); ?>
 
-		<div id="page" class="site">
-		<?php
-		// Load the shared navigation header.
-		$site_logo_url        = $header_vars['site_logo_url'];
-		$event_page_url       = $header_vars['event_page_url'];
-		$show_back_button     = $header_vars['show_back_button'];
-		$show_register_button = $header_vars['show_register_button'];
-		$back_button_text     = $header_vars['back_button_text'];
-		$register_button_url  = $header_vars['register_button_url'];
-		$register_button_text = $header_vars['register_button_text'];
+<div id="page" class="site">
+	<?php
+	// Load the shared navigation header.
+	$site_logo_url        = $header_vars['site_logo_url'];
+	$event_page_url       = $header_vars['event_page_url'];
+	$show_back_button     = $header_vars['show_back_button'];
+	$show_register_button = $header_vars['show_register_button'];
+	$back_button_text     = $header_vars['back_button_text'];
+	$register_button_url  = $header_vars['register_button_url'];
+	$register_button_text = $header_vars['register_button_text'];
 
-		$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
-		if ( file_exists( $nav_partial ) ) {
-			include $nav_partial;
-		}
-		?>
+	$nav_partial = WPFAEVENT_PATH . 'public/partials/header.php';
+	if ( file_exists( $nav_partial ) ) {
+		include $nav_partial;
+	}
+	?>
 <?php endif; ?>
 
-	<?php if ( $wpfaevent_is_embed ) : ?>
+<?php if ( $wpfaevent_is_embed ) : ?>
 	<section class="wpfa-speakers">
-	<?php else : ?>
+<?php else : ?>
 	<main class="wpfa-speakers">
-	<?php endif; ?>
+<?php endif; ?>
 		<section class="wpfa-speakers-hero">
 			<div class="container">
-				<h1><?php echo esc_html( apply_filters( 'wpfa_speakers_title', __( 'FOSSASIA Summit Speakers', 'wpfaevent' ) ) ); ?></h1>
-				<p><?php echo esc_html( apply_filters( 'wpfa_speakers_subtitle', __( 'Discover all the amazing speakers joining us at FOSSASIA Summit', 'wpfaevent' ) ) ); ?></p>
-
-				<form class="wpfa-speakers-search" method="get" action="<?php echo esc_url( get_permalink() ); ?>">
-					<label for="wpfa-speaker-search" class="screen-reader-text">
-						<?php esc_html_e( 'Search speakers', 'wpfaevent' ); ?>
-					</label>
-					<input
-						type="search"
-						id="wpfa-speaker-search"
-						name="q"
+				<h1>
+					<?php
+					echo esc_html(
+						$selected_event_id
+							? sprintf(
+								/* translators: %s: Event title. */
+								__( '%s Speakers', 'wpfaevent' ),
+								$selected_event_title
+							)
+							: apply_filters( 'wpfa_speakers_title', __( 'Event Speakers', 'wpfaevent' ) )
+					);
+					?>
+				</h1>
+				<p>
+					<?php
+					echo esc_html(
+						$selected_event_id
+							? __( 'Speakers linked to this event.', 'wpfaevent' )
+							: apply_filters( 'wpfa_speakers_subtitle', __( 'Choose an event to view its separate speaker list.', 'wpfaevent' ) )
+					);
+					?>
+					</p>
+					<?php if ( $selected_event_id ) : ?>
+					<form class="wpfa-speakers-search" method="get" action="<?php echo esc_url( $speakers_base_url ); ?>">
+						<label for="wpfa-speaker-search" class="screen-reader-text">
+							<?php esc_html_e( 'Search speakers', 'wpfaevent' ); ?>
+						</label>
+						<input
+							type="search"
+							id="wpfa-speaker-search"
+							name="q"
 							value="<?php echo esc_attr( $search_term ); ?>"
-						placeholder="<?php esc_attr_e( 'Search speakers...', 'wpfaevent' ); ?>"
-					/>
-					<button type="submit">
-						<span class="screen-reader-text"><?php esc_html_e( 'Search', 'wpfaevent' ); ?></span>
-						🔍
-					</button>
-					<input type="hidden" name="category" value="<?php echo esc_attr( $current_category ); ?>">
-				</form>
+							placeholder="<?php esc_attr_e( 'Search speakers...', 'wpfaevent' ); ?>"
+						/>
+						<button type="submit">
+							<span class="screen-reader-text"><?php esc_html_e( 'Search', 'wpfaevent' ); ?></span>
+							🔍
+						</button>
+						<input type="hidden" name="category" value="<?php echo esc_attr( $current_category ); ?>">
+						<input type="hidden" name="event" value="<?php echo esc_attr( $selected_event_slug ); ?>">
+					</form>
+				<?php endif; ?>
+
+				<?php if ( ! empty( $event_filter_posts ) ) : ?>
+					<div class="wpfa-speakers-filters wpfa-event-filters" aria-label="<?php esc_attr_e( 'Filter speakers by event', 'wpfaevent' ); ?>">
+						<a href="<?php echo esc_url( $speakers_base_url ); ?>"
+							class="wpfa-filter-btn <?php echo esc_attr( $selected_event_id ? '' : 'active' ); ?>">
+							<?php esc_html_e( 'Choose Event', 'wpfaevent' ); ?>
+						</a>
+						<?php foreach ( $event_filter_posts as $event_filter_post ) : ?>
+							<?php
+							$event_filter_slug = get_post_field( 'post_name', $event_filter_post->ID );
+							$event_filter_args = array(
+								'event' => $event_filter_slug,
+							);
+							if ( $search_term ) {
+								$event_filter_args['q'] = $search_term;
+							}
+							$event_filter_url = add_query_arg( $event_filter_args, $speakers_base_url );
+							?>
+							<a href="<?php echo esc_url( $event_filter_url ); ?>"
+								class="wpfa-filter-btn <?php echo esc_attr( absint( $event_filter_post->ID ) === $selected_event_id ? 'active' : '' ); ?>">
+								<?php echo esc_html( get_the_title( $event_filter_post->ID ) ); ?>
+							</a>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
 
 				<?php if ( ! empty( $categories ) ) : ?>
 				<div class="wpfa-speakers-filters">
-					<a href="<?php echo esc_url( add_query_arg( array( 'category' => 'all' ), remove_query_arg( 'category' ) ) ); ?>"
-							class="wpfa-filter-btn <?php echo esc_attr( 'all' === $current_category ? 'active' : '' ); ?>"
+					<?php
+					$category_base_args = array(
+						'category' => 'all',
+					);
+					if ( $search_term ) {
+						$category_base_args['q'] = $search_term;
+					}
+					if ( $selected_event_slug ) {
+						$category_base_args['event'] = $selected_event_slug;
+					}
+					?>
+					<a href="<?php echo esc_url( add_query_arg( $category_base_args, $speakers_base_url ) ); ?>"
+						class="wpfa-filter-btn <?php echo esc_attr( 'all' === $current_category ? 'active' : '' ); ?>"
 						data-filter="all">
 						<?php esc_html_e( 'All Speakers', 'wpfaevent' ); ?>
 					</a>
 					<?php
 					foreach ( $categories as $category_term ) :
 						$category_slug = $category_term->slug;
-							$is_active = $current_category === $category_slug;
-						$category_url  = add_query_arg(
-							array( 'category' => $category_slug ),
-							remove_query_arg( array( 'paged', 'category' ) )
+						$is_active     = $current_category === $category_slug;
+						$category_args = array(
+							'category' => $category_slug,
 						);
+						if ( $search_term ) {
+							$category_args['q'] = $search_term;
+						}
+						if ( $selected_event_slug ) {
+							$category_args['event'] = $selected_event_slug;
+						}
+						$category_url   = add_query_arg( $category_args, $speakers_base_url );
+						$category_count = isset( $category_term_counts[ $category_term->term_id ] ) ? absint( $category_term_counts[ $category_term->term_id ] ) : absint( $category_term->count );
 						?>
 						<a href="<?php echo esc_url( $category_url ); ?>"
-							class="wpfa-filter-btn <?php echo $is_active ? 'active' : ''; ?>"
+							class="wpfa-filter-btn <?php echo esc_attr( $is_active ? 'active' : '' ); ?>"
 							data-filter="<?php echo esc_attr( $category_slug ); ?>">
 							<?php echo esc_html( $category_term->name ); ?>
-							<?php if ( $category_term->count > 0 ) : ?>
-								<span class="wpfa-filter-count">(<?php echo intval( $category_term->count ); ?>)</span>
+							<?php if ( $category_count > 0 ) : ?>
+								<span class="wpfa-filter-count">(<?php echo absint( $category_count ); ?>)</span>
 							<?php endif; ?>
 						</a>
 					<?php endforeach; ?>
@@ -186,58 +404,96 @@ $header_vars         = array(
 			</div>
 		</section>
 
-		<div class="container">
-			<div class="wpfa-results-info">
-				<?php
-				printf(
-						/* translators: 1: number of speakers shown, 2: total number of speakers. */
-					esc_html__( 'Showing %1$d of %2$d speakers', 'wpfaevent' ),
-					count( $speakers_query->posts ),
-					absint( $speakers_query->found_posts )
-				);
-				?>
-			</div>
+			<div class="container">
+				<div class="wpfa-results-info">
+					<?php
+					if ( $selected_event_id ) {
+						printf(
+							/* translators: 1: number of speakers shown, 2: event title. */
+							esc_html__( 'Showing %1$d speakers for %2$s', 'wpfaevent' ),
+							absint( $total_speakers ),
+							esc_html( $selected_event_title )
+						);
+					} else {
+						esc_html_e( 'Select an event to view its speaker list.', 'wpfaevent' );
+					}
+					?>
+					</div>
 
-				<?php if ( ! $speakers_query->have_posts() ) : ?>
-				<div class="wpfa-no-results">
-					<h3><?php esc_html_e( 'No speakers found', 'wpfaevent' ); ?></h3>
-					<p><?php esc_html_e( 'Try adjusting your search or filters', 'wpfaevent' ); ?></p>
-				</div>
-			<?php else : ?>
-				<div class="wpfa-speakers-grid" id="wpfa-speakers-grid">
-						<?php foreach ( $speakers_query->posts as $sid ) : ?>
-							<?php include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php'; ?>
-					<?php endforeach; ?>
-				</div>
+					<?php if ( empty( $paged_speaker_ids ) ) : ?>
+						<div class="wpfa-no-results">
+							<h3><?php esc_html_e( 'No speakers found', 'wpfaevent' ); ?></h3>
+							<p>
+								<?php
+								echo esc_html(
+									$selected_event_id
+										? __( 'No speakers are linked to this event yet.', 'wpfaevent' )
+										: __( 'Choose an event above to see that event\'s speakers.', 'wpfaevent' )
+								);
+								?>
+							</p>
+						</div>
+					<?php else : ?>
+					<div class="wpfa-speakers-list" id="wpfa-speakers-grid">
+						<?php $wpfa_featured_speaker_ids = $featured_speaker_ids; ?>
+						<?php if ( ! empty( $featured_display_speaker_ids ) ) : ?>
+							<section class="wpfa-speaker-group wpfa-featured-speaker-group" aria-labelledby="wpfa-featured-speakers-title">
+								<div class="wpfa-speaker-group-head">
+									<h2 id="wpfa-featured-speakers-title"><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h2>
+								</div>
+								<div class="wpfa-speakers-grid wpfa-featured-speakers-grid">
+									<?php foreach ( $featured_display_speaker_ids as $sid ) : ?>
+										<?php include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php'; ?>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endif; ?>
 
-				<?php
-					// Pagination.
-					$total           = max( 1, (int) ceil( $speakers_query->found_posts / $speakers_per_page ) );
-					$pagination_args = array();
-				if ( $search_term ) {
-					$pagination_args['q'] = $search_term;
-				}
-				if ( 'all' !== $current_category ) {
-					$pagination_args['category'] = $current_category;
-				}
+						<?php if ( ! empty( $regular_display_speaker_ids ) ) : ?>
+							<section class="wpfa-speaker-group wpfa-regular-speaker-group" aria-labelledby="wpfa-regular-speakers-title">
+								<?php if ( ! empty( $featured_display_speaker_ids ) ) : ?>
+									<div class="wpfa-speaker-group-head">
+										<h2 id="wpfa-regular-speakers-title"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h2>
+									</div>
+								<?php endif; ?>
+								<div class="wpfa-speakers-grid">
+									<?php foreach ( $regular_display_speaker_ids as $sid ) : ?>
+										<?php include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php'; ?>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endif; ?>
+						<?php unset( $wpfa_featured_speaker_ids ); ?>
+					</div>
 
-				wpfa_render_pagination(
-					$total,
-					$current_page,
-					__( 'Speakers pagination', 'wpfaevent' ),
-					$pagination_args
-				);
-				?>
+						<?php
+						if ( ! $selected_event_id ) {
+							// Pagination is only used for the generic chooser state.
+							$total           = max( 1, (int) ceil( $total_speakers / $speakers_per_page ) );
+							$pagination_args = array();
+							if ( $search_term ) {
+								$pagination_args['q'] = $search_term;
+							}
+							if ( 'all' !== $current_category ) {
+								$pagination_args['category'] = $current_category;
+							}
+
+							wpfa_render_pagination(
+								$total,
+								$current_page,
+								__( 'Speakers pagination', 'wpfaevent' ),
+								$pagination_args
+							);
+						}
+						?>
 			<?php endif; ?>
 			<?php wp_reset_postdata(); ?>
 		</div>
-	<?php if ( $wpfaevent_is_embed ) : ?>
+<?php if ( $wpfaevent_is_embed ) : ?>
 	</section>
-	<?php else : ?>
+<?php else : ?>
 	</main>
-	<?php endif; ?>
 
-<?php if ( ! $wpfaevent_is_embed ) : ?>
 	<footer class="wpfa-footer">
 		<div class="container">
 			<small>
@@ -257,7 +513,7 @@ $header_vars         = array(
 
 <?php
 // Load admin modals if the user is an admin.
-if ( current_user_can( 'manage_options' ) ) :
+if ( Wpfaevent_Roles::current_user_can_manage_dashboard() ) :
 	$modal_partial = WPFAEVENT_PATH . 'public/partials/speakers/speaker-modal.php';
 	if ( file_exists( $modal_partial ) ) {
 		include $modal_partial;

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -2,6 +2,8 @@
 /**
  * Single Event Template.
  *
+ * Displays imported Eventyay event data, event-specific speakers, and schedule.
+ *
  * @package    Wpfaevent
  * @subpackage Wpfaevent/public/templates
  * @since      1.0.0
@@ -17,9 +19,75 @@ if ( ! $event_id || 'wpfa_event' !== get_post_type( $event_id ) ) {
 	return;
 }
 
-if ( have_posts() ) {
-	the_post();
-}
+$read_dashboard_json = static function ( $filename, $fallback ) {
+	$upload_dir = wp_upload_dir();
+
+	if ( ! empty( $upload_dir['error'] ) ) {
+		return $fallback;
+	}
+
+	$path = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/' . sanitize_file_name( $filename );
+
+	if ( ! file_exists( $path ) || ! is_readable( $path ) ) {
+		return $fallback;
+	}
+
+	$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading plugin-managed JSON from uploads.
+	if ( false === $contents || '' === trim( $contents ) ) {
+		return $fallback;
+	}
+
+	$decoded = json_decode( $contents, true );
+
+	return ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) ? $decoded : $fallback;
+};
+
+$normalize_post_id_list = static function ( $post_ids ) {
+	if ( ! is_array( $post_ids ) ) {
+		return array();
+	}
+
+	$post_ids = array_map( 'absint', $post_ids );
+	$post_ids = array_filter( $post_ids );
+
+	return array_values( array_unique( $post_ids ) );
+};
+
+$get_linked_speaker_ids = static function ( $current_event_id ) use ( $normalize_post_id_list ) {
+	$current_event_id = absint( $current_event_id );
+	$speaker_ids      = $normalize_post_id_list( get_post_meta( $current_event_id, 'wpfa_event_speakers', true ) );
+
+	$reverse_speaker_ids = get_posts(
+		array(
+			'post_type'      => 'wpfa_speaker',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored as post meta.
+			'meta_query'     => array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'wpfa_speaker_events',
+					'value'   => 'i:' . $current_event_id . ';',
+					'compare' => 'LIKE',
+				),
+				array(
+					'key'     => 'wpfa_speaker_events',
+					'value'   => '"' . $current_event_id . '"',
+					'compare' => 'LIKE',
+				),
+				array(
+					'key'     => 'wpfa_speaker_events',
+					'value'   => (string) $current_event_id,
+					'compare' => '=',
+				),
+			),
+		)
+	);
+
+	return $normalize_post_id_list( array_merge( $speaker_ids, $reverse_speaker_ids ) );
+};
 
 $format_event_date = static function ( $date ) {
 	$date = trim( (string) $date );
@@ -28,49 +96,568 @@ $format_event_date = static function ( $date ) {
 		return '';
 	}
 
-	$timestamp = strtotime( $date );
-
-	if ( false === $timestamp ) {
+	try {
+		$datetime = new DateTimeImmutable( $date, wp_timezone() );
+	} catch ( Exception $exception ) {
 		return $date;
 	}
 
-	return date_i18n( get_option( 'date_format' ), $timestamp );
+	return wp_date( get_option( 'date_format' ), $datetime->getTimestamp(), wp_timezone() );
 };
 
-$site_logo_url = get_option( 'wpfa_site_logo_url', WPFAEVENT_URL . 'assets/images/logo.png' );
-$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
+$get_timezone_object = static function ( $timezone_string, $fallback_timezone ) {
+	try {
+		return new DateTimeZone( $timezone_string );
+	} catch ( Exception $exception ) {
+		return $fallback_timezone;
+	}
+};
 
-$start_date       = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
-$end_date         = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
-$event_time       = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_time', true ) );
-$event_location   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
-$lead_text        = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) );
-$event_url        = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_url', true ) );
-$registration_url = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_registration_link', true ) );
-$cfs_url          = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_cfs_link', true ) );
-$image_url        = get_the_post_thumbnail_url( $event_id, 'large' );
+$site_timezone        = wp_timezone();
+$site_timezone_string = wp_timezone_string();
 
-$start_label = $format_event_date( $start_date );
-$end_label   = $format_event_date( $end_date );
-$date_label  = $start_label;
+if ( '' === trim( (string) $site_timezone_string ) ) {
+	$site_timezone_string = $site_timezone->getName();
+}
 
-if ( $start_label && $end_label && $end_label !== $start_label ) {
-	$date_label = sprintf(
-		/* translators: 1: event start date, 2: event end date. */
-		__( '%1$s - %2$s', 'wpfaevent' ),
-		$start_label,
-		$end_label
+$event_timezone_string = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_timezone_string( $event_id ) : $site_timezone_string;
+$event_timezone        = $get_timezone_object( $event_timezone_string, $site_timezone );
+
+$selected_schedule_timezone_string = $event_timezone_string;
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only timezone converter for the public schedule.
+if ( isset( $_GET['schedule_tz'] ) ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized immediately before validation.
+	$requested_schedule_timezone = sanitize_text_field( wp_unslash( $_GET['schedule_tz'] ) );
+
+	if ( '' !== $requested_schedule_timezone ) {
+		try {
+			new DateTimeZone( $requested_schedule_timezone );
+			$selected_schedule_timezone_string = $requested_schedule_timezone;
+		} catch ( Exception $exception ) {
+			$selected_schedule_timezone_string = $event_timezone_string;
+		}
+	}
+}
+
+$selected_schedule_timezone = $get_timezone_object( $selected_schedule_timezone_string, $site_timezone );
+$schedule_timezone_options  = array_values(
+	array_unique(
+		array_merge(
+			array(
+				$event_timezone_string,
+				$site_timezone_string,
+				'UTC',
+			),
+			DateTimeZone::listIdentifiers()
+		)
+	)
+);
+
+$current_schedule_view = 'list';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only schedule view toggle.
+if ( isset( $_GET['schedule_view'] ) ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized before validation.
+	$requested_schedule_view = sanitize_title( wp_unslash( $_GET['schedule_view'] ) );
+
+	if ( in_array( $requested_schedule_view, array( 'list', 'calendar' ), true ) ) {
+		$current_schedule_view = $requested_schedule_view;
+	}
+}
+
+$format_timezone_label = static function ( $timezone_string ) use ( $event_timezone_string, $site_timezone_string ) {
+	$label = str_replace( '_', ' ', $timezone_string );
+
+	if ( $timezone_string === $event_timezone_string ) {
+		return sprintf(
+			/* translators: %s: event timezone. */
+			__( 'Event timezone (%s)', 'wpfaevent' ),
+			$label
+		);
+	}
+
+	if ( $timezone_string === $site_timezone_string ) {
+		return sprintf(
+			/* translators: %s: WordPress site timezone. */
+			__( 'Site timezone (%s)', 'wpfaevent' ),
+			$label
+		);
+	}
+
+	return $label;
+};
+
+$format_datetime_value = static function ( $value, $format, $timezone ) {
+	$value = trim( (string) $value );
+
+	if ( '' === $value ) {
+		return '';
+	}
+
+	try {
+		$datetime = new DateTimeImmutable( $value );
+	} catch ( Exception $exception ) {
+		return '';
+	}
+
+	return wp_date( $format, $datetime->getTimestamp(), $timezone );
+};
+
+$split_schedule_time_range = static function ( $time ) {
+	$parts = explode( ' - ', trim( (string) $time ), 2 );
+
+	if ( 2 !== count( $parts ) ) {
+		$parts = explode( '-', trim( (string) $time ), 2 );
+	}
+
+	$end_time = 2 === count( $parts ) ? trim( $parts[1] ) : '';
+
+	return array(
+		trim( $parts[0] ),
+		$end_time,
+	);
+};
+
+$build_schedule_fallback_datetime = static function ( $date, $time, $source_timezone ) use ( $split_schedule_time_range ) {
+	$date = trim( (string) $date );
+	$time = trim( (string) $time );
+
+	if ( '' === $date ) {
+		return null;
+	}
+
+	if ( '' !== $time ) {
+		$time_parts = $split_schedule_time_range( $time );
+		$time       = $time_parts[0];
+	}
+
+	$value = trim( $date . ' ' . $time );
+
+	try {
+		return new DateTimeImmutable( $value, $source_timezone );
+	} catch ( Exception $exception ) {
+		return null;
+	}
+};
+
+$format_schedule_date = static function ( $start_datetime, $fallback_date, $fallback_time ) use ( $format_datetime_value, $build_schedule_fallback_datetime, $selected_schedule_timezone, $event_timezone ) {
+	if ( $start_datetime ) {
+		$formatted_date = $format_datetime_value( $start_datetime, get_option( 'date_format' ), $selected_schedule_timezone );
+
+		if ( $formatted_date ) {
+			return $formatted_date;
+		}
+	}
+
+	$fallback_datetime = $build_schedule_fallback_datetime( $fallback_date, $fallback_time, $event_timezone );
+
+	return $fallback_datetime ? wp_date( get_option( 'date_format' ), $fallback_datetime->getTimestamp(), $selected_schedule_timezone ) : $fallback_date;
+};
+
+$format_schedule_time = static function ( $start_datetime, $end_datetime, $fallback_date, $fallback_time ) use ( $format_datetime_value, $build_schedule_fallback_datetime, $selected_schedule_timezone, $event_timezone, $split_schedule_time_range ) {
+	$start_label = $start_datetime ? $format_datetime_value( $start_datetime, get_option( 'time_format' ), $selected_schedule_timezone ) : '';
+	$end_label   = $end_datetime ? $format_datetime_value( $end_datetime, get_option( 'time_format' ), $selected_schedule_timezone ) : '';
+
+	if ( ! $start_label && $fallback_time ) {
+		$time_parts        = $split_schedule_time_range( $fallback_time );
+		$fallback_start    = $build_schedule_fallback_datetime( $fallback_date, $time_parts[0], $event_timezone );
+		$fallback_end_time = $time_parts[1];
+		$fallback_end      = $fallback_end_time ? $build_schedule_fallback_datetime( $fallback_date, $fallback_end_time, $event_timezone ) : null;
+		$start_label       = $fallback_start ? wp_date( get_option( 'time_format' ), $fallback_start->getTimestamp(), $selected_schedule_timezone ) : '';
+		$end_label         = $fallback_end ? wp_date( get_option( 'time_format' ), $fallback_end->getTimestamp(), $selected_schedule_timezone ) : '';
+	}
+
+	if ( $start_label && $end_label && $start_label !== $end_label ) {
+		return $start_label . ' - ' . $end_label;
+	}
+
+	return $start_label ? $start_label : $fallback_time;
+};
+
+$parse_schedule_datetime = static function ( $datetime ) {
+	$datetime = trim( (string) $datetime );
+
+	if ( '' === $datetime ) {
+		return null;
+	}
+
+	try {
+		return new DateTimeImmutable( $datetime );
+	} catch ( Exception $exception ) {
+		return null;
+	}
+};
+
+$site_settings      = $read_dashboard_json( 'site-settings-' . absint( $event_id ) . '.json', array() );
+$dashboard_speakers = $read_dashboard_json( 'speakers-' . absint( $event_id ) . '.json', array() );
+$schedule_table     = $read_dashboard_json( 'schedule-' . absint( $event_id ) . '.json', array() );
+$sponsor_groups     = $read_dashboard_json( 'sponsors-' . absint( $event_id ) . '.json', array() );
+$exhibitors         = $read_dashboard_json( 'exhibitors-' . absint( $event_id ) . '.json', array() );
+$section_visibility = isset( $site_settings['section_visibility'] ) && is_array( $site_settings['section_visibility'] ) ? $site_settings['section_visibility'] : array();
+
+$event_title          = get_the_title( $event_id );
+$start_date           = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
+$end_date             = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
+$location             = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+$venue_information    = trim( (string) get_post_meta( $event_id, 'wpfa_event_venue_information', true ) );
+$custom_tabs          = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_custom_tabs( get_post_meta( $event_id, 'wpfa_event_custom_tabs', true ) ) : array();
+$event_languages      = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_language_list( get_post_meta( $event_id, 'wpfa_event_languages', true ) ) : array();
+$event_language_label = implode( ', ', $event_languages );
+$event_url            = get_post_meta( $event_id, 'wpfa_event_url', true );
+$event_url            = $event_url ? esc_url_raw( $event_url ) : '';
+$about_content        = isset( $site_settings['about_section_content'] ) ? trim( (string) $site_settings['about_section_content'] ) : '';
+$post_content         = trim( (string) get_post_field( 'post_content', $event_id ) );
+$event_lead           = trim( (string) get_post_meta( $event_id, '_event_lead_text', true ) );
+
+$main_speaker_limit             = absint( apply_filters( 'wpfa_event_main_speaker_limit', 20, $event_id ) );
+$main_speaker_limit             = $main_speaker_limit ? $main_speaker_limit : 20;
+$speaker_ids                    = $get_linked_speaker_ids( $event_id );
+$featured_speaker_ids           = class_exists( 'Wpfaevent_Meta_Event' )
+	? Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers )
+	: array();
+$regular_speaker_ids            = array_values( array_diff( $speaker_ids, $featured_speaker_ids ) );
+$main_speaker_ids               = array_slice( $speaker_ids, 0, $main_speaker_limit );
+$main_regular_speaker_ids       = array_slice( $regular_speaker_ids, 0, $main_speaker_limit );
+$main_speaker_overflow_count    = max( 0, count( $speaker_ids ) - count( $main_speaker_ids ) );
+$regular_speaker_overflow_count = max( 0, count( $regular_speaker_ids ) - count( $main_regular_speaker_ids ) );
+
+$event_slug              = get_post_field( 'post_name', $event_id );
+$speaker_placeholder_url = WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
+$speakers_url            = add_query_arg( 'event', $event_slug, home_url( '/speakers/' ) );
+$schedule_page_url       = class_exists( 'Wpfaevent_Schedule_Helper' ) ? Wpfaevent_Schedule_Helper::get_schedule_page_url() : home_url( '/full-schedule/' );
+$event_schedule_args     = array(
+	'event' => $event_slug,
+);
+
+if ( 'calendar' === $current_schedule_view ) {
+	$event_schedule_args['view'] = 'calendar';
+}
+
+if ( $selected_schedule_timezone_string && $selected_schedule_timezone_string !== $event_timezone_string ) {
+	$event_schedule_args['schedule_tz'] = $selected_schedule_timezone_string;
+}
+
+$event_schedule_url   = add_query_arg( $event_schedule_args, $schedule_page_url );
+$additional_page_url  = class_exists( 'Wpfaevent_Additional_Information_Helper' ) ? Wpfaevent_Additional_Information_Helper::get_additional_information_page_url() : home_url( '/additional-information/' );
+$event_additional_url = add_query_arg( 'event', $event_slug, $additional_page_url );
+
+$build_event_schedule_view_url = static function ( $view ) use ( $event_id, $event_timezone_string, $selected_schedule_timezone_string ) {
+	$args = array();
+
+	if ( $selected_schedule_timezone_string && $selected_schedule_timezone_string !== $event_timezone_string ) {
+		$args['schedule_tz'] = $selected_schedule_timezone_string;
+	}
+
+	if ( 'calendar' === $view ) {
+		$args['schedule_view'] = 'calendar';
+	}
+
+	return add_query_arg( $args, get_permalink( $event_id ) ) . '#wpfa-event-schedule-title';
+};
+
+$register_text = ! empty( $site_settings['reg_button_text'] ) ? sanitize_text_field( $site_settings['reg_button_text'] ) : __( 'Get Tickets', 'wpfaevent' );
+$register_url  = ! empty( $site_settings['reg_button_link'] ) ? esc_url_raw( $site_settings['reg_button_link'] ) : $event_url;
+
+$event_calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
+$event_calendar_data = is_wp_error( $event_calendar_data ) ? array() : $event_calendar_data;
+$event_calendar_url  = ! empty( $event_calendar_data ) && class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_ics_url( $event_id ) : '';
+$event_google_url    = ! empty( $event_calendar_data ) && class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::build_google_calendar_url( $event_calendar_data ) : '';
+
+$show_about             = ! array_key_exists( 'about', $section_visibility ) || ! empty( $section_visibility['about'] );
+$show_speakers          = ! array_key_exists( 'speakers', $section_visibility ) || ! empty( $section_visibility['speakers'] );
+$show_schedule          = ! array_key_exists( 'schedule', $section_visibility ) || ! empty( $section_visibility['schedule'] );
+$show_sponsors          = ! array_key_exists( 'sponsors', $section_visibility ) || ! empty( $section_visibility['sponsors'] );
+$show_exhibitors        = ! array_key_exists( 'exhibitors', $section_visibility ) || ! empty( $section_visibility['exhibitors'] );
+$schedule_rows          = isset( $schedule_table['data'] ) && is_array( $schedule_table['data'] ) ? $schedule_table['data'] : array();
+$schedule_meta          = isset( $schedule_table['sessions'] ) && is_array( $schedule_table['sessions'] ) ? $schedule_table['sessions'] : array();
+$schedule_head          = ! empty( $schedule_rows[0] ) && is_array( $schedule_rows[0] ) ? $schedule_rows[0] : array();
+$schedule_body          = ! empty( $schedule_head ) ? array_slice( $schedule_rows, 1 ) : $schedule_rows;
+$speaker_count          = count( $speaker_ids );
+$featured_speaker_count = count( $featured_speaker_ids );
+$visible_sponsor_groups = array();
+$sponsor_count          = 0;
+$visible_exhibitors     = array();
+$event_colors           = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_colors( $event_id ) : array();
+$event_color_var_map    = array(
+	'wpfa_event_primary_color'          => '--event-primary',
+	'wpfa_event_hover_button_color'     => '--event-primary-dark',
+	'wpfa_event_theme_background_color' => '--event-soft',
+	'wpfa_event_theme_success_color'    => '--event-success',
+	'wpfa_event_theme_danger_color'     => '--event-danger',
+);
+$event_style_vars       = array();
+
+foreach ( $event_color_var_map as $meta_key => $css_var ) {
+	if ( ! empty( $event_colors[ $meta_key ] ) ) {
+		$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+	}
+}
+
+$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+
+foreach ( $sponsor_groups as $sponsor_group ) {
+	if ( ! is_array( $sponsor_group ) ) {
+		continue;
+	}
+
+	$group_sponsors         = isset( $sponsor_group['sponsors'] ) && is_array( $sponsor_group['sponsors'] ) ? $sponsor_group['sponsors'] : array();
+	$visible_group_sponsors = array();
+
+	foreach ( $group_sponsors as $sponsor ) {
+		if ( ! is_array( $sponsor ) || ( empty( $sponsor['name'] ) && empty( $sponsor['image'] ) ) ) {
+			continue;
+		}
+
+		$visible_group_sponsors[] = $sponsor;
+	}
+
+	if ( empty( $visible_group_sponsors ) ) {
+		continue;
+	}
+
+	$sponsor_group['sponsors'] = $visible_group_sponsors;
+	$visible_sponsor_groups[]  = $sponsor_group;
+	$sponsor_count            += count( $visible_group_sponsors );
+}
+
+foreach ( $exhibitors as $exhibitor ) {
+	if ( ! is_array( $exhibitor ) || empty( $exhibitor['name'] ) ) {
+		continue;
+	}
+
+	$visible_exhibitors[] = $exhibitor;
+}
+
+$dashboard_featured_speakers = array();
+$dashboard_regular_speakers  = array();
+
+foreach ( $dashboard_speakers as $dashboard_speaker ) {
+	if ( ! is_array( $dashboard_speaker ) || empty( $dashboard_speaker['name'] ) ) {
+		continue;
+	}
+
+	if ( ! empty( $dashboard_speaker['featured'] ) ) {
+		$dashboard_featured_speakers[] = $dashboard_speaker;
+		continue;
+	}
+
+	$dashboard_regular_speakers[] = $dashboard_speaker;
+}
+
+$main_dashboard_speakers                  = array_slice( $dashboard_speakers, 0, $main_speaker_limit );
+$main_dashboard_regular_speakers          = array_slice( $dashboard_regular_speakers, 0, $main_speaker_limit );
+$dashboard_speaker_overflow_count         = max( 0, count( $dashboard_speakers ) - count( $main_dashboard_speakers ) );
+$dashboard_regular_speaker_overflow_count = max( 0, count( $dashboard_regular_speakers ) - count( $main_dashboard_regular_speakers ) );
+
+if ( ! empty( $dashboard_featured_speakers ) ) {
+	usort(
+		$dashboard_featured_speakers,
+		static function ( $speaker_a, $speaker_b ) {
+			$order_a = isset( $speaker_a['featured_order'] ) ? absint( $speaker_a['featured_order'] ) : 0;
+			$order_b = isset( $speaker_b['featured_order'] ) ? absint( $speaker_b['featured_order'] ) : 0;
+
+			if ( $order_a && $order_b && $order_a !== $order_b ) {
+				return $order_a <=> $order_b;
+			}
+
+			if ( $order_a !== $order_b ) {
+				return $order_a ? -1 : 1;
+			}
+
+			return strcasecmp( $speaker_a['name'] ?? '', $speaker_b['name'] ?? '' );
+		}
 	);
 }
+
+if ( '' === $about_content ) {
+	$about_content = '' !== $post_content ? $post_content : $event_lead;
+}
+
+$date_label           = ! empty( $event_calendar_data['date_label'] ) ? sanitize_text_field( $event_calendar_data['date_label'] ) : $format_event_date( $start_date );
+$event_time_label     = ! empty( $event_calendar_data['time_label'] ) ? sanitize_text_field( $event_calendar_data['time_label'] ) : '';
+$event_timezone_label = ! empty( $event_calendar_data['timezone_label'] ) ? sanitize_text_field( $event_calendar_data['timezone_label'] ) : str_replace( '_', ' ', $event_timezone_string );
+$event_start_content  = ! empty( $event_calendar_data['start_content'] ) ? sanitize_text_field( $event_calendar_data['start_content'] ) : $start_date;
+$event_end_content    = ! empty( $event_calendar_data['end_content'] ) ? sanitize_text_field( $event_calendar_data['end_content'] ) : $end_date;
+
+if ( empty( $event_calendar_data['date_label'] ) && $end_date && $end_date !== $start_date ) {
+	$date_label .= $date_label ? ' - ' . $format_event_date( $end_date ) : $format_event_date( $end_date );
+}
+
+$build_schedule_calendar_url = static function ( $item ) use ( $build_schedule_fallback_datetime, $event_timezone, $event_timezone_string, $event_title, $event_url, $location, $parse_schedule_datetime, $split_schedule_time_range ) {
+	if ( ! class_exists( 'Wpfaevent_Calendar' ) ) {
+		return '';
+	}
+
+	$title      = ! empty( $item['title'] ) ? $item['title'] : $event_title;
+	$time_parts = $split_schedule_time_range( isset( $item['time'] ) ? $item['time'] : '' );
+	$start      = $parse_schedule_datetime( isset( $item['start_datetime'] ) ? $item['start_datetime'] : '' );
+	$end        = $parse_schedule_datetime( isset( $item['end_datetime'] ) ? $item['end_datetime'] : '' );
+	$all_day    = false;
+	$start_date = '';
+	$end_date   = '';
+
+	if ( ! $start ) {
+		$start = $build_schedule_fallback_datetime(
+			isset( $item['date'] ) ? $item['date'] : '',
+			$time_parts[0],
+			$event_timezone
+		);
+	}
+
+	if ( $start && ! $end && ! empty( $time_parts[1] ) ) {
+		$end = $build_schedule_fallback_datetime( isset( $item['date'] ) ? $item['date'] : '', $time_parts[1], $event_timezone );
+	}
+
+	if ( $start && $end && $end <= $start ) {
+		$end = $end->modify( '+1 day' );
+	}
+
+	if ( ! $start && empty( $time_parts[0] ) ) {
+		$start_date = class_exists( 'Wpfaevent_Meta_Event' )
+			? Wpfaevent_Meta_Event::sanitize_date_value( isset( $item['date'] ) ? $item['date'] : '' )
+			: '';
+		$end_date   = $start_date;
+		$all_day    = '' !== $start_date;
+	}
+
+	if ( ! $start && ! $all_day ) {
+		return '';
+	}
+
+	$details = array_filter(
+		array(
+			$event_title ? sprintf(
+				/* translators: %s: event title. */
+				__( 'Event: %s', 'wpfaevent' ),
+				$event_title
+			) : '',
+			! empty( $item['speakers'] ) ? sprintf(
+				/* translators: %s: speaker names. */
+				__( 'Speakers: %s', 'wpfaevent' ),
+				$item['speakers']
+			) : '',
+			! empty( $item['track'] ) ? sprintf(
+				/* translators: %s: session track. */
+				__( 'Track: %s', 'wpfaevent' ),
+				$item['track']
+			) : '',
+			! empty( $item['room'] ) ? sprintf(
+				/* translators: %s: session room. */
+				__( 'Room: %s', 'wpfaevent' ),
+				$item['room']
+			) : '',
+		)
+	);
+
+	$session_location = ! empty( $item['room'] ) ? $item['room'] : $location;
+
+	return Wpfaevent_Calendar::build_google_calendar_url(
+		array(
+			'title'           => $title,
+			'description'     => implode( "\n", $details ),
+			'location'        => $session_location,
+			'url'             => $event_url,
+			'timezone_string' => $event_timezone_string,
+			'all_day'         => $all_day,
+			'start_date'      => $start_date,
+			'end_date'        => $end_date,
+			'start_datetime'  => $all_day ? null : $start,
+			'end_datetime'    => $all_day ? null : $end,
+		)
+	);
+};
+
+$schedule_items = array();
+foreach ( $schedule_body as $row_index => $row ) {
+	if ( ! is_array( $row ) ) {
+		continue;
+	}
+
+	$row_meta       = isset( $schedule_meta[ $row_index ] ) && is_array( $schedule_meta[ $row_index ] ) ? $schedule_meta[ $row_index ] : array();
+	$start_datetime = isset( $row_meta['starts_at'] ) ? sanitize_text_field( $row_meta['starts_at'] ) : '';
+	$end_datetime   = isset( $row_meta['ends_at'] ) ? sanitize_text_field( $row_meta['ends_at'] ) : '';
+	$row_date       = isset( $row[0] ) ? sanitize_text_field( $row[0] ) : '';
+	$row_time       = isset( $row[1] ) ? sanitize_text_field( $row[1] ) : '';
+
+	$schedule_item = array(
+		'date'           => $row_date,
+		'date_label'     => $format_schedule_date( $start_datetime, $row_date, $row_time ),
+		'time'           => $row_time,
+		'time_label'     => $format_schedule_time( $start_datetime, $end_datetime, $row_date, $row_time ),
+		'title'          => ! empty( $row[2] ) ? sanitize_text_field( $row[2] ) : $event_title,
+		'speakers'       => isset( $row[3] ) ? sanitize_text_field( $row[3] ) : '',
+		'track'          => isset( $row[4] ) ? sanitize_text_field( $row[4] ) : '',
+		'room'           => isset( $row[5] ) ? sanitize_text_field( $row[5] ) : '',
+		'start_datetime' => $start_datetime,
+		'end_datetime'   => $end_datetime,
+	);
+
+	$schedule_item['calendar_url'] = $build_schedule_calendar_url( $schedule_item );
+
+	$time_parts                  = preg_split( '/\s*-\s*/', $schedule_item['time_label'], 2 );
+	$schedule_item['time_start'] = isset( $time_parts[0] ) ? trim( $time_parts[0] ) : $schedule_item['time_label'];
+	$schedule_item['time_end']   = isset( $time_parts[1] ) ? trim( $time_parts[1] ) : '';
+
+	$schedule_items[] = $schedule_item;
+}
+
+$schedule_preview_limit      = absint( apply_filters( 'wpfa_event_schedule_preview_limit', 3, $event_id ) );
+$schedule_preview_items      = $schedule_preview_limit ? array_slice( $schedule_items, 0, $schedule_preview_limit ) : $schedule_items;
+$schedule_preview_day_groups = array();
+
+foreach ( $schedule_preview_items as $schedule_item ) {
+	$day_key = ! empty( $schedule_item['date_label'] ) ? $schedule_item['date_label'] : __( 'TBD', 'wpfaevent' );
+
+	if ( ! isset( $schedule_preview_day_groups[ $day_key ] ) ) {
+		$schedule_preview_day_groups[ $day_key ] = array();
+	}
+
+	$schedule_preview_day_groups[ $day_key ][] = $schedule_item;
+}
+
+$schedule_hidden_count = max( 0, count( $schedule_items ) - count( $schedule_preview_items ) );
+$first_schedule        = ! empty( $schedule_items[0] ) ? $schedule_items[0] : array();
+$custom_sections       = array();
+
+foreach ( $custom_tabs as $custom_tab ) {
+	if ( empty( $custom_tab['slug'] ) || empty( $custom_tab['title'] ) || empty( $custom_tab['content'] ) ) {
+		continue;
+	}
+
+	$custom_sections[ $custom_tab['slug'] ] = $custom_tab['title'];
+}
+
+$wpfa_event_nav_context = array(
+	'show_about'      => $show_about,
+	'show_speakers'   => $show_speakers,
+	'show_schedule'   => $show_schedule,
+	'show_sponsors'   => $show_sponsors,
+	'show_exhibitors' => $show_exhibitors,
+	'has_about'       => $show_about && '' !== trim( $about_content ),
+	'has_speakers'    => $show_speakers && ( ! empty( $speaker_ids ) || ! empty( $dashboard_speakers ) ),
+	'has_schedule'    => $show_schedule && ! empty( $schedule_items ),
+	'has_sponsors'    => $show_sponsors && ! empty( $visible_sponsor_groups ),
+	'has_exhibitors'  => $show_exhibitors && ! empty( $visible_exhibitors ),
+	'has_venue'       => '' !== trim( wp_strip_all_tags( $venue_information ) ),
+	'custom_sections' => $custom_sections,
+);
+$wpfa_event_nav_items   = class_exists( 'Wpfaevent_Event_Navigation_Helper' )
+	? Wpfaevent_Event_Navigation_Helper::build_nav_items( $wpfa_event_nav_context )
+	: array();
+
+$site_logo_url = get_option( 'wpfa_site_logo_url', '' );
+if ( empty( $site_logo_url ) ) {
+	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
+}
+$site_logo_url = apply_filters( 'wpfa_site_logo_url', $site_logo_url );
 
 $header_vars = array(
 	'site_logo_url'        => $site_logo_url,
 	'event_page_url'       => home_url( '/events/' ),
 	'show_back_button'     => true,
-	'show_register_button' => ! empty( $registration_url ),
-	'back_button_text'     => __( 'Back to Events', 'wpfaevent' ),
-	'register_button_url'  => $registration_url,
-	'register_button_text' => __( 'Register', 'wpfaevent' ),
+	'show_register_button' => ! empty( $register_url ),
+	'back_button_text'     => __( 'All Events', 'wpfaevent' ),
+	'register_button_url'  => $register_url,
+	'register_button_text' => $register_text,
 );
 ?>
 <!DOCTYPE html>
@@ -80,8 +667,8 @@ $header_vars = array(
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<?php wp_head(); ?>
 </head>
-<body <?php body_class( 'wpfaevent wpfa-single-event-template' ); ?>>
-	<?php wp_body_open(); ?>
+<body <?php body_class( 'wpfaevent wpfa-event-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
+<?php wp_body_open(); ?>
 
 <div id="page" class="site">
 	<?php
@@ -99,91 +686,653 @@ $header_vars = array(
 	}
 	?>
 
-	<main class="wpfa-single-event">
-		<header class="page-hero wpfa-single-event-hero">
-			<div class="hero-bg" aria-hidden="true"></div>
-			<div class="container">
-				<h1><?php echo esc_html( get_the_title( $event_id ) ); ?></h1>
-
-				<?php if ( ! empty( $lead_text ) ) : ?>
-					<p><?php echo esc_html( $lead_text ); ?></p>
-				<?php elseif ( has_excerpt( $event_id ) ) : ?>
-					<p><?php echo esc_html( get_the_excerpt( $event_id ) ); ?></p>
-				<?php endif; ?>
-
-				<?php if ( ! empty( $registration_url ) || ! empty( $event_url ) || ! empty( $cfs_url ) ) : ?>
-					<div class="wpfa-single-event-actions">
-						<?php if ( ! empty( $registration_url ) ) : ?>
-							<a class="btn btn-primary" href="<?php echo esc_url( $registration_url ); ?>" target="_blank" rel="noopener">
-								<?php esc_html_e( 'Register', 'wpfaevent' ); ?>
-							</a>
+	<main class="wpfa-event-detail" itemscope itemtype="https://schema.org/Event">
+		<section class="wpfa-event-hero">
+			<div class="container wpfa-event-hero-inner">
+				<div class="wpfa-event-hero-copy">
+					<p class="wpfa-event-kicker"><?php esc_html_e( 'Eventyay Event', 'wpfaevent' ); ?></p>
+					<h1 itemprop="name"><?php echo esc_html( $event_title ); ?></h1>
+						<div class="wpfa-event-meta-list">
+							<?php if ( $date_label ) : ?>
+								<span itemprop="startDate" content="<?php echo esc_attr( $event_start_content ); ?>"><?php echo esc_html( $date_label ); ?></span>
+								<?php if ( $event_end_content ) : ?>
+									<meta itemprop="endDate" content="<?php echo esc_attr( $event_end_content ); ?>">
+								<?php endif; ?>
+							<?php endif; ?>
+							<?php if ( $event_time_label ) : ?>
+								<span><?php echo esc_html( $event_time_label ); ?></span>
+							<?php endif; ?>
+							<?php if ( $location ) : ?>
+								<span itemprop="location"><?php echo esc_html( $location ); ?></span>
 						<?php endif; ?>
-
-						<?php if ( ! empty( $event_url ) ) : ?>
-							<a class="btn btn-secondary" href="<?php echo esc_url( $event_url ); ?>" target="_blank" rel="noopener">
-								<?php esc_html_e( 'Event Website', 'wpfaevent' ); ?>
-							</a>
+						<?php if ( $event_language_label ) : ?>
+							<span><?php echo esc_html( $event_language_label ); ?></span>
 						<?php endif; ?>
-
-						<?php if ( ! empty( $cfs_url ) ) : ?>
-							<a class="btn btn-secondary" href="<?php echo esc_url( $cfs_url ); ?>" target="_blank" rel="noopener">
-								<?php esc_html_e( 'Call for Speakers', 'wpfaevent' ); ?>
-							</a>
+						<?php if ( ! empty( $schedule_items ) ) : ?>
+							<span>
+								<?php
+								printf(
+									/* translators: %d: number of schedule sessions. */
+									esc_html( _n( '%d session', '%d sessions', count( $schedule_items ), 'wpfaevent' ) ),
+									absint( count( $schedule_items ) )
+								);
+								?>
+							</span>
 						<?php endif; ?>
 					</div>
-				<?php endif; ?>
-			</div>
-		</header>
-
-		<div class="container">
-			<div class="wpfa-single-event-layout">
-				<article class="wpfa-single-event-content">
-					<?php if ( ! empty( $image_url ) ) : ?>
-						<figure class="wpfa-single-event-image">
-							<img src="<?php echo esc_url( $image_url ); ?>" alt="<?php echo esc_attr( get_the_title( $event_id ) ); ?>">
-						</figure>
+					<?php if ( '' !== trim( $about_content ) ) : ?>
+						<div class="wpfa-event-hero-text">
+							<?php echo wp_kses_post( wpautop( wp_trim_words( wp_strip_all_tags( $about_content ), 34 ) ) ); ?>
+						</div>
 					<?php endif; ?>
+				</div>
 
-					<div class="wpfa-single-event-body">
-						<?php
-						echo wp_kses_post(
-							apply_filters( 'the_content', get_post_field( 'post_content', $event_id ) )
-						);
-						?>
+				<aside class="wpfa-event-ticket-panel" aria-label="<?php esc_attr_e( 'Event details', 'wpfaevent' ); ?>">
+					<div class="wpfa-event-ticket-head">
+						<p><?php esc_html_e( 'Registration', 'wpfaevent' ); ?></p>
+						<strong><?php esc_html_e( 'Open', 'wpfaevent' ); ?></strong>
 					</div>
-				</article>
-
-				<aside class="wpfa-single-event-details" aria-label="<?php esc_attr_e( 'Event details', 'wpfaevent' ); ?>">
-					<h2><?php esc_html_e( 'Event Details', 'wpfaevent' ); ?></h2>
-
-					<?php if ( ! empty( $date_label ) ) : ?>
-						<div class="wpfa-single-event-detail">
-							<strong><?php esc_html_e( 'Date', 'wpfaevent' ); ?></strong>
-							<span><?php echo esc_html( $date_label ); ?></span>
-						</div>
+					<?php if ( $register_url ) : ?>
+						<a class="wpfa-event-register" href="<?php echo esc_url( $register_url ); ?>" target="_blank" rel="noopener">
+							<?php echo esc_html( $register_text ); ?>
+						</a>
 					<?php endif; ?>
-
-					<?php if ( ! empty( $event_time ) ) : ?>
-						<div class="wpfa-single-event-detail">
-							<strong><?php esc_html_e( 'Time', 'wpfaevent' ); ?></strong>
-							<span><?php echo esc_html( $event_time ); ?></span>
-						</div>
+					<?php if ( $event_google_url ) : ?>
+						<a class="wpfa-event-calendar-link" href="<?php echo esc_url( $event_google_url ); ?>" target="_blank" rel="noopener">
+							<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+						</a>
 					<?php endif; ?>
-
-					<?php if ( ! empty( $event_location ) ) : ?>
-						<div class="wpfa-single-event-detail">
-							<strong><?php esc_html_e( 'Location', 'wpfaevent' ); ?></strong>
-							<span><?php echo esc_html( $event_location ); ?></span>
-						</div>
+					<?php if ( $event_calendar_url ) : ?>
+						<a class="wpfa-event-calendar-download" href="<?php echo esc_url( $event_calendar_url ); ?>">
+							<?php esc_html_e( 'Download .ics', 'wpfaevent' ); ?>
+						</a>
 					<?php endif; ?>
+					<dl class="wpfa-event-facts">
+							<?php if ( $date_label ) : ?>
+								<div>
+									<dt><?php esc_html_e( 'When', 'wpfaevent' ); ?></dt>
+									<dd><?php echo esc_html( $date_label ); ?></dd>
+								</div>
+							<?php endif; ?>
+							<?php if ( $event_time_label ) : ?>
+								<div>
+									<dt><?php esc_html_e( 'Time', 'wpfaevent' ); ?></dt>
+									<dd><?php echo esc_html( $event_time_label ); ?></dd>
+								</div>
+							<?php endif; ?>
+							<?php if ( $event_timezone_label ) : ?>
+								<div>
+									<dt><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></dt>
+									<dd><?php echo esc_html( $event_timezone_label ); ?></dd>
+								</div>
+							<?php endif; ?>
+							<?php if ( $location ) : ?>
+								<div>
+								<dt><?php esc_html_e( 'Where', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( $location ); ?></dd>
+							</div>
+						<?php endif; ?>
+						<?php if ( $event_language_label ) : ?>
+							<div>
+								<dt><?php esc_html_e( 'Languages', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( $event_language_label ); ?></dd>
+							</div>
+						<?php endif; ?>
+						<div>
+							<dt><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></dt>
+							<dd><?php echo esc_html( number_format_i18n( $speaker_count ) ); ?></dd>
+						</div>
+						<?php if ( $sponsor_count ) : ?>
+							<div>
+								<dt><?php esc_html_e( 'Sponsors', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( number_format_i18n( $sponsor_count ) ); ?></dd>
+							</div>
+						<?php endif; ?>
+						<?php if ( ! empty( $visible_exhibitors ) ) : ?>
+							<div>
+								<dt><?php esc_html_e( 'Exhibitors', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( number_format_i18n( count( $visible_exhibitors ) ) ); ?></dd>
+							</div>
+						<?php endif; ?>
+						<?php if ( ! empty( $first_schedule['time_label'] ) ) : ?>
+							<div>
+								<dt><?php esc_html_e( 'Starts', 'wpfaevent' ); ?></dt>
+								<dd><?php echo esc_html( $first_schedule['time_label'] ); ?></dd>
+							</div>
+						<?php endif; ?>
+					</dl>
 				</aside>
 			</div>
-		</div>
+		</section>
+
+		<?php if ( ! empty( $wpfa_event_nav_items ) ) : ?>
+			<?php include WPFAEVENT_PATH . 'public/partials/event-section-nav.php'; ?>
+		<?php endif; ?>
+
+		<?php if ( $show_about && '' !== trim( $about_content ) ) : ?>
+			<section id="about" class="wpfa-event-section wpfa-event-about" aria-labelledby="wpfa-event-about-title">
+				<div class="container">
+					<div class="wpfa-event-section-layout">
+						<header class="wpfa-event-section-label">
+							<p><?php esc_html_e( 'Overview', 'wpfaevent' ); ?></p>
+							<h2 id="wpfa-event-about-title"><?php esc_html_e( 'About this event', 'wpfaevent' ); ?></h2>
+						</header>
+						<div class="wpfa-event-rich-text" itemprop="description">
+							<?php echo wp_kses_post( wpautop( $about_content ) ); ?>
+						</div>
+					</div>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( $show_speakers ) : ?>
+			<section id="speakers" class="wpfa-event-section wpfa-event-speakers" aria-labelledby="wpfa-event-speakers-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-speakers-title"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'People linked to this event only.', 'wpfaevent' ); ?></p>
+						</div>
+						<a href="<?php echo esc_url( $speakers_url ); ?>"><?php esc_html_e( 'Open Event Speaker List', 'wpfaevent' ); ?></a>
+					</div>
+
+					<?php if ( ! empty( $speaker_ids ) ) : ?>
+						<?php if ( $featured_speaker_count ) : ?>
+							<div class="wpfa-event-featured-speakers">
+								<h3><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h3>
+								<div class="wpfa-speakers-grid wpfa-featured-speakers-grid">
+									<?php
+									$wpfa_hide_speaker_card_admin_actions = true;
+									$wpfa_schedule_display_timezone       = $selected_schedule_timezone;
+									$wpfa_featured_speaker_ids            = $featured_speaker_ids;
+									foreach ( $featured_speaker_ids as $sid ) :
+										if ( 'wpfa_speaker' !== get_post_type( $sid ) || 'publish' !== get_post_status( $sid ) ) {
+											continue;
+										}
+
+										include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php';
+									endforeach;
+									unset( $wpfa_hide_speaker_card_admin_actions );
+									unset( $wpfa_schedule_display_timezone );
+									unset( $wpfa_featured_speaker_ids );
+									?>
+								</div>
+							</div>
+						<?php endif; ?>
+
+						<?php if ( ! empty( $regular_speaker_ids ) ) : ?>
+							<div class="wpfa-event-regular-speakers">
+								<h3><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h3>
+								<div class="wpfa-speakers-grid">
+									<?php
+									$wpfa_hide_speaker_card_admin_actions = true;
+									$wpfa_schedule_display_timezone       = $selected_schedule_timezone;
+									foreach ( $main_regular_speaker_ids as $sid ) :
+										if ( 'wpfa_speaker' !== get_post_type( $sid ) || 'publish' !== get_post_status( $sid ) ) {
+											continue;
+										}
+
+										include WPFAEVENT_PATH . 'public/partials/speakers/speaker-card.php';
+									endforeach;
+									unset( $wpfa_hide_speaker_card_admin_actions );
+									unset( $wpfa_schedule_display_timezone );
+									?>
+								</div>
+								<?php if ( $regular_speaker_overflow_count ) : ?>
+									<p class="wpfa-event-speaker-limit-note">
+										<?php
+										printf(
+											/* translators: 1: shown speaker count, 2: total speaker count. */
+											esc_html__( 'Showing the main %1$d of %2$d speakers. Open the full event speaker list to view everyone.', 'wpfaevent' ),
+											absint( count( $main_regular_speaker_ids ) ),
+											absint( count( $regular_speaker_ids ) )
+										);
+										?>
+									</p>
+								<?php endif; ?>
+							</div>
+						<?php endif; ?>
+					<?php elseif ( ! empty( $dashboard_speakers ) ) : ?>
+						<?php if ( ! empty( $dashboard_featured_speakers ) ) : ?>
+							<div class="wpfa-event-featured-speakers">
+								<h3><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h3>
+								<div class="wpfa-speakers-grid wpfa-featured-speakers-grid">
+									<?php foreach ( $dashboard_featured_speakers as $speaker ) : ?>
+										<?php
+										$wpfa_dashboard_speaker_is_featured = true;
+										include WPFAEVENT_PATH . 'public/partials/speakers/dashboard-speaker-card.php';
+										unset( $wpfa_dashboard_speaker_is_featured );
+										?>
+									<?php endforeach; ?>
+								</div>
+							</div>
+
+							<?php if ( ! empty( $dashboard_regular_speakers ) ) : ?>
+								<div class="wpfa-event-regular-speakers">
+									<h3><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h3>
+									<div class="wpfa-speakers-grid">
+										<?php foreach ( $main_dashboard_regular_speakers as $speaker ) : ?>
+											<?php include WPFAEVENT_PATH . 'public/partials/speakers/dashboard-speaker-card.php'; ?>
+										<?php endforeach; ?>
+									</div>
+									<?php if ( $dashboard_regular_speaker_overflow_count ) : ?>
+										<p class="wpfa-event-speaker-limit-note">
+											<?php
+											printf(
+												/* translators: 1: shown speaker count, 2: total speaker count. */
+												esc_html__( 'Showing the main %1$d of %2$d speakers. Open the full event speaker list to view everyone.', 'wpfaevent' ),
+												absint( count( $main_dashboard_regular_speakers ) ),
+												absint( count( $dashboard_regular_speakers ) )
+											);
+											?>
+										</p>
+									<?php endif; ?>
+								</div>
+							<?php endif; ?>
+						<?php else : ?>
+							<div class="wpfa-speakers-grid">
+								<?php foreach ( $main_dashboard_speakers as $speaker ) : ?>
+									<?php include WPFAEVENT_PATH . 'public/partials/speakers/dashboard-speaker-card.php'; ?>
+								<?php endforeach; ?>
+							</div>
+							<?php if ( $dashboard_speaker_overflow_count ) : ?>
+								<p class="wpfa-event-speaker-limit-note">
+									<?php
+									printf(
+										/* translators: 1: shown speaker count, 2: total speaker count. */
+										esc_html__( 'Showing the main %1$d of %2$d speakers. Open the full event speaker list to view everyone.', 'wpfaevent' ),
+										absint( count( $main_dashboard_speakers ) ),
+										absint( count( $dashboard_speakers ) )
+									);
+									?>
+								</p>
+							<?php endif; ?>
+						<?php endif; ?>
+					<?php else : ?>
+						<p class="wpfa-empty-state"><?php esc_html_e( 'No speakers have been imported for this event yet.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( $show_schedule ) : ?>
+			<section id="schedule-overview" class="wpfa-event-section wpfa-event-schedule" aria-labelledby="wpfa-event-schedule-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-schedule-title"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Times and rooms imported from Eventyay.', 'wpfaevent' ); ?></p>
+						</div>
+						<?php if ( ! empty( $schedule_items ) ) : ?>
+							<div class="wpfa-event-section-actions">
+								<nav class="wpfa-schedule-view-switch" aria-label="<?php esc_attr_e( 'Schedule view', 'wpfaevent' ); ?>">
+									<a
+										class="<?php echo esc_attr( 'list' === $current_schedule_view ? 'is-active' : '' ); ?>"
+										href="<?php echo esc_url( $build_event_schedule_view_url( 'list' ) ); ?>"
+										<?php if ( 'list' === $current_schedule_view ) : ?>
+											aria-current="page"
+										<?php endif; ?>
+									>
+										<?php esc_html_e( 'List', 'wpfaevent' ); ?>
+									</a>
+									<a
+										class="<?php echo esc_attr( 'calendar' === $current_schedule_view ? 'is-active' : '' ); ?>"
+										href="<?php echo esc_url( $build_event_schedule_view_url( 'calendar' ) ); ?>"
+										<?php if ( 'calendar' === $current_schedule_view ) : ?>
+											aria-current="page"
+										<?php endif; ?>
+									>
+										<?php esc_html_e( 'Calendar', 'wpfaevent' ); ?>
+									</a>
+								</nav>
+								<a href="<?php echo esc_url( $event_schedule_url ); ?>"><?php esc_html_e( 'Full Schedule', 'wpfaevent' ); ?></a>
+								<form class="wpfa-event-timezone-form" action="<?php echo esc_url( get_permalink( $event_id ) . '#wpfa-event-schedule-title' ); ?>" method="get">
+									<?php if ( 'calendar' === $current_schedule_view ) : ?>
+										<input type="hidden" name="schedule_view" value="calendar">
+									<?php endif; ?>
+									<label for="wpfa-event-schedule-timezone">
+										<span><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></span>
+										<select id="wpfa-event-schedule-timezone" class="wpfa-event-timezone-select" name="schedule_tz">
+											<?php foreach ( $schedule_timezone_options as $timezone_option ) : ?>
+												<option value="<?php echo esc_attr( $timezone_option ); ?>" <?php selected( $selected_schedule_timezone_string, $timezone_option ); ?>>
+													<?php echo esc_html( $format_timezone_label( $timezone_option ) ); ?>
+												</option>
+											<?php endforeach; ?>
+										</select>
+									</label>
+									<button type="submit"><?php esc_html_e( 'Convert', 'wpfaevent' ); ?></button>
+								</form>
+							</div>
+						<?php endif; ?>
+					</div>
+					<?php if ( ! empty( $schedule_preview_items ) ) : ?>
+						<?php if ( 'calendar' === $current_schedule_view ) : ?>
+							<div class="wpfa-schedule-calendar" role="list">
+								<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
+									<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading">
+										<header class="wpfa-schedule-calendar-day-head">
+											<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading"><?php echo esc_html( $day_label ); ?></h3>
+											<span>
+												<?php
+												printf(
+													/* translators: %d: number of sessions on this day. */
+													esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+													absint( count( $day_sessions ) )
+												);
+												?>
+											</span>
+										</header>
+										<div class="wpfa-schedule-calendar-slots">
+											<?php foreach ( $day_sessions as $item ) : ?>
+												<article class="wpfa-schedule-calendar-slot">
+													<?php if ( ! empty( $item['time_label'] ) ) : ?>
+														<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+													<?php endif; ?>
+													<h4><?php echo esc_html( $item['title'] ); ?></h4>
+													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+														<ul class="wpfa-schedule-calendar-meta">
+															<?php if ( ! empty( $item['speakers'] ) ) : ?>
+																<li><?php echo esc_html( $item['speakers'] ); ?></li>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['room'] ) ) : ?>
+																<li><?php echo esc_html( $item['room'] ); ?></li>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['track'] ) ) : ?>
+																<li><?php echo esc_html( $item['track'] ); ?></li>
+															<?php endif; ?>
+														</ul>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+														<?php
+														$session_calendar_label = sprintf(
+															/* translators: %s: session title. */
+															__( 'Add %s to Google Calendar', 'wpfaevent' ),
+															$item['title']
+														);
+														?>
+														<a
+															class="wpfa-schedule-session-calendar"
+															href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+															target="_blank"
+															rel="noopener"
+															aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+														>
+															<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+														</a>
+													<?php endif; ?>
+												</article>
+											<?php endforeach; ?>
+										</div>
+									</section>
+								<?php endforeach; ?>
+							</div>
+						<?php else : ?>
+							<div class="wpfa-schedule-program">
+								<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
+									<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+										<header class="wpfa-schedule-day-head">
+											<div>
+												<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h3>
+												<p>
+													<?php
+													printf(
+														/* translators: %d: number of sessions on this day. */
+														esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+														absint( count( $day_sessions ) )
+													);
+													?>
+												</p>
+											</div>
+										</header>
+
+										<div class="wpfa-schedule-day-sessions" role="list">
+											<?php foreach ( $day_sessions as $item ) : ?>
+												<article class="wpfa-schedule-session" role="listitem">
+													<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+														<?php if ( ! empty( $item['time_start'] ) ) : ?>
+															<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+																<?php echo esc_html( $item['time_start'] ); ?>
+															</time>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['time_end'] ) ) : ?>
+															<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
+														<?php endif; ?>
+													</div>
+
+													<div class="wpfa-schedule-session-main">
+														<h4 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h4>
+
+														<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+															<dl class="wpfa-schedule-session-details">
+																<?php if ( ! empty( $item['speakers'] ) ) : ?>
+																	<div class="wpfa-schedule-detail">
+																		<dt><?php esc_html_e( 'Speaker', 'wpfaevent' ); ?></dt>
+																		<dd><?php echo esc_html( $item['speakers'] ); ?></dd>
+																	</div>
+																<?php endif; ?>
+																<?php if ( ! empty( $item['room'] ) ) : ?>
+																	<div class="wpfa-schedule-detail">
+																		<dt><?php esc_html_e( 'Room', 'wpfaevent' ); ?></dt>
+																		<dd><?php echo esc_html( $item['room'] ); ?></dd>
+																	</div>
+																<?php endif; ?>
+																<?php if ( ! empty( $item['track'] ) ) : ?>
+																	<div class="wpfa-schedule-detail">
+																		<dt><?php esc_html_e( 'Track', 'wpfaevent' ); ?></dt>
+																		<dd><?php echo esc_html( $item['track'] ); ?></dd>
+																	</div>
+																<?php endif; ?>
+															</dl>
+														<?php endif; ?>
+
+														<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+															<?php
+															$session_calendar_label = sprintf(
+																/* translators: %s: session title. */
+																__( 'Add %s to Google Calendar', 'wpfaevent' ),
+																$item['title']
+															);
+															?>
+															<a
+																class="wpfa-schedule-session-calendar"
+																href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+																target="_blank"
+																rel="noopener"
+																aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+															>
+																<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+															</a>
+														<?php endif; ?>
+													</div>
+												</article>
+											<?php endforeach; ?>
+										</div>
+									</section>
+								<?php endforeach; ?>
+							</div>
+						<?php endif; ?>
+						<?php if ( $schedule_hidden_count ) : ?>
+							<p class="wpfa-event-schedule-preview-note">
+								<?php
+								printf(
+									/* translators: 1: shown session count, 2: total session count. */
+									esc_html__( 'Showing the first %1$d of %2$d sessions. Open the full schedule to view every session.', 'wpfaevent' ),
+									absint( count( $schedule_preview_items ) ),
+									absint( count( $schedule_items ) )
+								);
+								?>
+							</p>
+						<?php endif; ?>
+					<?php else : ?>
+						<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( '' !== trim( wp_strip_all_tags( $venue_information ) ) ) : ?>
+			<section id="venue" class="wpfa-event-section wpfa-event-venue" aria-labelledby="wpfa-event-venue-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-venue-title"><?php esc_html_e( 'Additional information', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Nearby hotels, transportation, parking, directions, and venue notes.', 'wpfaevent' ); ?></p>
+						</div>
+						<a href="<?php echo esc_url( $event_additional_url ); ?>"><?php esc_html_e( 'View Additional Information', 'wpfaevent' ); ?></a>
+					</div>
+					<div class="wpfa-event-rich-text wpfa-event-additional-preview">
+						<?php echo wp_kses_post( wpautop( $venue_information ) ); ?>
+					</div>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php foreach ( $custom_tabs as $custom_tab ) : ?>
+			<?php
+			if ( empty( $custom_tab['slug'] ) || empty( $custom_tab['title'] ) || empty( $custom_tab['content'] ) ) {
+				continue;
+			}
+
+			$custom_tab_title_id = 'wpfa-event-custom-tab-' . sanitize_html_class( $custom_tab['slug'] ) . '-title';
+			?>
+			<section id="custom-section-<?php echo esc_attr( $custom_tab['slug'] ); ?>" class="wpfa-event-section wpfa-event-custom-tab" aria-labelledby="<?php echo esc_attr( $custom_tab_title_id ); ?>">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="<?php echo esc_attr( $custom_tab_title_id ); ?>"><?php echo esc_html( $custom_tab['title'] ); ?></h2>
+						</div>
+					</div>
+					<div class="wpfa-event-rich-text wpfa-event-custom-tab-content">
+						<?php echo wp_kses_post( wpautop( $custom_tab['content'] ) ); ?>
+					</div>
+				</div>
+			</section>
+		<?php endforeach; ?>
+
+		<?php if ( $show_sponsors && ! empty( $visible_sponsor_groups ) ) : ?>
+			<section id="sponsors" class="wpfa-event-section wpfa-event-sponsors" aria-labelledby="wpfa-event-sponsors-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-sponsors-title"><?php esc_html_e( 'Sponsors', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Organizations supporting this event.', 'wpfaevent' ); ?></p>
+						</div>
+					</div>
+
+					<div class="wpfa-event-partner-groups">
+						<?php foreach ( $visible_sponsor_groups as $sponsor_group ) : ?>
+							<?php
+							$group_name = ! empty( $sponsor_group['group_name'] ) ? sanitize_text_field( $sponsor_group['group_name'] ) : __( 'Sponsors', 'wpfaevent' );
+							$logo_size  = ! empty( $sponsor_group['logo_size'] ) ? absint( $sponsor_group['logo_size'] ) : 160;
+							?>
+							<div class="wpfa-event-partner-group">
+								<h3><?php echo esc_html( $group_name ); ?></h3>
+								<div class="wpfa-event-partner-grid">
+									<?php foreach ( $sponsor_group['sponsors'] as $sponsor ) : ?>
+										<?php
+										$sponsor_name        = ! empty( $sponsor['name'] ) ? sanitize_text_field( $sponsor['name'] ) : '';
+										$sponsor_image       = ! empty( $sponsor['image'] ) ? esc_url_raw( $sponsor['image'] ) : '';
+										$sponsor_description = ! empty( $sponsor['description'] ) ? wp_kses_post( $sponsor['description'] ) : '';
+										$sponsor_detail_url  = class_exists( 'Wpfaevent_Partner_Helper' )
+											? Wpfaevent_Partner_Helper::get_partner_detail_url( $event_id, 'sponsor', $sponsor )
+											: '';
+										?>
+										<a class="wpfa-event-partner-card wpfa-event-partner-card-link" href="<?php echo esc_url( $sponsor_detail_url ? $sponsor_detail_url : '#' ); ?>">
+											<?php if ( $sponsor_image ) : ?>
+												<div class="wpfa-event-partner-logo" style="--partner-logo-size: <?php echo esc_attr( $logo_size ); ?>px;">
+													<img src="<?php echo esc_url( $sponsor_image ); ?>" alt="<?php echo esc_attr( $sponsor_name ); ?>" loading="lazy">
+												</div>
+											<?php endif; ?>
+											<div class="wpfa-event-partner-body">
+												<?php if ( $sponsor_name ) : ?>
+													<h4><?php echo esc_html( $sponsor_name ); ?></h4>
+												<?php endif; ?>
+												<?php if ( $sponsor_description ) : ?>
+													<div class="wpfa-event-partner-description"><?php echo wp_kses_post( wpautop( wp_trim_words( wp_strip_all_tags( $sponsor_description ), 24, '…' ) ) ); ?></div>
+												<?php endif; ?>
+												<span class="wpfa-event-partner-view-details"><?php esc_html_e( 'View details', 'wpfaevent' ); ?></span>
+											</div>
+										</a>
+									<?php endforeach; ?>
+								</div>
+							</div>
+						<?php endforeach; ?>
+					</div>
+				</div>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( $show_exhibitors && ! empty( $visible_exhibitors ) ) : ?>
+			<section id="exhibitors" class="wpfa-event-section wpfa-event-exhibitors" aria-labelledby="wpfa-event-exhibitors-title">
+				<div class="container">
+					<div class="wpfa-event-section-head">
+						<div>
+							<h2 id="wpfa-event-exhibitors-title"><?php esc_html_e( 'Exhibitors', 'wpfaevent' ); ?></h2>
+							<p><?php esc_html_e( 'Exhibitor booths and resources for this event.', 'wpfaevent' ); ?></p>
+						</div>
+					</div>
+
+					<div class="wpfa-event-exhibitor-grid">
+						<?php foreach ( $visible_exhibitors as $exhibitor ) : ?>
+							<?php
+							$exhibitor_name        = sanitize_text_field( $exhibitor['name'] );
+							$exhibitor_logo        = ! empty( $exhibitor['logo'] ) ? esc_url_raw( $exhibitor['logo'] ) : '';
+							$exhibitor_banner      = ! empty( $exhibitor['banner'] ) ? esc_url_raw( $exhibitor['banner'] ) : '';
+							$exhibitor_initial     = $exhibitor_name ? strtoupper( substr( $exhibitor_name, 0, 1 ) ) : '';
+							$exhibitor_card_class  = 'wpfa-event-exhibitor-card';
+							$exhibitor_card_class .= $exhibitor_banner ? ' has-banner' : ' no-banner';
+							$exhibitor_card_class .= $exhibitor_logo ? ' has-logo' : ' no-logo';
+							$exhibitor_detail_url  = class_exists( 'Wpfaevent_Partner_Helper' )
+								? Wpfaevent_Partner_Helper::get_partner_detail_url( $event_id, 'exhibitor', $exhibitor )
+								: '';
+							?>
+							<a class="<?php echo esc_attr( $exhibitor_card_class ); ?> wpfa-event-exhibitor-card-link" href="<?php echo esc_url( $exhibitor_detail_url ? $exhibitor_detail_url : '#' ); ?>">
+								<?php if ( $exhibitor_banner ) : ?>
+									<img class="wpfa-event-exhibitor-banner" src="<?php echo esc_url( $exhibitor_banner ); ?>" alt="<?php echo esc_attr( $exhibitor_name ); ?>" loading="lazy">
+								<?php endif; ?>
+								<span class="wpfa-event-exhibitor-summary">
+									<span class="wpfa-event-exhibitor-main">
+										<?php if ( $exhibitor_logo ) : ?>
+											<span class="wpfa-event-exhibitor-logo">
+												<img src="<?php echo esc_url( $exhibitor_logo ); ?>" alt="<?php echo esc_attr( $exhibitor_name ); ?>" loading="lazy">
+											</span>
+										<?php else : ?>
+											<span class="wpfa-event-exhibitor-placeholder" aria-hidden="true">
+												<?php echo esc_html( $exhibitor_initial ); ?>
+											</span>
+										<?php endif; ?>
+										<span class="wpfa-event-exhibitor-copy">
+											<span class="wpfa-event-exhibitor-eyebrow"><?php esc_html_e( 'Exhibitor', 'wpfaevent' ); ?></span>
+											<span class="wpfa-event-exhibitor-name"><?php echo esc_html( $exhibitor_name ); ?></span>
+										</span>
+									</span>
+									<span class="wpfa-event-exhibitor-toggle">
+										<span class="wpfa-event-exhibitor-toggle-closed"><?php esc_html_e( 'View details', 'wpfaevent' ); ?></span>
+									</span>
+								</span>
+							</a>
+						<?php endforeach; ?>
+					</div>
+				</div>
+			</section>
+		<?php endif; ?>
 	</main>
 
-	<?php require WPFAEVENT_PATH . 'public/partials/footer.php'; ?>
+	<footer class="wpfa-footer">
+		<div class="container">
+			<small>
+				<?php
+				printf(
+					/* translators: %s: Current year. */
+					esc_html__( 'FOSSASIA %s - Open Source Community Events', 'wpfaevent' ),
+					esc_html( date_i18n( 'Y' ) )
+				);
+				?>
+			</small>
+		</div>
+	</footer>
 </div>
 
-	<?php wp_footer(); ?>
+<?php wp_footer(); ?>
 </body>
 </html>

--- a/public/templates/single-wpfa-speaker.php
+++ b/public/templates/single-wpfa-speaker.php
@@ -20,21 +20,22 @@ if ( ! $speaker_id || 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
 	return;
 }
 
-$speaker_name  = get_the_title( $speaker_id );
-$position      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_position', true ) );
-$organization  = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_organization', true ) );
-$bio           = get_post_meta( $speaker_id, 'wpfa_speaker_bio', true );
-$photo_url     = get_post_meta( $speaker_id, 'wpfa_speaker_headshot_url', true );
-$linkedin      = get_post_meta( $speaker_id, 'wpfa_speaker_linkedin', true );
-$twitter       = get_post_meta( $speaker_id, 'wpfa_speaker_twitter', true );
-$github        = get_post_meta( $speaker_id, 'wpfa_speaker_github', true );
-$website       = get_post_meta( $speaker_id, 'wpfa_speaker_website', true );
-$talk_title    = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_title', true ) );
-$talk_date     = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_date', true ) );
-$talk_start    = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_time', true ) );
-$talk_end      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_end_time', true ) );
-$talk_abstract = get_post_meta( $speaker_id, 'wpfa_speaker_talk_abstract', true );
-$photo_alt     = sprintf(
+$speaker_name    = get_the_title( $speaker_id );
+$position        = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_position', true ) );
+$organization    = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_organization', true ) );
+$bio             = get_post_meta( $speaker_id, 'wpfa_speaker_bio', true );
+$photo_url       = get_post_meta( $speaker_id, 'wpfa_speaker_headshot_url', true );
+$placeholder_url = WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg';
+$linkedin        = get_post_meta( $speaker_id, 'wpfa_speaker_linkedin', true );
+$twitter         = get_post_meta( $speaker_id, 'wpfa_speaker_twitter', true );
+$github          = get_post_meta( $speaker_id, 'wpfa_speaker_github', true );
+$website         = get_post_meta( $speaker_id, 'wpfa_speaker_website', true );
+$talk_title      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_title', true ) );
+$talk_date       = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_date', true ) );
+$talk_start      = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_time', true ) );
+$talk_end        = sanitize_text_field( get_post_meta( $speaker_id, 'wpfa_speaker_talk_end_time', true ) );
+$talk_abstract   = get_post_meta( $speaker_id, 'wpfa_speaker_talk_abstract', true );
+$photo_alt       = sprintf(
 	/* translators: %s: Speaker name. */
 	__( 'Photo of %s', 'wpfaevent' ),
 	$speaker_name
@@ -68,52 +69,7 @@ if ( $talk_start || $talk_end ) {
 
 $has_session_details = $talk_title || $talk_date || $talk_start || $talk_end || $talk_abstract;
 
-$stored_event_ids = get_post_meta( $speaker_id, 'wpfa_speaker_events', true );
-$stored_event_ids = is_array( $stored_event_ids ) ? array_map( 'absint', $stored_event_ids ) : array();
-$stored_event_ids = array_filter( $stored_event_ids );
-
-$relationship_event_ids = array();
-if ( empty( $stored_event_ids ) ) {
-	$relationship_event_ids = get_posts(
-		array(
-			'post_type'      => 'wpfa_event',
-			'post_status'    => 'publish',
-			'posts_per_page' => -1,
-			'fields'         => 'ids',
-			'no_found_rows'  => true,
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
-			'meta_query'     => array(
-				'relation' => 'OR',
-				array(
-					'key'     => 'wpfa_event_speakers',
-					'value'   => 'i:' . $speaker_id . ';',
-					'compare' => 'LIKE',
-				),
-				array(
-					'key'     => 'wpfa_event_speakers',
-					'value'   => '"' . $speaker_id . '"',
-					'compare' => 'LIKE',
-				),
-				array(
-					'key'     => 'wpfa_event_speakers',
-					'value'   => (string) $speaker_id,
-					'compare' => '=',
-				),
-			),
-		)
-	);
-}
-
-$linked_event_ids = array_values(
-	array_unique(
-		array_filter(
-			array_map(
-				'absint',
-				array_merge( $stored_event_ids, $relationship_event_ids )
-			)
-		)
-	)
-);
+$linked_event_ids = Wpfaevent_Meta_Speaker::get_events_linked_to_speaker( $speaker_id, 'publish' );
 
 usort(
 	$linked_event_ids,
@@ -194,26 +150,12 @@ $header_vars = array(
 							itemprop="image"
 						>
 					<?php else : ?>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 300 300"
-							class="wpfa-placeholder-svg"
-							role="img"
-							aria-label="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>"
+						<img
+							src="<?php echo esc_url( $placeholder_url ); ?>"
+							alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>"
+							class="wpfa-speaker-placeholder-img"
+							itemprop="image"
 						>
-							<rect width="100%" height="100%" fill="#eee" />
-							<text
-								x="50%"
-								y="50%"
-								dominant-baseline="middle"
-								text-anchor="middle"
-								font-family="sans-serif"
-								font-size="20"
-								fill="#999"
-							>
-								<?php esc_html_e( 'Speaker', 'wpfaevent' ); ?>
-							</text>
-						</svg>
 					<?php endif; ?>
 				</div>
 
@@ -287,67 +229,52 @@ $header_vars = array(
 								</a>
 							<?php endif; ?>
 						</div>
+					<?php endif; ?>
+				</div>
+			</div>
+		</section>
+
+		<?php if ( $has_session_details ) : ?>
+			<section class="wpfa-speaker-sessions" aria-labelledby="wpfa-speaker-sessions-title">
+				<div class="container">
+					<h2 id="wpfa-speaker-sessions-title"><?php esc_html_e( 'Sessions by this speaker', 'wpfaevent' ); ?></h2>
+
+					<article class="wpfa-speaker-session-card" itemprop="performerIn" itemscope itemtype="https://schema.org/Event">
+						<?php if ( $talk_title ) : ?>
+							<h3 itemprop="name"><?php echo esc_html( $talk_title ); ?></h3>
 						<?php endif; ?>
-					</div>
+
+						<?php if ( ! empty( $session_meta ) ) : ?>
+							<p class="wpfa-speaker-session-meta"><?php echo esc_html( implode( ' | ', $session_meta ) ); ?></p>
+						<?php endif; ?>
+
+						<?php if ( $talk_abstract ) : ?>
+							<div class="wpfa-speaker-session-abstract" itemprop="description">
+								<?php echo wp_kses_post( wpautop( $talk_abstract ) ); ?>
+							</div>
+						<?php endif; ?>
+					</article>
 				</div>
 			</section>
+		<?php endif; ?>
 
-			<?php if ( $has_session_details ) : ?>
-				<section class="wpfa-speaker-sessions" aria-labelledby="wpfa-speaker-sessions-title">
-					<div class="container">
-						<h2 id="wpfa-speaker-sessions-title"><?php esc_html_e( 'Sessions by this speaker', 'wpfaevent' ); ?></h2>
+		<section class="wpfa-linked-events" aria-labelledby="wpfa-linked-events-title">
+			<div class="container">
+				<h2 id="wpfa-linked-events-title"><?php esc_html_e( 'Linked Events', 'wpfaevent' ); ?></h2>
 
-						<article class="wpfa-speaker-session-card" itemprop="performerIn" itemscope itemtype="https://schema.org/Event">
-							<?php if ( $talk_title ) : ?>
-								<h3 itemprop="name"><?php echo esc_html( $talk_title ); ?></h3>
-							<?php endif; ?>
-
-							<?php if ( ! empty( $session_meta ) ) : ?>
-								<p class="wpfa-speaker-session-meta"><?php echo esc_html( implode( ' | ', $session_meta ) ); ?></p>
-							<?php endif; ?>
-
-							<?php if ( $talk_abstract ) : ?>
-								<div class="wpfa-speaker-session-abstract" itemprop="description">
-									<?php echo wp_kses_post( wpautop( $talk_abstract ) ); ?>
-								</div>
-							<?php endif; ?>
-						</article>
-					</div>
-				</section>
-			<?php endif; ?>
-
-			<section class="wpfa-linked-events" aria-labelledby="wpfa-linked-events-title">
-				<div class="container">
-					<h2 id="wpfa-linked-events-title"><?php esc_html_e( 'Linked Events', 'wpfaevent' ); ?></h2>
-
-					<?php if ( ! empty( $linked_event_ids ) ) : ?>
+				<?php if ( ! empty( $linked_event_ids ) ) : ?>
 					<div class="wpfa-linked-events-grid">
 						<?php foreach ( $linked_event_ids as $event_id ) : ?>
 							<?php
-							$event_title   = get_the_title( $event_id );
-							$event_start   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
-							$event_end     = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
-							$event_loc     = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
-							$event_url     = get_post_meta( $event_id, 'wpfa_event_url', true );
-							$event_url     = $event_url ? $event_url : get_permalink( $event_id );
-							$event_meta    = array();
-							$calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
-							$calendar_data = is_wp_error( $calendar_data ) ? array() : $calendar_data;
+							$event_title = get_the_title( $event_id );
+							$event_start = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_start_date', true ) );
+							$event_end   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_end_date', true ) );
+							$event_loc   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+							$event_url   = get_post_meta( $event_id, 'wpfa_event_url', true );
+							$event_url   = $event_url ? $event_url : get_permalink( $event_id );
+							$event_meta  = array();
 
-							if ( ! empty( $calendar_data['date_label'] ) ) {
-								$date_time_label = sanitize_text_field( $calendar_data['date_label'] );
-								$time_label      = ! empty( $calendar_data['time_label'] ) ? sanitize_text_field( $calendar_data['time_label'] ) : '';
-
-								if ( $time_label ) {
-									$date_time_label .= ' | ' . $time_label;
-
-									if ( empty( $calendar_data['all_day'] ) && ! empty( $calendar_data['timezone_label'] ) ) {
-										$date_time_label .= ' (' . sanitize_text_field( $calendar_data['timezone_label'] ) . ')';
-									}
-								}
-
-								$event_meta[] = $date_time_label;
-							} elseif ( $event_start ) {
+							if ( $event_start ) {
 								$event_meta[] = $event_start . ( $event_end ? ' - ' . $event_end : '' );
 							}
 


### PR DESCRIPTION
## Summary

Split out from #121 as part 3b of the stack. Stacked on #125. Adds all public-facing PHP templates and partials that render imported Eventyay data:

- **Single event page** (`single-wpfa-event.php`): event details, schedule preview, speaker sections, sponsors, and exhibitors
- **Event archive** (`archive-wpfa-event.php`): filtering and search for imported events with metadata cards
- **Speaker listing** (`page-speakers.php`): event-filtered speaker views and featured speaker grouping
- **Partner page** (`page-partner.php`): new partner detail page
- **Additional information page** (`page-additional-information.php`): new additional info page
- **Updated listing pages**: `page-events.php`, `page-past-events.php`, `page-schedule.php`, `single-wpfa-speaker.php`
- **Partials**: event cards, event modal, section nav, speaker cards, dashboard speaker card, footer, additional-information partial

## Stack

1. #119: Eventyay import core
2. #120: Related Eventyay data import
3. #125: Helpers, CSS, JS, admin (3a)
4. **This PR**: Frontend templates and partials (3b)

After #125 merges, this PR can be retargeted to `split-81-eventyay-display-helpers` → then to `main` when the rest of the stack lands.

## Tests

- `composer phpcs`
- `php tests/speaker-relationship-test.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)