### PR TITLE
Split #81: Eventyay speaker import relations and dashboard filtering

### DIFF
--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Eventyay event import functionality.
+ * Eventyay import and dashboard sync functionality.
  *
  * @link       https://fossasia.org
  * @since      1.0.0
@@ -10,14 +10,13 @@
  */
 
 /**
- * Handles Eventyay settings and event post imports.
+ * Handles Eventyay settings, imports, and dashboard syncs.
  *
  * @package    Wpfaevent
  * @subpackage Wpfaevent/admin
  * @author     FOSSASIA <contact@fossasia.org>
  */
 class Wpfaevent_Eventyay_Importer {
-
 	/**
 	 * Sanitize Eventyay import options.
 	 *
@@ -202,8 +201,10 @@ class Wpfaevent_Eventyay_Importer {
 					<h2><?php esc_html_e( 'Where Imported Data Shows Up', 'wpfaevent' ); ?></h2>
 					<ul>
 						<li><?php esc_html_e( 'Events are saved as Events posts with Eventyay source metadata for repeat imports.', 'wpfaevent' ); ?></li>
-						<li><?php esc_html_e( 'Event title, description, dates, timezone, location, and Eventyay URL are updated from the Eventyay API.', 'wpfaevent' ); ?></li>
-						<li><?php esc_html_e( 'Speaker, schedule, sponsor, and exhibitor imports are handled by the follow-up Eventyay data import PR.', 'wpfaevent' ); ?></li>
+						<li><?php esc_html_e( 'Speakers are saved as Speaker posts and linked only to the event they came from.', 'wpfaevent' ); ?></li>
+						<li><?php esc_html_e( 'Sponsors and exhibitors are imported into event-specific dashboard JSON files.', 'wpfaevent' ); ?></li>
+						<li><?php esc_html_e( 'Dashboard JSON is written to uploads/fossasia-data using event-specific file names.', 'wpfaevent' ); ?></li>
+						<li><?php esc_html_e( 'Frontend rendering for imported data is handled by the follow-up display PR.', 'wpfaevent' ); ?></li>
 					</ul>
 				</div>
 		</div>
@@ -244,7 +245,7 @@ class Wpfaevent_Eventyay_Importer {
 				<h2><?php esc_html_e( 'Update Events from Eventyay', 'wpfaevent' ); ?></h2>
 				<p><?php esc_html_e( 'Run this when Eventyay data changes after events have already been imported.', 'wpfaevent' ); ?></p>
 				<p class="description">
-					<?php esc_html_e( 'Existing Eventyay-owned event posts are updated in place while source metadata is preserved for future imports.', 'wpfaevent' ); ?>
+					<?php esc_html_e( 'Existing Eventyay-owned event posts, speakers, schedules, sponsors, exhibitors, and event Info content are updated in place.', 'wpfaevent' ); ?>
 				</p>
 
 				<?php if ( is_wp_error( $endpoint_preview ) ) : ?>
@@ -314,12 +315,20 @@ class Wpfaevent_Eventyay_Importer {
 				array(
 					'type'    => 'success',
 					'message' => sprintf(
-						/* translators: 1: fetched events, 2: created events, 3: updated events, 4: skipped events. */
-						esc_html__( 'Fetched %1$d Eventyay event(s). Created %2$d, updated %3$d, skipped %4$d.', 'wpfaevent' ),
+						/* translators: 1: fetched events, 2: created events, 3: updated events, 4: skipped events, 5: sessions, 6: speakers, 7: sponsors, 8: exhibitors, 9: schedule rows, 10: about updates, 11: skipped program imports, 12: skipped sponsor/exhibitor imports. */
+						esc_html__( 'Fetched %1$d Eventyay event(s). Created %2$d, updated %3$d, skipped %4$d. Imported %5$d session(s), %6$d speaker(s), %7$d sponsor(s), %8$d exhibitor(s), %9$d schedule row(s), and updated %10$d about section(s); skipped program import for %11$d event(s) and sponsor/exhibitor import for %12$d event(s).', 'wpfaevent' ),
 						absint( $result['fetched'] ),
 						absint( $result['created'] ),
 						absint( $result['updated'] ),
-						absint( $result['skipped'] )
+						absint( $result['skipped'] ),
+						absint( $result['sessions'] ),
+						absint( $result['speakers'] ),
+						absint( $result['sponsors'] ),
+						absint( $result['exhibitors'] ),
+						absint( $result['schedule_rows'] ),
+						absint( $result['about_updates'] ),
+						absint( $result['program_skipped'] ),
+						absint( $result['partner_skipped'] )
 					),
 				),
 				MINUTE_IN_SECONDS
@@ -450,10 +459,20 @@ class Wpfaevent_Eventyay_Importer {
 		}
 
 		$result = array(
-			'fetched' => count( $events ),
-			'created' => 0,
-			'updated' => 0,
-			'skipped' => 0,
+			'fetched'          => count( $events ),
+			'created'          => 0,
+			'updated'          => 0,
+			'skipped'          => 0,
+			'sessions'         => 0,
+			'speakers'         => 0,
+			'sponsors'         => 0,
+			'exhibitors'       => 0,
+			'created_speakers' => 0,
+			'updated_speakers' => 0,
+			'about_updates'    => 0,
+			'schedule_rows'    => 0,
+			'program_skipped'  => 0,
+			'partner_skipped'  => 0,
 		);
 
 		foreach ( $events as $event ) {
@@ -469,6 +488,35 @@ class Wpfaevent_Eventyay_Importer {
 			} else {
 				++$result['updated'];
 			}
+
+			$dashboard = $this->sync_eventyay_event_dashboard_data( $upsert['id'], $event, $settings, $upsert['event_slug'] );
+			if ( is_wp_error( $dashboard ) ) {
+				++$result['program_skipped'];
+				continue;
+			}
+
+			$result['about_updates'] += absint( $dashboard['about_updated'] );
+
+			$partners = $this->import_eventyay_event_partner_data( $upsert['id'], $event, $settings, $upsert['event_slug'] );
+			if ( is_wp_error( $partners ) ) {
+				++$result['partner_skipped'];
+			} else {
+				$result['sponsors']        += absint( $partners['sponsor_count'] );
+				$result['exhibitors']      += absint( $partners['exhibitor_count'] );
+				$result['partner_skipped'] += absint( $partners['skipped'] );
+			}
+
+			$program = $this->import_eventyay_event_program( $upsert['id'], $settings, $upsert['event_slug'] );
+			if ( is_wp_error( $program ) ) {
+				++$result['program_skipped'];
+				continue;
+			}
+
+			$result['sessions']         += absint( $program['session_count'] );
+			$result['speakers']         += absint( $program['speaker_count'] );
+			$result['created_speakers'] += absint( $program['created_speakers'] );
+			$result['updated_speakers'] += absint( $program['updated_speakers'] );
+			$result['schedule_rows']    += absint( $program['schedule_rows'] );
 		}
 
 		return $result;
@@ -1004,12 +1052,1235 @@ class Wpfaevent_Eventyay_Importer {
 		return is_array( $value ) && ! empty( $value );
 	}
 
+		/**
+		 * Build the newer Eventyay submissions endpoint for an imported event.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array  $settings   Import settings.
+		 * @param string $event_slug Eventyay event slug.
+		 * @return string|WP_Error Endpoint URL.
+		 */
+	private function build_eventyay_submissions_endpoint( $settings, $event_slug ) {
+		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
+		$base_url   = untrailingslashit( esc_url_raw( $settings['base_url'] ) );
+		$event_slug = $this->sanitize_eventyay_path_segment( $event_slug );
+
+		if ( empty( $base_url ) || ! wp_http_validate_url( $base_url ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_invalid_base_url',
+				esc_html__( 'The Eventyay API base URL is invalid.', 'wpfaevent' )
+			);
+		}
+
+		if ( empty( $settings['organizer_slug'] ) || empty( $event_slug ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_missing_program_path',
+				esc_html__( 'The Eventyay organizer or event slug is missing for speaker import.', 'wpfaevent' )
+			);
+		}
+
+		$url = trailingslashit( $base_url ) . sprintf(
+			'api/v1/organizers/%s/events/%s/submissions/',
+			rawurlencode( $settings['organizer_slug'] ),
+			rawurlencode( $event_slug )
+		);
+
+		return esc_url_raw(
+			add_query_arg(
+				array(
+					'expand'    => 'speakers,track,submission_type,slots.room',
+					'lang'      => 'en',
+					'page_size' => absint( apply_filters( 'wpfaevent_eventyay_program_import_page_size', 50 ) ),
+				),
+				$url
+			)
+		);
+	}
+
+		/**
+		 * Build the newer Eventyay speakers endpoint for an imported event.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array  $settings   Import settings.
+		 * @param string $event_slug Eventyay event slug.
+		 * @return string|WP_Error Endpoint URL.
+		 */
+	private function build_eventyay_speakers_endpoint( $settings, $event_slug ) {
+		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
+		$base_url   = untrailingslashit( esc_url_raw( $settings['base_url'] ) );
+		$event_slug = $this->sanitize_eventyay_path_segment( $event_slug );
+
+		if ( empty( $base_url ) || ! wp_http_validate_url( $base_url ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_invalid_base_url',
+				esc_html__( 'The Eventyay API base URL is invalid.', 'wpfaevent' )
+			);
+		}
+
+		if ( empty( $settings['organizer_slug'] ) || empty( $event_slug ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_missing_speakers_path',
+				esc_html__( 'The Eventyay organizer or event slug is missing for speaker import.', 'wpfaevent' )
+			);
+		}
+
+		$url = trailingslashit( $base_url ) . sprintf(
+			'api/v1/organizers/%s/events/%s/speakers/',
+			rawurlencode( $settings['organizer_slug'] ),
+			rawurlencode( $event_slug )
+		);
+
+		return esc_url_raw(
+			add_query_arg(
+				array(
+					'expand'    => 'submissions,submissions.track,submissions.submission_type,submissions.slots.room',
+					'lang'      => 'en',
+					'page_size' => absint( apply_filters( 'wpfaevent_eventyay_speaker_import_page_size', 50 ) ),
+				),
+				$url
+			)
+		);
+	}
+
+	/**
+	 * Build the newer Eventyay schedule slots endpoint for an imported event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $settings   Import settings.
+	 * @param string $event_slug Eventyay event slug.
+	 * @return string|WP_Error Endpoint URL.
+	 */
+	private function build_eventyay_slots_endpoint( $settings, $event_slug ) {
+		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
+		$base_url   = untrailingslashit( esc_url_raw( $settings['base_url'] ) );
+		$event_slug = $this->sanitize_eventyay_path_segment( $event_slug );
+
+		if ( empty( $base_url ) || ! wp_http_validate_url( $base_url ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_invalid_base_url',
+				esc_html__( 'The Eventyay API base URL is invalid.', 'wpfaevent' )
+			);
+		}
+
+		if ( empty( $settings['organizer_slug'] ) || empty( $event_slug ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_missing_slots_path',
+				esc_html__( 'The Eventyay organizer or event slug is missing for schedule import.', 'wpfaevent' )
+			);
+		}
+
+		$url = trailingslashit( $base_url ) . sprintf(
+			'api/v1/organizers/%s/events/%s/slots/',
+			rawurlencode( $settings['organizer_slug'] ),
+			rawurlencode( $event_slug )
+		);
+
+		return esc_url_raw(
+			add_query_arg(
+				array(
+					'expand'    => 'room,submission,submission.speakers,submission.track,submission.submission_type',
+					'lang'      => 'en',
+					'page_size' => absint( apply_filters( 'wpfaevent_eventyay_slot_import_page_size', 50 ) ),
+				),
+				$url
+			)
+		);
+	}
+
+	/**
+	 * Build candidate Eventyay partner resource endpoints for an imported event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $settings      Import settings.
+	 * @param array  $event         Eventyay event resource.
+	 * @param string $event_slug    Eventyay event slug.
+	 * @param string $resource_type Partner resource type. Accepts sponsors or exhibitors.
+	 * @return array Endpoint URLs.
+	 */
+	private function build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type ) {
+		$resource_type = sanitize_key( $resource_type );
+		if ( ! in_array( $resource_type, array( 'sponsors', 'exhibitors' ), true ) ) {
+			return array();
+		}
+
+		$endpoints       = array();
+		$modern_endpoint = $this->build_eventyay_modern_partner_endpoint( $settings, $event_slug, $resource_type );
+		if ( ! is_wp_error( $modern_endpoint ) ) {
+			$endpoints[] = $modern_endpoint;
+		}
+
+		$endpoints = array_merge(
+			$endpoints,
+			$this->build_eventyay_legacy_partner_endpoints( $settings, $event, $event_slug, $resource_type )
+		);
+
+		return array_values( array_unique( array_filter( $endpoints ) ) );
+	}
+
+	/**
+	 * Build the newer organizer/event Eventyay partner endpoint.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $settings      Import settings.
+	 * @param string $event_slug    Eventyay event slug.
+	 * @param string $resource_type Partner resource type.
+	 * @return string|WP_Error Endpoint URL.
+	 */
+	private function build_eventyay_modern_partner_endpoint( $settings, $event_slug, $resource_type ) {
+		$settings      = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
+		$base_url      = untrailingslashit( esc_url_raw( $settings['base_url'] ) );
+		$event_slug    = $this->sanitize_eventyay_path_segment( $event_slug );
+		$resource_type = sanitize_key( $resource_type );
+
+		if ( empty( $base_url ) || ! wp_http_validate_url( $base_url ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_invalid_base_url',
+				esc_html__( 'The Eventyay API base URL is invalid.', 'wpfaevent' )
+			);
+		}
+
+		if ( empty( $settings['organizer_slug'] ) || empty( $event_slug ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_missing_partner_path',
+				esc_html__( 'The Eventyay organizer or event slug is missing for sponsor/exhibitor import.', 'wpfaevent' )
+			);
+		}
+
+		$url = trailingslashit( $base_url ) . sprintf(
+			'api/v1/organizers/%s/events/%s/%s/',
+			rawurlencode( $settings['organizer_slug'] ),
+			rawurlencode( $event_slug ),
+			rawurlencode( $resource_type )
+		);
+
+		return esc_url_raw(
+			add_query_arg(
+				array(
+					'lang'      => 'en',
+					'page_size' => absint( apply_filters( 'wpfaevent_eventyay_partner_import_page_size', 50, $resource_type ) ),
+					'sort'      => 'sponsors' === $resource_type ? 'level' : 'position',
+				),
+				$url
+			)
+		);
+	}
+
+	/**
+	 * Build legacy Eventyay partner endpoints from the Open Event API shape.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $settings      Import settings.
+	 * @param array  $event         Eventyay event resource.
+	 * @param string $event_slug    Eventyay event slug.
+	 * @param string $resource_type Partner resource type.
+	 * @return array Endpoint URLs.
+	 */
+	private function build_eventyay_legacy_partner_endpoints( $settings, $event, $event_slug, $resource_type ) {
+		$settings      = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
+		$base_url      = untrailingslashit( esc_url_raw( $settings['base_url'] ) );
+		$event_slug    = $this->sanitize_eventyay_path_segment( $event_slug );
+		$resource_type = sanitize_key( $resource_type );
+		$source_id     = $this->eventyay_event_first_present_raw( $event, array( '_eventyay_source_id', 'id', 'code', 'identifier' ), false );
+		$identifiers   = array();
+
+		if ( is_scalar( $source_id ) && '' !== trim( (string) $source_id ) ) {
+			$identifiers[] = sanitize_text_field( (string) $source_id );
+		}
+
+		if ( $event_slug ) {
+			$identifiers[] = $event_slug;
+		}
+
+		if ( empty( $identifiers ) ) {
+			return array();
+		}
+
+		$api_bases   = array( $base_url );
+		$api_bases[] = apply_filters( 'wpfaevent_eventyay_legacy_api_base_url', 'https://api.eventyay.com', $settings );
+		$endpoints   = array();
+
+		foreach ( array_unique( array_filter( $api_bases ) ) as $api_base ) {
+			$api_base = untrailingslashit( esc_url_raw( $api_base ) );
+			if ( empty( $api_base ) || ! wp_http_validate_url( $api_base ) ) {
+				continue;
+			}
+
+			foreach ( array_unique( array_filter( $identifiers ) ) as $identifier ) {
+				$url = trailingslashit( $this->trim_eventyay_legacy_api_version_path( $api_base ) ) .
+					'v1/events/' .
+					rawurlencode( $identifier ) .
+					'/' .
+					rawurlencode( $resource_type );
+
+				$endpoints[] = esc_url_raw(
+					add_query_arg(
+						array(
+							'page[size]' => absint( apply_filters( 'wpfaevent_eventyay_partner_import_page_size', 100, $resource_type ) ),
+							'sort'       => 'sponsors' === $resource_type ? 'level' : 'position',
+							'filter'     => '[]',
+						),
+						$url
+					)
+				);
+			}
+		}
+
+		return $endpoints;
+	}
+
+	/**
+	 * Import Eventyay sponsors and exhibitors into event-specific dashboard JSON.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $event_id   Imported WordPress event post ID.
+	 * @param array  $event      Eventyay event resource.
+	 * @param array  $settings   Import settings.
+	 * @param string $event_slug Eventyay event slug.
+	 * @return array|WP_Error Import result.
+	 */
+	private function import_eventyay_event_partner_data( $event_id, $event, $settings, $event_slug ) {
+		$result = array(
+			'sponsor_count'   => 0,
+			'exhibitor_count' => 0,
+			'skipped'         => 0,
+		);
+
+		$sponsors = $this->fetch_eventyay_partner_collection( $settings, $event, $event_slug, 'sponsors' );
+		if ( is_wp_error( $sponsors ) ) {
+			++$result['skipped'];
+		} else {
+			$normalized_sponsors = $this->normalize_eventyay_sponsor_resources( $sponsors['resources'], $settings );
+			$existing_sponsors   = $this->read_dashboard_json_file( 'sponsors-' . absint( $event_id ) . '.json', array() );
+			$sponsor_groups      = $this->merge_eventyay_sponsor_groups( $normalized_sponsors, $existing_sponsors );
+			$write_result        = $this->write_dashboard_json_file( 'sponsors-' . absint( $event_id ) . '.json', $sponsor_groups );
+
+			if ( is_wp_error( $write_result ) ) {
+				return $write_result;
+			}
+
+			$result['sponsor_count'] = count( $normalized_sponsors );
+		}
+
+		$exhibitors = $this->fetch_eventyay_partner_collection( $settings, $event, $event_slug, 'exhibitors' );
+		if ( is_wp_error( $exhibitors ) ) {
+			++$result['skipped'];
+		} else {
+			$normalized_exhibitors = $this->normalize_eventyay_exhibitor_resources( $exhibitors['resources'], $settings );
+			$existing_exhibitors   = $this->read_dashboard_json_file( 'exhibitors-' . absint( $event_id ) . '.json', array() );
+			$merged_exhibitors     = $this->merge_eventyay_flat_records( $normalized_exhibitors, $existing_exhibitors );
+			$write_result          = $this->write_dashboard_json_file( 'exhibitors-' . absint( $event_id ) . '.json', $merged_exhibitors );
+
+			if ( is_wp_error( $write_result ) ) {
+				return $write_result;
+			}
+
+			$result['exhibitor_count'] = count( $normalized_exhibitors );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Fetch Eventyay partner resources from the first available endpoint.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $settings      Import settings.
+	 * @param array  $event         Eventyay event resource.
+	 * @param string $event_slug    Eventyay event slug.
+	 * @param string $resource_type Partner resource type.
+	 * @return array|WP_Error Partner resources and metadata.
+	 */
+	private function fetch_eventyay_partner_collection( $settings, $event, $event_slug, $resource_type ) {
+		$endpoints = $this->build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type );
+		if ( empty( $endpoints ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_missing_partner_endpoint',
+				esc_html__( 'Could not build an Eventyay sponsors/exhibitors endpoint.', 'wpfaevent' )
+			);
+		}
+
+		$not_found_errors = array();
+
+		foreach ( $endpoints as $endpoint ) {
+			$fetched = $this->fetch_eventyay_partner_resources( $endpoint, $settings, $resource_type );
+			if ( ! is_wp_error( $fetched ) ) {
+				return $fetched;
+			}
+
+			if ( ! $this->eventyay_error_has_http_status( $fetched, 404 ) ) {
+				return $fetched;
+			}
+
+			$not_found_errors[] = $fetched;
+		}
+
+		return new WP_Error(
+			'wpfaevent_eventyay_partner_endpoint_not_found',
+			sprintf(
+				/* translators: %s: partner resource type. */
+				esc_html__( 'Eventyay did not expose a %s endpoint for this event.', 'wpfaevent' ),
+				sanitize_text_field( $resource_type )
+			),
+			array(
+				'http_status' => 404,
+				'errors'      => $not_found_errors,
+			)
+		);
+	}
+
+	/**
+	 * Fetch one Eventyay partner endpoint, following pagination.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $endpoint      API endpoint URL.
+	 * @param array  $settings      Import settings.
+	 * @param string $resource_type Partner resource type.
+	 * @return array|WP_Error Partner resources and metadata.
+	 */
+	private function fetch_eventyay_partner_resources( $endpoint, $settings, $resource_type ) {
+		$resources = array();
+		$next_url  = $endpoint;
+		$page      = 0;
+		$seen_urls = array();
+		$max_pages = absint( apply_filters( 'wpfaevent_eventyay_partner_import_max_pages', 20, $resource_type ) );
+
+		if ( ! $max_pages ) {
+			$max_pages = 20;
+		}
+
+		while ( $next_url ) {
+			if ( isset( $seen_urls[ $next_url ] ) ) {
+				return new WP_Error(
+					'wpfaevent_eventyay_partner_pagination_loop',
+					esc_html__( 'Eventyay sponsor/exhibitor pagination returned a repeated next URL.', 'wpfaevent' )
+				);
+			}
+
+			if ( $page >= $max_pages ) {
+				return new WP_Error(
+					'wpfaevent_eventyay_partner_page_limit',
+					esc_html__( 'Eventyay sponsor/exhibitor import stopped before completion because the pagination page limit was reached.', 'wpfaevent' )
+				);
+			}
+
+			$seen_urls[ $next_url ] = true;
+			++$page;
+
+			$current_url = $next_url;
+			$payload     = $this->fetch_eventyay_rest_json( $current_url, $settings['api_token'] );
+			if ( is_wp_error( $payload ) ) {
+				return $payload;
+			}
+
+			if ( isset( $payload['results'] ) && is_array( $payload['results'] ) ) {
+				foreach ( $payload['results'] as $resource ) {
+					if ( is_array( $resource ) ) {
+						$resources[] = $resource;
+					}
+				}
+
+				$next_url = ! empty( $payload['next'] ) ? $this->normalize_eventyay_next_url( $payload['next'], $current_url ) : '';
+				if ( is_wp_error( $next_url ) ) {
+					return $next_url;
+				}
+				continue;
+			}
+
+			if ( isset( $payload['data'] ) && is_array( $payload['data'] ) ) {
+				foreach ( $this->eventyay_list_value( $payload['data'] ) as $resource ) {
+					if ( is_array( $resource ) ) {
+						$resources[] = $resource;
+					}
+				}
+
+				$next_url = ! empty( $payload['links']['next'] ) ? $this->normalize_eventyay_next_url( $payload['links']['next'], $current_url ) : '';
+				if ( is_wp_error( $next_url ) ) {
+					return $next_url;
+				}
+				continue;
+			}
+
+			$resources[] = $payload;
+			$next_url    = '';
+		}
+
+		return array(
+			'resources' => $resources,
+			'pages'     => $page,
+			'endpoint'  => esc_url_raw( $endpoint ),
+		);
+	}
+
+	/**
+	 * Normalize Eventyay sponsor resources into dashboard sponsor records.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $resources Eventyay sponsor resources.
+	 * @param array $settings  Import settings.
+	 * @return array
+	 */
+	private function normalize_eventyay_sponsor_resources( $resources, $settings ) {
+		$sponsors = array();
+
+		foreach ( $resources as $resource ) {
+			$sponsor = $this->normalize_eventyay_sponsor_resource( $resource, $settings );
+			if ( ! empty( $sponsor['name'] ) ) {
+				$sponsors[] = $sponsor;
+			}
+		}
+
+		usort(
+			$sponsors,
+			static function ( $sponsor_a, $sponsor_b ) {
+				$level_a = isset( $sponsor_a['level'] ) ? absint( $sponsor_a['level'] ) : 0;
+				$level_b = isset( $sponsor_b['level'] ) ? absint( $sponsor_b['level'] ) : 0;
+
+				if ( $level_a !== $level_b ) {
+					if ( ! $level_a ) {
+						return 1;
+					}
+
+					if ( ! $level_b ) {
+						return -1;
+					}
+
+					return $level_a <=> $level_b;
+				}
+
+				return strcasecmp( $sponsor_a['name'], $sponsor_b['name'] );
+			}
+		);
+
+		return $sponsors;
+	}
+
+	/**
+	 * Normalize one Eventyay sponsor resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $sponsor_resource Eventyay sponsor resource.
+	 * @param array $settings Import settings.
+	 * @return array
+	 */
+	private function normalize_eventyay_sponsor_resource( $sponsor_resource, $settings ) {
+		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
+		$source_id        = $this->eventyay_resource_identifier( $sponsor_resource );
+		$name             = $this->eventyay_first_present_text( $sponsor_resource, array( 'name', 'title', 'label' ) );
+		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'type', 'level_name', 'level-name', 'tier', 'category' ) );
+		$level            = $this->eventyay_first_present_raw( $sponsor_resource, array( 'level', 'position', 'order', 'sort_order', 'sort-order' ) );
+
+		return array(
+			'id'          => $source_id ? 'eventyay-sponsor-' . sanitize_key( $source_id ) : 'eventyay-sponsor-' . sanitize_title( $name ),
+			'source'      => 'eventyay',
+			'eventyay_id' => sanitize_text_field( $source_id ),
+			'name'        => sanitize_text_field( $name ),
+			'description' => $this->eventyay_first_present_rich_text( $sponsor_resource, array( 'description', 'subtitle', 'summary' ) ),
+			'link'        => $this->eventyay_url_value( $this->eventyay_first_present_raw( $sponsor_resource, array( 'url', 'link', 'website', 'website-url', 'website_url' ) ), $settings['base_url'] ),
+			'image'       => $this->eventyay_url_value( $this->eventyay_first_present_raw( $sponsor_resource, array( 'logo-url', 'logo_url', 'logo', 'image', 'image-url', 'image_url' ) ), $settings['base_url'] ),
+			'type'        => sanitize_text_field( $type ),
+			'level'       => is_numeric( $level ) ? absint( $level ) : 0,
+		);
+	}
+
+	/**
+	 * Merge imported Eventyay sponsors with manually maintained dashboard groups.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $imported Imported sponsors.
+	 * @param array $existing Existing dashboard sponsor groups.
+	 * @return array
+	 */
+	private function merge_eventyay_sponsor_groups( $imported, $existing ) {
+		$existing = is_array( $existing ) ? $existing : array();
+		$groups   = array();
+
+		foreach ( $existing as $group ) {
+			if ( ! is_array( $group ) || $this->is_eventyay_sponsor_group( $group ) ) {
+				continue;
+			}
+
+			$groups[] = $group;
+		}
+
+		foreach ( $this->group_eventyay_sponsors( $imported ) as $group ) {
+			$groups[] = $group;
+		}
+
+		return array_values( $groups );
+	}
+
+	/**
+	 * Group imported sponsors by Eventyay type or level.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $sponsors Imported sponsors.
+	 * @return array
+	 */
+	private function group_eventyay_sponsors( $sponsors ) {
+		$groups = array();
+
+		foreach ( $sponsors as $sponsor ) {
+			$group_name = ! empty( $sponsor['type'] ) ? $sponsor['type'] : '';
+			if ( '' === trim( $group_name ) && ! empty( $sponsor['level'] ) ) {
+				$group_name = sprintf(
+					/* translators: %d: Sponsor level number. */
+					__( 'Level %d Sponsors', 'wpfaevent' ),
+					absint( $sponsor['level'] )
+				);
+			}
+
+			if ( '' === trim( $group_name ) ) {
+				$group_name = __( 'Sponsors', 'wpfaevent' );
+			}
+
+			$key = sanitize_key( $group_name );
+			if ( empty( $groups[ $key ] ) ) {
+				$groups[ $key ] = array(
+					'group_name'         => sanitize_text_field( $group_name ),
+					'source'             => 'eventyay',
+					'eventyay_group_key' => $key,
+					'centered'           => false,
+					'logo_size'          => 160,
+					'sponsors'           => array(),
+				);
+			}
+
+			$groups[ $key ]['sponsors'][] = $sponsor;
+		}
+
+		return array_values( $groups );
+	}
+
+	/**
+	 * Determine whether a sponsor group is owned by Eventyay import.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $group Sponsor group.
+	 * @return bool
+	 */
+	private function is_eventyay_sponsor_group( $group ) {
+		if ( ! empty( $group['source'] ) && 'eventyay' === $group['source'] ) {
+			return true;
+		}
+
+		if ( empty( $group['sponsors'] ) || ! is_array( $group['sponsors'] ) ) {
+			return false;
+		}
+
+		foreach ( $group['sponsors'] as $sponsor ) {
+			if ( is_array( $sponsor ) && ! empty( $sponsor['source'] ) && 'eventyay' === $sponsor['source'] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalize Eventyay exhibitor resources.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $resources Eventyay exhibitor resources.
+	 * @param array $settings  Import settings.
+	 * @return array
+	 */
+	private function normalize_eventyay_exhibitor_resources( $resources, $settings ) {
+		$exhibitors = array();
+
+		foreach ( $resources as $resource ) {
+			$exhibitor = $this->normalize_eventyay_exhibitor_resource( $resource, $settings );
+			if ( ! empty( $exhibitor['name'] ) ) {
+				$exhibitors[] = $exhibitor;
+			}
+		}
+
+		usort(
+			$exhibitors,
+			static function ( $exhibitor_a, $exhibitor_b ) {
+				$position_a = isset( $exhibitor_a['position'] ) ? absint( $exhibitor_a['position'] ) : 0;
+				$position_b = isset( $exhibitor_b['position'] ) ? absint( $exhibitor_b['position'] ) : 0;
+
+				if ( $position_a !== $position_b ) {
+					if ( ! $position_a ) {
+						return 1;
+					}
+
+					if ( ! $position_b ) {
+						return -1;
+					}
+
+					return $position_a <=> $position_b;
+				}
+
+				return strcasecmp( $exhibitor_a['name'], $exhibitor_b['name'] );
+			}
+		);
+
+		return $exhibitors;
+	}
+
+	/**
+	 * Normalize one Eventyay exhibitor resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $exhibitor_resource Eventyay exhibitor resource.
+	 * @param array $settings Import settings.
+	 * @return array
+	 */
+	private function normalize_eventyay_exhibitor_resource( $exhibitor_resource, $settings ) {
+		$exhibitor_resource = $this->normalize_eventyay_api_resource( $exhibitor_resource );
+		$source_id          = $this->eventyay_resource_identifier( $exhibitor_resource );
+		$name               = $this->eventyay_first_present_text( $exhibitor_resource, array( 'name', 'title', 'label' ) );
+		$position           = $this->eventyay_first_present_raw( $exhibitor_resource, array( 'position', 'order', 'sort_order', 'sort-order' ) );
+
+		return array(
+			'id'            => $source_id ? 'eventyay-exhibitor-' . sanitize_key( $source_id ) : 'eventyay-exhibitor-' . sanitize_title( $name ),
+			'source'        => 'eventyay',
+			'eventyay_id'   => sanitize_text_field( $source_id ),
+			'name'          => sanitize_text_field( $name ),
+			'description'   => $this->eventyay_first_present_rich_text( $exhibitor_resource, array( 'description', 'subtitle', 'summary' ) ),
+			'link'          => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'url', 'link', 'website', 'website-url', 'website_url' ) ), $settings['base_url'] ),
+			'logo'          => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'logo-url', 'logo_url', 'logo', 'image', 'image-url', 'image_url' ) ), $settings['base_url'] ),
+			'banner'        => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'banner-url', 'banner_url', 'banner' ) ), $settings['base_url'] ),
+			'video'         => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'video-url', 'video_url', 'video' ) ), $settings['base_url'] ),
+			'slides'        => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'slides-url', 'slides_url', 'slides' ) ), $settings['base_url'] ),
+			'contact_email' => sanitize_email( $this->eventyay_first_present_text( $exhibitor_resource, array( 'contact-email', 'contact_email', 'email' ) ) ),
+			'contact_link'  => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'contact-link', 'contact_link' ) ), $settings['base_url'] ),
+			'position'      => is_numeric( $position ) ? absint( $position ) : 0,
+		);
+	}
+
+	/**
+	 * Merge imported Eventyay flat records with manually maintained records.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $imported Imported records.
+	 * @param array $existing Existing records.
+	 * @return array
+	 */
+	private function merge_eventyay_flat_records( $imported, $existing ) {
+		$existing = is_array( $existing ) ? $existing : array();
+		$records  = array();
+
+		foreach ( $existing as $record ) {
+			if ( ! is_array( $record ) || ( ! empty( $record['source'] ) && 'eventyay' === $record['source'] ) ) {
+				continue;
+			}
+
+			$records[] = $record;
+		}
+
+		foreach ( $imported as $record ) {
+			$records[] = $record;
+		}
+
+		return array_values( $records );
+	}
+
+	/**
+	 * Import speakers and session data for an Eventyay event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $event_id   Imported WordPress event post ID.
+	 * @param array  $settings   Import settings.
+	 * @param string $event_slug Eventyay event slug.
+	 * @return array|WP_Error Import result.
+	 */
+	private function import_eventyay_event_program( $event_id, $settings, $event_slug ) {
+		$endpoint = $this->build_eventyay_submissions_endpoint( $settings, $event_slug );
+		$program  = array(
+			'speakers'      => array(),
+			'sessions'      => array(),
+			'session_count' => 0,
+		);
+		$error    = null;
+
+		if ( is_wp_error( $endpoint ) ) {
+			$error = $endpoint;
+		} else {
+			$fetched = $this->fetch_eventyay_program_resources( $endpoint, $settings );
+			if ( is_wp_error( $fetched ) ) {
+				$error = $fetched;
+			} else {
+				$program = $this->normalize_eventyay_submissions_payload( $fetched['submissions'], $settings, $event_slug );
+			}
+		}
+
+		$speakers = $this->fetch_eventyay_event_speaker_program( $settings, $event_slug );
+		if ( is_wp_error( $speakers ) ) {
+			if ( null === $error ) {
+				$error = $speakers;
+			}
+		} else {
+			$program = $this->merge_eventyay_program_payloads( $program, $speakers );
+		}
+
+		$slots = $this->fetch_eventyay_event_slot_program( $settings, $event_slug );
+		if ( is_wp_error( $slots ) ) {
+			if ( null === $error ) {
+				$error = $slots;
+			}
+		} else {
+			$program = $this->merge_eventyay_program_payloads( $program, $slots );
+		}
+
+		if ( $error && empty( $program['speakers'] ) && empty( $program['sessions'] ) ) {
+			return $error;
+		}
+
+		$cpt_result = array(
+			'created' => 0,
+			'updated' => 0,
+		);
+
+		$existing_speakers  = $this->read_dashboard_json_file( 'speakers-' . absint( $event_id ) . '.json', array() );
+		$dashboard_speakers = $this->merge_dashboard_speaker_state( $program['speakers'], $existing_speakers );
+		$write_result       = $this->write_dashboard_json_file( 'speakers-' . absint( $event_id ) . '.json', $dashboard_speakers );
+
+		if ( is_wp_error( $write_result ) ) {
+			return $write_result;
+		}
+
+		$cpt_result = $this->sync_eventyay_speaker_posts( $dashboard_speakers, $event_id );
+
+		$schedule_rows = $this->write_eventyay_schedule_table( $event_id, $program['sessions'] );
+		if ( is_wp_error( $schedule_rows ) ) {
+			return $schedule_rows;
+		}
+
+		return array(
+			'speaker_count'    => count( $program['speakers'] ),
+			'session_count'    => $program['session_count'],
+			'created_speakers' => $cpt_result['created'],
+			'updated_speakers' => $cpt_result['updated'],
+			'schedule_rows'    => $schedule_rows,
+		);
+	}
+
+	/**
+	 * Write imported Eventyay sessions into the dashboard schedule table.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int   $event_id Imported WordPress event post ID.
+	 * @param array $sessions Normalized Eventyay sessions.
+	 * @return int|WP_Error Number of imported schedule data rows.
+	 */
+	private function write_eventyay_schedule_table( $event_id, $sessions ) {
+		$event_id = absint( $event_id );
+		$sessions = is_array( $sessions ) ? $sessions : array();
+
+		if ( ! $event_id ) {
+			return 0;
+		}
+
+		$filename          = 'schedule-' . $event_id . '.json';
+		$existing_schedule = $this->read_dashboard_json_file( $filename, array() );
+		if (
+			is_array( $existing_schedule )
+			&& ! empty( $existing_schedule['name'] )
+			&& ( empty( $existing_schedule['source'] ) || 'eventyay' !== $existing_schedule['source'] )
+		) {
+			return 0;
+		}
+
+		$table        = $this->build_eventyay_schedule_table( $sessions );
+		$write_result = $this->write_dashboard_json_file( $filename, $table );
+		if ( is_wp_error( $write_result ) ) {
+			return $write_result;
+		}
+
+		return max( 0, absint( $table['rows'] ) - 1 );
+	}
+
+	/**
+	 * Build the dashboard schedule table payload from Eventyay sessions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $sessions Normalized Eventyay sessions.
+	 * @return array
+	 */
+	private function build_eventyay_schedule_table( $sessions ) {
+		usort(
+			$sessions,
+			static function ( $session_a, $session_b ) {
+				$a_time = ! empty( $session_a['starts_at'] ) ? $session_a['starts_at'] : trim( (string) ( isset( $session_a['date'] ) ? $session_a['date'] : '' ) . ' ' . ( isset( $session_a['time'] ) ? $session_a['time'] : '' ) );
+				$b_time = ! empty( $session_b['starts_at'] ) ? $session_b['starts_at'] : trim( (string) ( isset( $session_b['date'] ) ? $session_b['date'] : '' ) . ' ' . ( isset( $session_b['time'] ) ? $session_b['time'] : '' ) );
+
+				return strcmp( $a_time, $b_time );
+			}
+		);
+
+		$rows              = array(
+			array(
+				__( 'Date', 'wpfaevent' ),
+				__( 'Time', 'wpfaevent' ),
+				__( 'Session', 'wpfaevent' ),
+				__( 'Speaker(s)', 'wpfaevent' ),
+				__( 'Track', 'wpfaevent' ),
+				__( 'Room', 'wpfaevent' ),
+			),
+		);
+		$schedule_sessions = array();
+
+		foreach ( $sessions as $session ) {
+			if ( ! is_array( $session ) ) {
+				continue;
+			}
+
+			$starts_at = isset( $session['starts_at'] ) ? sanitize_text_field( $session['starts_at'] ) : '';
+			$ends_at   = isset( $session['ends_at'] ) ? sanitize_text_field( $session['ends_at'] ) : '';
+			$date      = isset( $session['date'] ) ? sanitize_text_field( $session['date'] ) : '';
+			$time      = isset( $session['time'] ) ? sanitize_text_field( $session['time'] ) : '';
+
+			if ( ! empty( $session['end_time'] ) ) {
+				$end_time = sanitize_text_field( $session['end_time'] );
+				$time    .= $time ? ' - ' . $end_time : $end_time;
+			}
+
+			$speakers = '';
+			if ( ! empty( $session['speakers'] ) && is_array( $session['speakers'] ) ) {
+				$speakers = implode( ', ', array_map( 'sanitize_text_field', $session['speakers'] ) );
+			}
+
+			$title = isset( $session['title'] ) ? sanitize_text_field( $session['title'] ) : '';
+			$track = isset( $session['track'] ) ? sanitize_text_field( $session['track'] ) : '';
+			$room  = isset( $session['room'] ) ? sanitize_text_field( $session['room'] ) : '';
+
+			$rows[] = array(
+				$date,
+				sanitize_text_field( $time ),
+				$title,
+				$speakers,
+				$track,
+				$room,
+			);
+
+			$schedule_sessions[] = array(
+				'title'     => $title,
+				'date'      => $date,
+				'time'      => sanitize_text_field( $time ),
+				'speakers'  => $speakers,
+				'track'     => $track,
+				'room'      => $room,
+				'starts_at' => $starts_at,
+				'ends_at'   => $ends_at,
+			);
+		}
+
+		return array(
+			'name'     => __( 'Eventyay Schedule', 'wpfaevent' ),
+			'rows'     => count( $rows ),
+			'cols'     => 6,
+			'data'     => $rows,
+			'sessions' => $schedule_sessions,
+			'source'   => 'eventyay',
+		);
+	}
+
+	/**
+	 * Fetch Eventyay submission resources, following paginated list responses.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $endpoint Submission endpoint.
+	 * @param array  $settings Import settings.
+	 * @return array|WP_Error Submission resources and metadata.
+	 */
+	private function fetch_eventyay_program_resources( $endpoint, $settings ) {
+		$submissions = array();
+		$next_url    = $endpoint;
+		$page        = 0;
+		$seen_urls   = array();
+		$max_pages   = absint( apply_filters( 'wpfaevent_eventyay_program_import_max_pages', 20 ) );
+
+		if ( ! $max_pages ) {
+			$max_pages = 20;
+		}
+
+		while ( $next_url ) {
+			if ( isset( $seen_urls[ $next_url ] ) ) {
+				return new WP_Error(
+					'wpfaevent_eventyay_program_pagination_loop',
+					esc_html__( 'Eventyay program pagination returned a repeated next URL.', 'wpfaevent' )
+				);
+			}
+
+			if ( $page >= $max_pages ) {
+				return new WP_Error(
+					'wpfaevent_eventyay_program_page_limit',
+					esc_html__( 'Eventyay program import stopped before completion because the pagination page limit was reached.', 'wpfaevent' )
+				);
+			}
+
+			$seen_urls[ $next_url ] = true;
+			++$page;
+
+			$current_url = $next_url;
+			$payload     = $this->fetch_eventyay_rest_json( $current_url, $settings['api_token'] );
+			if ( is_wp_error( $payload ) ) {
+				return $payload;
+			}
+
+			if ( isset( $payload['results'] ) && is_array( $payload['results'] ) ) {
+				foreach ( $payload['results'] as $submission ) {
+					if ( is_array( $submission ) ) {
+						$submissions[] = $submission;
+					}
+				}
+
+				$next_url = ! empty( $payload['next'] ) ? $this->normalize_eventyay_next_url( $payload['next'], $current_url ) : '';
+				if ( is_wp_error( $next_url ) ) {
+					return $next_url;
+				}
+				continue;
+			}
+
+			$submissions[] = $payload;
+			$next_url      = '';
+		}
+
+		return array(
+			'submissions' => $submissions,
+			'pages'       => $page,
+		);
+	}
+
+	/**
+	 * Fetch and normalize speaker profiles for an Eventyay event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $settings   Import settings.
+	 * @param string $event_slug Eventyay event slug.
+	 * @return array|WP_Error Normalized speaker program payload.
+	 */
+	private function fetch_eventyay_event_speaker_program( $settings, $event_slug ) {
+		$endpoint = $this->build_eventyay_speakers_endpoint( $settings, $event_slug );
+		if ( is_wp_error( $endpoint ) ) {
+			return $endpoint;
+		}
+
+		$fetched = $this->fetch_eventyay_speaker_resources( $endpoint, $settings );
+		if ( is_wp_error( $fetched ) ) {
+			return $fetched;
+		}
+
+		return $this->normalize_eventyay_speakers_payload( $fetched['speakers'], $settings, $event_slug );
+	}
+
+	/**
+	 * Fetch Eventyay speaker resources, following paginated list responses.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $endpoint Speaker endpoint.
+	 * @param array  $settings Import settings.
+	 * @return array|WP_Error Speaker resources and metadata.
+	 */
+	private function fetch_eventyay_speaker_resources( $endpoint, $settings ) {
+		$speakers  = array();
+		$next_url  = $endpoint;
+		$page      = 0;
+		$seen_urls = array();
+		$max_pages = absint( apply_filters( 'wpfaevent_eventyay_speaker_import_max_pages', 20 ) );
+
+		if ( ! $max_pages ) {
+			$max_pages = 20;
+		}
+
+		while ( $next_url ) {
+			if ( isset( $seen_urls[ $next_url ] ) ) {
+				return new WP_Error(
+					'wpfaevent_eventyay_speaker_pagination_loop',
+					esc_html__( 'Eventyay speaker pagination returned a repeated next URL.', 'wpfaevent' )
+				);
+			}
+
+			if ( $page >= $max_pages ) {
+				return new WP_Error(
+					'wpfaevent_eventyay_speaker_page_limit',
+					esc_html__( 'Eventyay speaker import stopped before completion because the pagination page limit was reached.', 'wpfaevent' )
+				);
+			}
+
+			$seen_urls[ $next_url ] = true;
+			++$page;
+
+			$current_url = $next_url;
+			$payload     = $this->fetch_eventyay_rest_json( $current_url, $settings['api_token'] );
+			if ( is_wp_error( $payload ) ) {
+				return $payload;
+			}
+
+			if ( isset( $payload['results'] ) && is_array( $payload['results'] ) ) {
+				foreach ( $payload['results'] as $speaker ) {
+					if ( is_array( $speaker ) ) {
+						$speakers[] = $speaker;
+					}
+				}
+
+				$next_url = ! empty( $payload['next'] ) ? $this->normalize_eventyay_next_url( $payload['next'], $current_url ) : '';
+				if ( is_wp_error( $next_url ) ) {
+					return $next_url;
+				}
+				continue;
+			}
+
+			if ( isset( $payload['data'] ) && is_array( $payload['data'] ) ) {
+				foreach ( $this->eventyay_list_value( $payload['data'] ) as $speaker ) {
+					if ( is_array( $speaker ) ) {
+						$speakers[] = $speaker;
+					}
+				}
+
+				$next_url = ! empty( $payload['links']['next'] ) ? $this->normalize_eventyay_next_url( $payload['links']['next'], $current_url ) : '';
+				if ( is_wp_error( $next_url ) ) {
+					return $next_url;
+				}
+				continue;
+			}
+
+			$speakers[] = $payload;
+			$next_url   = '';
+		}
+
+		return array(
+			'speakers' => $speakers,
+			'pages'    => $page,
+		);
+	}
+
+	/**
+	 * Fetch and normalize scheduled slots for an Eventyay event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $settings   Import settings.
+	 * @param string $event_slug Eventyay event slug.
+	 * @return array|WP_Error Normalized slot program payload.
+	 */
+	private function fetch_eventyay_event_slot_program( $settings, $event_slug ) {
+		$endpoint = $this->build_eventyay_slots_endpoint( $settings, $event_slug );
+		if ( is_wp_error( $endpoint ) ) {
+			return $endpoint;
+		}
+
+		$fetched = $this->fetch_eventyay_slot_resources( $endpoint, $settings );
+		if ( is_wp_error( $fetched ) ) {
+			return $fetched;
+		}
+
+		return $this->normalize_eventyay_slots_payload( $fetched['slots'], $settings, $event_slug );
+	}
+
+	/**
+	 * Fetch Eventyay slot resources, following paginated list responses.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $endpoint Slot endpoint.
+	 * @param array  $settings Import settings.
+	 * @return array|WP_Error Slot resources and metadata.
+	 */
+	private function fetch_eventyay_slot_resources( $endpoint, $settings ) {
+		$slots     = array();
+		$next_url  = $endpoint;
+		$page      = 0;
+		$seen_urls = array();
+		$max_pages = absint( apply_filters( 'wpfaevent_eventyay_slot_import_max_pages', 20 ) );
+
+		if ( ! $max_pages ) {
+			$max_pages = 20;
+		}
+
+		while ( $next_url ) {
+			if ( isset( $seen_urls[ $next_url ] ) ) {
+				return new WP_Error(
+					'wpfaevent_eventyay_slot_pagination_loop',
+					esc_html__( 'Eventyay slot pagination returned a repeated next URL.', 'wpfaevent' )
+				);
+			}
+
+			if ( $page >= $max_pages ) {
+				return new WP_Error(
+					'wpfaevent_eventyay_slot_page_limit',
+					esc_html__( 'Eventyay slot import stopped before completion because the pagination page limit was reached.', 'wpfaevent' )
+				);
+			}
+
+			$seen_urls[ $next_url ] = true;
+			++$page;
+
+			$current_url = $next_url;
+			$payload     = $this->fetch_eventyay_rest_json( $current_url, $settings['api_token'] );
+			if ( is_wp_error( $payload ) ) {
+				return $payload;
+			}
+
+			if ( isset( $payload['results'] ) && is_array( $payload['results'] ) ) {
+				foreach ( $payload['results'] as $slot ) {
+					if ( is_array( $slot ) ) {
+						$slots[] = $slot;
+					}
+				}
+
+				$next_url = ! empty( $payload['next'] ) ? $this->normalize_eventyay_next_url( $payload['next'], $current_url ) : '';
+				if ( is_wp_error( $next_url ) ) {
+					return $next_url;
+				}
+				continue;
+			}
+
+			if ( isset( $payload['data'] ) && is_array( $payload['data'] ) ) {
+				foreach ( $this->eventyay_list_value( $payload['data'] ) as $slot ) {
+					if ( is_array( $slot ) ) {
+						$slots[] = $slot;
+					}
+				}
+
+				$next_url = ! empty( $payload['links']['next'] ) ? $this->normalize_eventyay_next_url( $payload['links']['next'], $current_url ) : '';
+				if ( is_wp_error( $next_url ) ) {
+					return $next_url;
+				}
+				continue;
+			}
+
+			$slots[]  = $payload;
+			$next_url = '';
+		}
+
+		return array(
+			'slots' => $slots,
+			'pages' => $page,
+		);
+	}
+
 	/**
 	 * Normalize a paginated Eventyay next URL.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $next_url      Raw next URL.
+	 * @param string $next_url Raw next URL.
 	 * @param string $reference_url Current request URL used to resolve relative next links.
 	 * @return string|WP_Error
 	 */
@@ -1240,24 +2511,6 @@ class Wpfaevent_Eventyay_Importer {
 	}
 
 	/**
-	 * Decode an Eventyay error body if possible.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $body Response body.
-	 * @return array|string
-	 */
-	private function decode_eventyay_error_body( $body ) {
-		$decoded = json_decode( $body, true );
-
-		if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
-			return $decoded;
-		}
-
-		return $this->truncate_string( $body );
-	}
-
-	/**
 	 * Build request headers for Eventyay REST calls.
 	 *
 	 * @since 1.0.0
@@ -1450,6 +2703,70 @@ class Wpfaevent_Eventyay_Importer {
 		return sanitize_text_field( $this->eventyay_location_text_value( $location ) );
 	}
 
+		/**
+		 * Get Eventyay event languages from likely field shapes.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $event Eventyay event resource.
+		 * @return array<string>
+		 */
+	private function eventyay_event_languages( $event ) {
+		$languages = $this->eventyay_event_first_present_raw(
+			$event,
+			array(
+				'languages',
+				'language',
+				'event_languages',
+				'event-languages',
+				'event_language',
+				'event-language',
+				'supported_languages',
+				'supported-languages',
+				'content_languages',
+				'content-languages',
+				'content_locales',
+				'content-locales',
+				'locales',
+				'locale',
+			),
+			true
+		);
+
+		return Wpfaevent_Meta_Event::sanitize_language_list( $languages );
+	}
+
+	/**
+	 * Get Eventyay event theme colors from event settings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $event Eventyay event resource.
+	 * @return array<string, string>
+	 */
+	private function eventyay_event_colors( $event ) {
+		$color_fields = array(
+			'wpfa_event_primary_color'          => array( 'primary_color', 'primary-color', 'primaryColor', 'event_color', 'event-color', 'theme_color', 'theme-color', 'color' ),
+			'wpfa_event_hover_button_color'     => array( 'hover_button_color', 'hover-button-color', 'hoverButtonColor', 'button_hover_color', 'button-hover-color' ),
+			'wpfa_event_theme_background_color' => array( 'theme_color_background', 'theme-color-background', 'themeColorBackground', 'background_color', 'background-color' ),
+			'wpfa_event_theme_success_color'    => array( 'theme_color_success', 'theme-color-success', 'themeColorSuccess', 'success_color', 'success-color' ),
+			'wpfa_event_theme_danger_color'     => array( 'theme_color_danger', 'theme-color-danger', 'themeColorDanger', 'danger_color', 'danger-color' ),
+		);
+		$colors       = array();
+
+		foreach ( $color_fields as $meta_key => $candidate_keys ) {
+			$color = Wpfaevent_Meta_Event::sanitize_color_value(
+				$this->eventyay_event_first_present_raw( $event, $candidate_keys, true )
+			);
+
+			if ( $color ) {
+				$colors[ $meta_key ] = $color;
+			}
+		}
+
+		return $colors;
+	}
+
 			/**
 			 * Create or update one imported Eventyay event post.
 			 *
@@ -1517,6 +2834,8 @@ class Wpfaevent_Eventyay_Importer {
 		$normalized_ends_at   = $this->normalize_eventyay_datetime( $end_datetime );
 		$location             = $this->eventyay_event_location( $event );
 		$event_url            = $this->eventyay_public_event_url( $event, $settings, $event_slug );
+		$languages            = $this->eventyay_event_languages( $event );
+		$colors               = $this->eventyay_event_colors( $event );
 
 		$this->update_or_delete_post_meta( $saved_id, 'wpfa_event_start_date', $start_date );
 		$this->update_or_delete_post_meta( $saved_id, 'wpfa_event_end_date', $end_date );
@@ -1528,6 +2847,13 @@ class Wpfaevent_Eventyay_Importer {
 		$this->update_or_delete_post_meta( $saved_id, 'wpfa_event_ends_at', $normalized_ends_at );
 		$this->update_or_delete_post_meta( $saved_id, 'wpfa_event_location', $location );
 		$this->update_or_delete_post_meta( $saved_id, 'wpfa_event_url', $event_url );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_event_languages', $languages );
+
+		if ( ! empty( $colors ) || $this->eventyay_event_has_settings_payload( $event ) ) {
+			foreach ( Wpfaevent_Meta_Event::get_event_color_meta_fields() as $meta_key => $label ) {
+				$this->update_or_delete_post_meta( $saved_id, $meta_key, isset( $colors[ $meta_key ] ) ? $colors[ $meta_key ] : '' );
+			}
+		}
 
 		// Keep older dashboard/landing metadata in sync with the canonical event meta.
 		$this->update_or_delete_post_meta( $saved_id, '_event_date', $start_date );
@@ -1553,13 +2879,942 @@ class Wpfaevent_Eventyay_Importer {
 	}
 
 	/**
+	 * Sync imported Eventyay event details into dashboard JSON data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $event_id   Imported WordPress event post ID.
+	 * @param array  $event      Eventyay event resource.
+	 * @param array  $settings   Import settings.
+	 * @param string $event_slug Eventyay event slug.
+	 * @return array|WP_Error Dashboard sync result.
+	 */
+	private function sync_eventyay_event_dashboard_data( $event_id, $event, $settings, $event_slug ) {
+		$event_id = absint( $event_id );
+		if ( ! $event_id ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_missing_dashboard_event',
+				esc_html__( 'Could not update dashboard data for an imported Eventyay event without an event ID.', 'wpfaevent' )
+			);
+		}
+
+		$settings_file      = 'site-settings-' . $event_id . '.json';
+		$dashboard_settings = $this->read_dashboard_json_file( $settings_file, array() );
+		$dashboard_settings = is_array( $dashboard_settings ) ? $dashboard_settings : array();
+		$description        = $this->eventyay_event_description( $event );
+		$event_url          = $this->eventyay_public_event_url( $event, $settings, $event_slug );
+		$about_updated      = 0;
+
+		$default_section_visibility = array(
+			'about'      => true,
+			'speakers'   => true,
+			'schedule'   => true,
+			'sponsors'   => true,
+			'exhibitors' => true,
+		);
+
+		if ( empty( $dashboard_settings['section_visibility'] ) || ! is_array( $dashboard_settings['section_visibility'] ) ) {
+			$dashboard_settings['section_visibility'] = $default_section_visibility;
+		} else {
+			$dashboard_settings['section_visibility'] = wp_parse_args( $dashboard_settings['section_visibility'], $default_section_visibility );
+		}
+
+		if ( '' !== trim( $description ) ) {
+			$dashboard_settings['about_section_content'] = wp_kses_post( $description );
+			$about_updated                               = 1;
+		} elseif ( ! isset( $dashboard_settings['about_section_content'] ) ) {
+			$dashboard_settings['about_section_content'] = '';
+		}
+
+		if ( empty( $dashboard_settings['reg_button_text'] ) ) {
+			$dashboard_settings['reg_button_text'] = __( 'Get Tickets', 'wpfaevent' );
+		}
+
+		if ( $event_url ) {
+			$dashboard_settings['reg_button_link'] = esc_url_raw( $event_url );
+		}
+
+		$write_result = $this->write_dashboard_json_file( $settings_file, $dashboard_settings );
+		if ( is_wp_error( $write_result ) ) {
+			return $write_result;
+		}
+
+		return array(
+			'about_updated' => $about_updated,
+		);
+	}
+
+	/**
+	 * Normalize Eventyay submissions into dashboard speaker data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $submissions Eventyay submission resources.
+	 * @param array  $settings    Import settings.
+	 * @param string $event_slug  Eventyay event slug.
+	 * @return array
+	 */
+	private function normalize_eventyay_submissions_payload( $submissions, $settings, $event_slug ) {
+		$speakers      = array();
+		$sessions      = array();
+		$session_count = 0;
+
+		if ( ! is_array( $submissions ) ) {
+			return array(
+				'speakers'      => array(),
+				'sessions'      => array(),
+				'session_count' => 0,
+			);
+		}
+
+		foreach ( $submissions as $submission ) {
+			if ( ! is_array( $submission ) ) {
+				continue;
+			}
+
+			$submission        = $this->normalize_eventyay_api_resource( $submission );
+			$speaker_resources = $this->eventyay_list_value( isset( $submission['speakers'] ) ? $submission['speakers'] : array() );
+			$session           = $this->normalize_eventyay_submission_session( $submission );
+			$speaker_names     = array();
+
+			foreach ( $speaker_resources as $speaker_resource ) {
+				if ( ! is_array( $speaker_resource ) ) {
+					continue;
+				}
+
+				$speaker = $this->normalize_eventyay_submission_speaker( $speaker_resource, $settings, $event_slug );
+				if ( empty( $speaker['name'] ) ) {
+					continue;
+				}
+
+				$speaker_names[] = $speaker['name'];
+
+				if ( empty( $speaker['category'] ) && ! empty( $session['track'] ) ) {
+					$speaker['category'] = $session['track'];
+				}
+
+				$this->merge_eventyay_speaker( $speakers, $speaker, $session );
+			}
+
+			$session['speakers'] = array_values( array_unique( $speaker_names ) );
+			if ( $this->eventyay_session_has_content( $session ) ) {
+				$sessions[] = $session;
+				++$session_count;
+			}
+		}
+
+		return array(
+			'speakers'      => array_values( $speakers ),
+			'sessions'      => array_values( $sessions ),
+			'session_count' => $session_count,
+		);
+	}
+
+	/**
+	 * Normalize Eventyay speaker profile resources into dashboard speaker data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $speaker_resources Eventyay speaker resources.
+	 * @param array  $settings          Import settings.
+	 * @param string $event_slug        Eventyay event slug.
+	 * @return array
+	 */
+	private function normalize_eventyay_speakers_payload( $speaker_resources, $settings, $event_slug ) {
+		$speakers = array();
+		$sessions = array();
+
+		if ( ! is_array( $speaker_resources ) ) {
+			return array(
+				'speakers'      => array(),
+				'sessions'      => array(),
+				'session_count' => 0,
+			);
+		}
+
+		foreach ( $speaker_resources as $speaker_resource ) {
+			if ( ! is_array( $speaker_resource ) ) {
+				continue;
+			}
+
+			$speaker_resource = $this->normalize_eventyay_api_resource( $speaker_resource );
+			$speaker          = $this->normalize_eventyay_submission_speaker( $speaker_resource, $settings, $event_slug );
+			if ( empty( $speaker['name'] ) ) {
+				continue;
+			}
+
+			$speaker_sessions = $this->eventyay_list_value( $this->eventyay_first_present_raw( $speaker_resource, array( 'submissions', 'sessions', 'talks' ) ) );
+			if ( empty( $speaker_sessions ) ) {
+				$this->merge_eventyay_speaker( $speakers, $speaker, array() );
+				continue;
+			}
+
+			foreach ( $speaker_sessions as $session_resource ) {
+				if ( ! is_array( $session_resource ) ) {
+					continue;
+				}
+
+				$session             = $this->normalize_eventyay_submission_session( $this->normalize_eventyay_api_resource( $session_resource ) );
+				$session['speakers'] = array_values( array_unique( array( $speaker['name'] ) ) );
+				$speaker['category'] = empty( $speaker['category'] ) && ! empty( $session['track'] ) ? $session['track'] : $speaker['category'];
+				$sessions            = $this->merge_eventyay_session_payload( $sessions, $session );
+				$this->merge_eventyay_speaker( $speakers, $speaker, $session );
+			}
+		}
+
+		return array(
+			'speakers'      => array_values( $speakers ),
+			'sessions'      => array_values( $sessions ),
+			'session_count' => count( $sessions ),
+		);
+	}
+
+	/**
+	 * Normalize Eventyay schedule slot resources into dashboard speaker and session data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $slot_resources Eventyay slot resources.
+	 * @param array  $settings       Import settings.
+	 * @param string $event_slug     Eventyay event slug.
+	 * @return array
+	 */
+	private function normalize_eventyay_slots_payload( $slot_resources, $settings, $event_slug ) {
+		$speakers = array();
+		$sessions = array();
+
+		if ( ! is_array( $slot_resources ) ) {
+			return array(
+				'speakers'      => array(),
+				'sessions'      => array(),
+				'session_count' => 0,
+			);
+		}
+
+		foreach ( $slot_resources as $slot_resource ) {
+			if ( ! is_array( $slot_resource ) ) {
+				continue;
+			}
+
+			$slot_resource = $this->normalize_eventyay_api_resource( $slot_resource );
+			$submission    = isset( $slot_resource['submission'] ) && is_array( $slot_resource['submission'] )
+				? $this->normalize_eventyay_api_resource( $slot_resource['submission'] )
+				: array();
+			$session       = $this->normalize_eventyay_slot_session( $slot_resource, $submission );
+			$speaker_names = array();
+
+			$speaker_resources = $this->eventyay_list_value( isset( $submission['speakers'] ) ? $submission['speakers'] : array() );
+			foreach ( $speaker_resources as $speaker_resource ) {
+				if ( ! is_array( $speaker_resource ) ) {
+					continue;
+				}
+
+				$speaker = $this->normalize_eventyay_submission_speaker( $speaker_resource, $settings, $event_slug );
+				if ( empty( $speaker['name'] ) ) {
+					continue;
+				}
+
+				$speaker_names[] = $speaker['name'];
+
+				if ( empty( $speaker['category'] ) && ! empty( $session['track'] ) ) {
+					$speaker['category'] = $session['track'];
+				}
+
+				$this->merge_eventyay_speaker( $speakers, $speaker, $session );
+			}
+
+			$session['speakers'] = array_values( array_unique( $speaker_names ) );
+			$sessions            = $this->merge_eventyay_session_payload( $sessions, $session );
+		}
+
+		return array(
+			'speakers'      => array_values( $speakers ),
+			'sessions'      => array_values( $sessions ),
+			'session_count' => count( $sessions ),
+		);
+	}
+
+	/**
+	 * Merge two normalized Eventyay program payloads.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $base  Base program payload.
+	 * @param array $extra Extra program payload.
+	 * @return array
+	 */
+	private function merge_eventyay_program_payloads( $base, $extra ) {
+		$base  = is_array( $base ) ? $base : array();
+		$extra = is_array( $extra ) ? $extra : array();
+
+		$merged_speakers = array();
+		foreach ( array_merge( isset( $base['speakers'] ) && is_array( $base['speakers'] ) ? $base['speakers'] : array(), isset( $extra['speakers'] ) && is_array( $extra['speakers'] ) ? $extra['speakers'] : array() ) as $speaker ) {
+			if ( ! is_array( $speaker ) || empty( $speaker['name'] ) ) {
+				continue;
+			}
+
+			$this->merge_eventyay_speaker( $merged_speakers, $speaker, array() );
+			if ( ! empty( $speaker['sessions'] ) && is_array( $speaker['sessions'] ) ) {
+				foreach ( $speaker['sessions'] as $session ) {
+					if ( is_array( $session ) ) {
+						$this->merge_eventyay_speaker( $merged_speakers, $speaker, $session );
+					}
+				}
+			}
+		}
+
+		$merged_sessions = array();
+		foreach ( array_merge( isset( $base['sessions'] ) && is_array( $base['sessions'] ) ? $base['sessions'] : array(), isset( $extra['sessions'] ) && is_array( $extra['sessions'] ) ? $extra['sessions'] : array() ) as $session ) {
+			if ( is_array( $session ) ) {
+				$merged_sessions = $this->merge_eventyay_session_payload( $merged_sessions, $session );
+			}
+		}
+
+		return array(
+			'speakers'      => array_values( $merged_speakers ),
+			'sessions'      => array_values( $merged_sessions ),
+			'session_count' => count( $merged_sessions ),
+		);
+	}
+
+	/**
+	 * Add a session to a normalized session list if it is not already present.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $sessions Session list.
+	 * @param array $session  Session payload.
+	 * @return array
+	 */
+	private function merge_eventyay_session_payload( $sessions, $session ) {
+		if ( ! $this->eventyay_session_has_content( $session ) ) {
+			return $sessions;
+		}
+
+		$key = ! empty( $session['id'] ) ? 'id:' . sanitize_key( $session['id'] ) : 'title:' . sanitize_title( ( isset( $session['title'] ) ? $session['title'] : '' ) . '-' . ( isset( $session['date'] ) ? $session['date'] : '' ) . '-' . ( isset( $session['time'] ) ? $session['time'] : '' ) );
+		if ( empty( $sessions[ $key ] ) ) {
+			$sessions[ $key ] = $session;
+			return $sessions;
+		}
+
+		if ( ! empty( $session['speakers'] ) && is_array( $session['speakers'] ) ) {
+			$existing_speakers            = isset( $sessions[ $key ]['speakers'] ) && is_array( $sessions[ $key ]['speakers'] ) ? $sessions[ $key ]['speakers'] : array();
+			$sessions[ $key ]['speakers'] = array_values( array_unique( array_merge( $existing_speakers, $session['speakers'] ) ) );
+		}
+
+		return $sessions;
+	}
+
+	/**
+	 * Normalize a newer Eventyay submission as a speaker session.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $submission Eventyay submission resource.
+	 * @return array
+	 */
+	private function normalize_eventyay_submission_session( $submission ) {
+		$submission = $this->normalize_eventyay_api_resource( $submission );
+		$source_id  = $this->eventyay_resource_identifier( $submission );
+		$slot       = $this->eventyay_first_slot( $submission );
+		$track      = isset( $submission['track'] ) ? $submission['track'] : array();
+		$room       = $this->eventyay_slot_room_name( $slot );
+		$starts_at  = $this->eventyay_first_present_raw( $slot, array( 'start', 'starts_at', 'starts-at', 'start_time', 'start-time', 'date_from', 'date-from' ) );
+		$ends_at    = $this->eventyay_first_present_raw( $slot, array( 'end', 'ends_at', 'ends-at', 'end_time', 'end-time', 'date_to', 'date-to' ) );
+
+		if ( empty( $starts_at ) ) {
+			$starts_at = $this->eventyay_first_present_raw( $submission, array( 'starts_at', 'starts-at', 'start_time', 'start-time', 'date_from', 'date-from' ) );
+		}
+
+		if ( empty( $ends_at ) ) {
+			$ends_at = $this->eventyay_first_present_raw( $submission, array( 'ends_at', 'ends-at', 'end_time', 'end-time', 'date_to', 'date-to' ) );
+		}
+
+		if ( empty( $room ) ) {
+			$room = $this->eventyay_first_present_text( $submission, array( 'room', 'room_name', 'room-name', 'venue' ) );
+		}
+
+		return array(
+			'id'        => $source_id ? 'eventyay-submission-' . sanitize_key( $source_id ) : 'eventyay-submission-' . sanitize_title( $this->eventyay_text_value( isset( $submission['title'] ) ? $submission['title'] : '' ) ),
+			'title'     => $this->eventyay_text_value( isset( $submission['title'] ) ? $submission['title'] : '' ),
+			'date'      => $this->format_eventyay_date( $starts_at ),
+			'time'      => $this->format_eventyay_time( $starts_at ),
+			'end_time'  => $this->format_eventyay_time( $ends_at ),
+			'starts_at' => $this->normalize_eventyay_datetime( $starts_at ),
+			'ends_at'   => $this->normalize_eventyay_datetime( $ends_at ),
+			'abstract'  => $this->eventyay_submission_abstract( $submission ),
+			'track'     => is_array( $track ) ? $this->eventyay_text_value( isset( $track['name'] ) ? $track['name'] : '' ) : $this->eventyay_text_value( $track ),
+			'room'      => $room,
+			'source_id' => sanitize_text_field( $source_id ),
+		);
+	}
+
+	/**
+	 * Normalize a newer Eventyay schedule slot as a speaker session.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $slot       Eventyay slot resource.
+	 * @param array $submission Eventyay submission resource.
+	 * @return array
+	 */
+	private function normalize_eventyay_slot_session( $slot, $submission ) {
+		$slot       = $this->normalize_eventyay_api_resource( $slot );
+		$submission = $this->normalize_eventyay_api_resource( $submission );
+		$source_id  = $this->eventyay_resource_identifier( $submission );
+		$slot_id    = $this->eventyay_resource_identifier( $slot );
+		$track      = isset( $submission['track'] ) ? $submission['track'] : array();
+		$room       = $this->eventyay_slot_room_name( $slot );
+		$starts_at  = $this->eventyay_first_present_raw( $slot, array( 'start', 'starts_at', 'starts-at', 'start_time', 'start-time' ) );
+		$ends_at    = $this->eventyay_first_present_raw( $slot, array( 'end', 'ends_at', 'ends-at', 'end_time', 'end-time' ) );
+		$title      = $this->eventyay_first_present_text( $submission, array( 'title', 'name' ) );
+		$abstract   = $this->eventyay_submission_abstract( $submission );
+
+		if ( empty( $title ) ) {
+			$title = $this->eventyay_first_present_text( $slot, array( 'title', 'name', 'description' ) );
+		}
+
+		if ( empty( $abstract ) ) {
+			$abstract = $this->eventyay_first_present_rich_text( $slot, array( 'description', 'abstract' ) );
+		}
+
+		return array(
+			'id'        => $source_id ? 'eventyay-submission-' . sanitize_key( $source_id ) : 'eventyay-slot-' . sanitize_key( $slot_id ),
+			'title'     => $title,
+			'date'      => $this->format_eventyay_date( $starts_at ),
+			'time'      => $this->format_eventyay_time( $starts_at ),
+			'end_time'  => $this->format_eventyay_time( $ends_at ),
+			'starts_at' => $this->normalize_eventyay_datetime( $starts_at ),
+			'ends_at'   => $this->normalize_eventyay_datetime( $ends_at ),
+			'abstract'  => $abstract,
+			'track'     => is_array( $track ) ? $this->eventyay_text_value( isset( $track['name'] ) ? $track['name'] : '' ) : $this->eventyay_text_value( $track ),
+			'room'      => $room,
+			'source_id' => sanitize_text_field( $source_id ? $source_id : $slot_id ),
+		);
+	}
+
+	/**
+	 * Determine whether a normalized Eventyay session has useful content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $session Normalized session.
+	 * @return bool
+	 */
+	private function eventyay_session_has_content( $session ) {
+		foreach ( array( 'title', 'date', 'time', 'end_time', 'abstract', 'track', 'room' ) as $key ) {
+			if ( ! empty( $session[ $key ] ) ) {
+				return true;
+			}
+		}
+
+		return ! empty( $session['speakers'] );
+	}
+
+	/**
+	 * Extract a display room name from an expanded Eventyay slot.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $slot Eventyay slot resource.
+	 * @return string
+	 */
+	private function eventyay_slot_room_name( $slot ) {
+		$slot = $this->normalize_eventyay_api_resource( $slot );
+
+		$room_name = $this->eventyay_first_present_text( $slot, array( 'room_name', 'room-name', 'venue' ) );
+		if ( $room_name ) {
+			return $room_name;
+		}
+
+		if ( empty( $slot['room'] ) ) {
+			return '';
+		}
+
+		if ( is_array( $slot['room'] ) ) {
+			return $this->eventyay_first_present_text( $this->normalize_eventyay_api_resource( $slot['room'] ), array( 'name', 'title', 'slug' ) );
+		}
+
+		return $this->eventyay_text_value( $slot['room'] );
+	}
+
+	/**
+	 * Normalize a newer Eventyay speaker resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $speaker_resource Eventyay speaker resource.
+	 * @param array  $settings         Import settings.
+	 * @param string $event_slug       Eventyay event slug.
+	 * @return array
+	 */
+	private function normalize_eventyay_submission_speaker( $speaker_resource, $settings, $event_slug ) {
+		$speaker_resource = $this->normalize_eventyay_api_resource( $speaker_resource );
+		$source_id        = $this->eventyay_resource_identifier( $speaker_resource );
+		$name             = $this->eventyay_first_present_text( $speaker_resource, array( 'name', 'fullname', 'full_name', 'full-name', 'public_name', 'public-name', 'display_name', 'display-name' ) );
+
+		if ( empty( $name ) ) {
+			$name = trim(
+				$this->eventyay_text_value( isset( $speaker_resource['first_name'] ) ? $speaker_resource['first_name'] : '' ) . ' ' .
+				$this->eventyay_text_value( isset( $speaker_resource['last_name'] ) ? $speaker_resource['last_name'] : '' )
+			);
+		}
+
+		$eventyay_speaker_id = implode(
+			':',
+			array_filter(
+				array(
+					$settings['organizer_slug'],
+					$event_slug,
+					$source_id ? $source_id : sanitize_title( $name ),
+				)
+			)
+		);
+
+		$position     = $this->eventyay_first_present_text( $speaker_resource, array( 'position', 'job_title', 'job-title', 'title', 'role', 'speaking_experience', 'speaking-experience' ) );
+		$organization = $this->eventyay_first_present_text( $speaker_resource, array( 'organization', 'organisation', 'company', 'affiliation' ) );
+		$category     = $this->eventyay_first_present_text( $speaker_resource, array( 'category', 'track' ) );
+
+		return array(
+			'id'                  => 'eventyay-' . sanitize_key( $eventyay_speaker_id ),
+			'eventyay_speaker_id' => sanitize_text_field( $eventyay_speaker_id ),
+			'name'                => sanitize_text_field( $name ),
+			'title'               => sanitize_text_field( $position ? $position : $organization ),
+			'position'            => sanitize_text_field( $position ),
+			'organization'        => sanitize_text_field( $organization ),
+			'category'            => sanitize_text_field( $category ),
+			'image'               => $this->eventyay_url_value( $this->eventyay_first_present_raw( $speaker_resource, array( 'avatar', 'avatar_url', 'avatar-url', 'avatar_url_original', 'avatar-url-original', 'image', 'image_url', 'image-url', 'photo', 'photo_url', 'photo-url' ) ), $settings['base_url'] ),
+			'bio'                 => $this->eventyay_first_present_rich_text( $speaker_resource, array( 'biography', 'bio', 'description', 'abstract', 'short_biography', 'short-biography', 'long_biography', 'long-biography' ) ),
+			'social'              => array(
+				'linkedin' => $this->eventyay_url_value( $this->eventyay_first_present_raw( $speaker_resource, array( 'linkedin', 'linkedin_url', 'linkedin-url' ) ), $settings['base_url'] ),
+				'twitter'  => $this->eventyay_url_value( $this->eventyay_first_present_raw( $speaker_resource, array( 'twitter', 'twitter_url', 'twitter-url', 'x_url' ) ), $settings['base_url'] ),
+				'github'   => $this->eventyay_url_value( $this->eventyay_first_present_raw( $speaker_resource, array( 'github', 'github_url', 'github-url' ) ), $settings['base_url'] ),
+				'website'  => $this->eventyay_url_value( $this->eventyay_first_present_raw( $speaker_resource, array( 'website', 'website_url', 'website-url', 'homepage', 'homepage_url', 'homepage-url', 'url' ) ), $settings['base_url'] ),
+			),
+			'featured'            => $this->eventyay_speaker_is_featured( $speaker_resource, $category ),
+			'featured_order'      => $this->eventyay_speaker_featured_order( $speaker_resource ),
+			'sessions'            => array(),
+			'source'              => 'eventyay',
+		);
+	}
+
+	/**
+	 * Detect whether an Eventyay speaker is marked for featured display.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $speaker_resource Normalized Eventyay speaker resource.
+	 * @param string $category         Speaker category or track label.
+	 * @return bool
+	 */
+	private function eventyay_speaker_is_featured( $speaker_resource, $category = '' ) {
+		$featured = $this->eventyay_first_present_raw(
+			$speaker_resource,
+			array(
+				'featured',
+				'is_featured',
+				'is-featured',
+				'featured_speaker',
+				'featured-speaker',
+				'highlighted',
+				'is_highlighted',
+				'is-highlighted',
+				'keynote',
+				'is_keynote',
+				'is-keynote',
+				'show_on_frontpage',
+				'show-on-frontpage',
+			)
+		);
+
+		if ( $this->eventyay_truthy_value( $featured ) ) {
+			return true;
+		}
+
+		return is_string( $category ) && (bool) preg_match( '/\b(featured|keynote|plenary|highlight)\b/i', $category );
+	}
+
+	/**
+	 * Get an optional featured speaker order from Eventyay data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $speaker_resource Normalized Eventyay speaker resource.
+	 * @return int
+	 */
+	private function eventyay_speaker_featured_order( $speaker_resource ) {
+		$order = $this->eventyay_first_present_raw(
+			$speaker_resource,
+			array(
+				'featured_order',
+				'featured-order',
+				'featured_position',
+				'featured-position',
+				'featuredPosition',
+				'speaker_order',
+				'speaker-order',
+				'sort_order',
+				'sort-order',
+				'order',
+			)
+		);
+
+		return is_numeric( $order ) ? absint( $order ) : 0;
+	}
+
+	/**
+	 * Convert Eventyay truth-ish values into a boolean.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $value Raw value.
+	 * @return bool
+	 */
+	private function eventyay_truthy_value( $value ) {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+
+		if ( is_numeric( $value ) ) {
+			return 0 !== (int) $value;
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( array( 'value', 'featured', 'is_featured', 'enabled', 'selected' ) as $key ) {
+				if ( array_key_exists( $key, $value ) ) {
+					return $this->eventyay_truthy_value( $value[ $key ] );
+				}
+			}
+
+			return ! empty( $value );
+		}
+
+		if ( ! is_scalar( $value ) ) {
+			return false;
+		}
+
+		return in_array( strtolower( trim( (string) $value ) ), array( '1', 'true', 'yes', 'y', 'on', 'featured', 'keynote', 'highlighted' ), true );
+	}
+
+	/**
+	 * Extract a submission abstract from likely Eventyay fields.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $submission Eventyay submission resource.
+	 * @return string
+	 */
+	private function eventyay_submission_abstract( $submission ) {
+		return $this->eventyay_first_present_rich_text(
+			$submission,
+			array(
+				'abstract',
+				'description',
+				'content',
+				'notes',
+			)
+		);
+	}
+
+	/**
+	 * Extract the first scheduled slot from a submission.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $submission Eventyay submission resource.
+	 * @return array
+	 */
+	private function eventyay_first_slot( $submission ) {
+		if ( ! empty( $submission['slot'] ) && is_array( $submission['slot'] ) ) {
+			return $this->normalize_eventyay_api_resource( $submission['slot'] );
+		}
+
+		if ( ! empty( $submission['slots'] ) && is_array( $submission['slots'] ) ) {
+			foreach ( $this->eventyay_list_value( $submission['slots'] ) as $slot ) {
+				if ( is_array( $slot ) ) {
+					return $this->normalize_eventyay_api_resource( $slot );
+				}
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Normalize an Eventyay resource into a flat field map.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $eventyay_resource Eventyay resource.
+	 * @return array
+	 */
+	private function normalize_eventyay_api_resource( $eventyay_resource ) {
+		if ( ! is_array( $eventyay_resource ) ) {
+			return array();
+		}
+
+		if ( isset( $eventyay_resource['data'] ) && is_array( $eventyay_resource['data'] ) && $this->is_jsonapi_resource( $eventyay_resource['data'] ) ) {
+			$eventyay_resource = $eventyay_resource['data'];
+		}
+
+		$normalized = array();
+
+		if ( isset( $eventyay_resource['attributes'] ) && is_array( $eventyay_resource['attributes'] ) ) {
+			$normalized = $eventyay_resource['attributes'];
+		}
+
+		foreach ( $eventyay_resource as $key => $value ) {
+			if ( in_array( $key, array( 'attributes', 'relationships' ), true ) ) {
+				continue;
+			}
+
+			$normalized[ $key ] = $value;
+		}
+
+		if ( isset( $eventyay_resource['relationships'] ) && is_array( $eventyay_resource['relationships'] ) ) {
+			foreach ( $eventyay_resource['relationships'] as $relationship_key => $relationship ) {
+				if ( ! is_array( $relationship ) || ! array_key_exists( 'data', $relationship ) ) {
+					continue;
+				}
+
+				$normalized[ $relationship_key ] = $this->normalize_eventyay_relationship_data( $relationship['data'] );
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize JSON:API relationship data when included directly in Eventyay payloads.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $relationship_data Relationship data.
+	 * @return mixed
+	 */
+	private function normalize_eventyay_relationship_data( $relationship_data ) {
+		if ( ! is_array( $relationship_data ) ) {
+			return $relationship_data;
+		}
+
+		if ( $this->is_jsonapi_resource( $relationship_data ) ) {
+			return $this->normalize_eventyay_api_resource( $relationship_data );
+		}
+
+		$normalized = array();
+		foreach ( $relationship_data as $item ) {
+			$normalized[] = is_array( $item ) ? $this->normalize_eventyay_api_resource( $item ) : $item;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Get a list value from an Eventyay resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $value Raw value.
+	 * @return array
+	 */
+	private function eventyay_list_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		if ( isset( $value['results'] ) && is_array( $value['results'] ) ) {
+			return $value['results'];
+		}
+
+		if ( array_key_exists( 'data', $value ) && is_array( $value['data'] ) ) {
+			if ( $this->is_jsonapi_resource( $value['data'] ) ) {
+				return array( $value['data'] );
+			}
+
+			return $value['data'];
+		}
+
+		if (
+			! array_key_exists( 0, $value )
+			&& (
+				$this->is_jsonapi_resource( $value )
+				|| isset( $value['id'] )
+				|| isset( $value['name'] )
+				|| isset( $value['title'] )
+				|| isset( $value['attributes'] )
+			)
+		) {
+			return array( $value );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Extract a stable identifier from an Eventyay resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $eventyay_resource Eventyay resource.
+	 * @return string
+	 */
+	private function eventyay_resource_identifier( $eventyay_resource ) {
+		foreach ( array( '_eventyay_source_id', 'code', 'id', 'slug' ) as $key ) {
+			if ( isset( $eventyay_resource[ $key ] ) && is_scalar( $eventyay_resource[ $key ] ) && '' !== trim( (string) $eventyay_resource[ $key ] ) ) {
+				return sanitize_text_field( (string) $eventyay_resource[ $key ] );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return the first non-empty plain text field from an Eventyay resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $eventyay_resource Eventyay resource.
+	 * @param array $keys              Candidate keys.
+	 * @return string
+	 */
+	private function eventyay_first_present_text( $eventyay_resource, $keys ) {
+		$value = $this->eventyay_first_present_raw( $eventyay_resource, $keys );
+
+		return $this->eventyay_text_value( $value );
+	}
+
+	/**
+	 * Return the first non-empty rich text field from an Eventyay resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $eventyay_resource Eventyay resource.
+	 * @param array $keys              Candidate keys.
+	 * @return string
+	 */
+	private function eventyay_first_present_rich_text( $eventyay_resource, $keys ) {
+		$value = $this->eventyay_first_present_raw( $eventyay_resource, $keys );
+
+		return $this->eventyay_rich_text_value( $value );
+	}
+
+	/**
+	 * Return the first non-empty raw field from an Eventyay resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $eventyay_resource Eventyay resource.
+	 * @param array $keys              Candidate keys.
+	 * @return mixed
+	 */
+	private function eventyay_first_present_raw( $eventyay_resource, $keys ) {
+		foreach ( $keys as $key ) {
+			if ( ! array_key_exists( $key, $eventyay_resource ) ) {
+				continue;
+			}
+
+			if ( is_scalar( $eventyay_resource[ $key ] ) && '' !== trim( (string) $eventyay_resource[ $key ] ) ) {
+				return $eventyay_resource[ $key ];
+			}
+
+			if ( is_array( $eventyay_resource[ $key ] ) && ! empty( $eventyay_resource[ $key ] ) ) {
+				return $eventyay_resource[ $key ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Convert an Eventyay URL-ish value into an absolute URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed  $value    Raw value.
+	 * @param string $base_url Eventyay base URL.
+	 * @return string
+	 */
+	private function eventyay_url_value( $value, $base_url ) {
+		if ( is_array( $value ) ) {
+			foreach ( array( 'url', 'href', 'download', 'thumbnail', 'image', 'en', 'default' ) as $key ) {
+				if ( ! empty( $value[ $key ] ) ) {
+					return $this->eventyay_url_value( $value[ $key ], $base_url );
+				}
+			}
+
+			return '';
+		}
+
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		$value = trim( (string) $value );
+		if ( '' === $value ) {
+			return '';
+		}
+
+		if ( wp_http_validate_url( $value ) ) {
+			return esc_url_raw( $value );
+		}
+
+		$base_url = untrailingslashit( esc_url_raw( $base_url ) );
+		if ( ! empty( $base_url ) && wp_http_validate_url( $base_url ) && 0 === strpos( $value, '/' ) ) {
+			return esc_url_raw( $base_url . $value );
+		}
+
+		return '';
+	}
+
+		/**
+		 * Convert an Eventyay location-ish value into display text.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param mixed $value Raw location value.
+		 * @return string
+		 */
+	private function eventyay_location_text_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $this->eventyay_text_value( $value );
+		}
+
+		foreach ( array( 'name', 'title', 'label', 'location', 'address', 'full_address', 'full-address', 'formatted_address', 'formatted-address' ) as $key ) {
+			if ( ! empty( $value[ $key ] ) ) {
+				$text = $this->eventyay_text_value( $value[ $key ] );
+
+				if ( '' !== $text ) {
+					return $text;
+				}
+			}
+		}
+
+		$parts = array();
+		foreach ( array( 'street', 'street_address', 'street-address', 'address_line_1', 'address-line-1', 'line1', 'postal_code', 'postal-code', 'postcode', 'zip', 'city', 'region', 'state', 'country' ) as $key ) {
+			if ( empty( $value[ $key ] ) ) {
+				continue;
+			}
+
+			$part = $this->eventyay_text_value( $value[ $key ] );
+			if ( '' !== $part ) {
+				$parts[] = $part;
+			}
+		}
+
+		if ( ! empty( $parts ) ) {
+			return implode( ', ', array_values( array_unique( $parts ) ) );
+		}
+
+		return $this->eventyay_text_value( $value );
+	}
+
+	/**
 	 * Determine whether an Eventyay event has a fetched settings payload.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return bool
-	 * @phpstan-ignore method.unused
 	 */
 	private function eventyay_event_has_settings_payload( $event ) {
 		foreach ( array( '_eventyay_settings', 'settings' ) as $settings_key ) {
@@ -1835,275 +4090,1040 @@ class Wpfaevent_Eventyay_Importer {
 		);
 	}
 
-	/**
-	 * Normalize an Eventyay resource into a flat field map.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $eventyay_resource Eventyay resource.
-	 * @return array
-	 */
-	private function normalize_eventyay_api_resource( $eventyay_resource ) {
-		if ( ! is_array( $eventyay_resource ) ) {
-			return array();
-		}
-
-		if ( isset( $eventyay_resource['data'] ) && is_array( $eventyay_resource['data'] ) && $this->is_jsonapi_resource( $eventyay_resource['data'] ) ) {
-			$eventyay_resource = $eventyay_resource['data'];
-		}
-
-		$normalized = array();
-
-		if ( isset( $eventyay_resource['attributes'] ) && is_array( $eventyay_resource['attributes'] ) ) {
-			$normalized = $eventyay_resource['attributes'];
-		}
-
-		foreach ( $eventyay_resource as $key => $value ) {
-			if ( in_array( $key, array( 'attributes', 'relationships' ), true ) ) {
-				continue;
-			}
-
-			$normalized[ $key ] = $value;
-		}
-
-		if ( isset( $eventyay_resource['relationships'] ) && is_array( $eventyay_resource['relationships'] ) ) {
-			foreach ( $eventyay_resource['relationships'] as $relationship_key => $relationship ) {
-				if ( ! is_array( $relationship ) || ! array_key_exists( 'data', $relationship ) ) {
-					continue;
-				}
-
-				$normalized[ $relationship_key ] = $this->normalize_eventyay_relationship_data( $relationship['data'] );
-			}
-		}
-
-		return $normalized;
-	}
 
 	/**
-	 * Normalize JSON:API relationship data when included directly in Eventyay payloads.
+	 * Handle Eventyay JSON:API speaker sync for the admin dashboard.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param mixed $relationship_data Relationship data.
-	 * @return mixed
 	 */
-	private function normalize_eventyay_relationship_data( $relationship_data ) {
-		if ( ! is_array( $relationship_data ) ) {
-			return $relationship_data;
+	public function ajax_sync_eventyay() {
+		if ( ! check_ajax_referer( 'fossasia_admin_nonce', 'nonce', false ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Invalid nonce', 'wpfaevent' ),
+				),
+				403
+			);
 		}
 
-		if ( $this->is_jsonapi_resource( $relationship_data ) ) {
-			return $this->normalize_eventyay_api_resource( $relationship_data );
+		if ( ! Wpfaevent_Roles::current_user_can_import_eventyay() ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Unauthorized', 'wpfaevent' ),
+				),
+				403
+			);
 		}
 
-		$normalized = array();
-		foreach ( $relationship_data as $item ) {
-			$normalized[] = is_array( $item ) ? $this->normalize_eventyay_api_resource( $item ) : $item;
+		$event_id = isset( $_POST['event_id'] ) ? absint( $_POST['event_id'] ) : 0;
+		if ( ! $event_id ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Missing event ID.', 'wpfaevent' ),
+				),
+				400
+			);
 		}
 
-		return $normalized;
-	}
-
-	/**
-	 * Get a list value from an Eventyay resource.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param mixed $value Raw value.
-	 * @return array
-	 * @phpstan-ignore method.unused
-	 */
-	private function eventyay_list_value( $value ) {
-		if ( ! is_array( $value ) ) {
-			return array();
+		$api_url = $this->get_eventyay_sync_url( $event_id );
+		if ( empty( $api_url ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Please save an Eventyay API URL before syncing.', 'wpfaevent' ),
+				),
+				400
+			);
 		}
 
-		if ( isset( $value['results'] ) && is_array( $value['results'] ) ) {
-			return $value['results'];
+		$api_url = $this->prepare_eventyay_sync_url( $api_url );
+		if ( is_wp_error( $api_url ) ) {
+			$this->send_eventyay_ajax_error( $api_url );
 		}
 
-		if ( array_key_exists( 'data', $value ) && is_array( $value['data'] ) ) {
-			if ( $this->is_jsonapi_resource( $value['data'] ) ) {
-				return array( $value['data'] );
-			}
-
-			return $value['data'];
+		$settings_write = $this->persist_eventyay_sync_url( $event_id, $api_url );
+		if ( is_wp_error( $settings_write ) ) {
+			$this->send_eventyay_ajax_error( $settings_write );
 		}
 
-		if (
-			! array_key_exists( 0, $value )
-			&& (
-				$this->is_jsonapi_resource( $value )
-				|| isset( $value['id'] )
-				|| isset( $value['name'] )
-				|| isset( $value['title'] )
-				|| isset( $value['attributes'] )
+		$payload = $this->fetch_eventyay_json( $api_url );
+		if ( is_wp_error( $payload ) ) {
+			$this->send_eventyay_ajax_error( $payload );
+		}
+
+		$import = $this->normalize_eventyay_payload( $payload );
+		if ( is_wp_error( $import ) ) {
+			$this->send_eventyay_ajax_error( $import );
+		}
+
+		$existing_speakers  = $this->read_dashboard_json_file( 'speakers-' . $event_id . '.json', array() );
+		$dashboard_speakers = $this->merge_dashboard_speaker_state( $import['speakers'], $existing_speakers );
+		$write_result       = $this->write_dashboard_json_file( 'speakers-' . $event_id . '.json', $dashboard_speakers );
+
+		if ( is_wp_error( $write_result ) ) {
+			$this->send_eventyay_ajax_error( $write_result );
+		}
+
+		$cpt_result = $this->sync_eventyay_speaker_posts( $import['speakers'], $event_id );
+
+		wp_send_json_success(
+			array(
+				'message'          => sprintf(
+					/* translators: 1: speaker count, 2: session count. */
+					esc_html__( 'Synced %1$d speaker(s) from %2$d Eventyay session(s).', 'wpfaevent' ),
+					count( $import['speakers'] ),
+					$import['session_count']
+				),
+				'speaker_count'    => count( $import['speakers'] ),
+				'session_count'    => $import['session_count'],
+				'created_speakers' => $cpt_result['created'],
+				'updated_speakers' => $cpt_result['updated'],
 			)
-		) {
-			return array( $value );
-		}
-
-		return $value;
+		);
 	}
 
 	/**
-	 * Extract a stable identifier from an Eventyay resource.
+	 * Send a structured Eventyay sync failure response.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array $eventyay_resource Eventyay resource.
-	 * @return string
-	 * @phpstan-ignore method.unused
+	 * @param WP_Error $error Error object.
+	 * @return void
 	 */
-	private function eventyay_resource_identifier( $eventyay_resource ) {
-		foreach ( array( '_eventyay_source_id', 'code', 'id', 'slug' ) as $key ) {
-			if ( isset( $eventyay_resource[ $key ] ) && is_scalar( $eventyay_resource[ $key ] ) && '' !== trim( (string) $eventyay_resource[ $key ] ) ) {
-				return sanitize_text_field( (string) $eventyay_resource[ $key ] );
+	private function send_eventyay_ajax_error( $error ) {
+		$error_data = $error->get_error_data();
+		$status     = 500;
+		$response   = array(
+			'message' => $error->get_error_message(),
+			'code'    => $error->get_error_code(),
+		);
+
+		if ( is_array( $error_data ) ) {
+			$response = array_merge( $response, $error_data );
+
+			if ( isset( $error_data['status'] ) ) {
+				$status = absint( $error_data['status'] );
 			}
 		}
 
-		return '';
-	}
-
-	/**
-	 * Return the first non-empty plain text field from an Eventyay resource.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $eventyay_resource Eventyay resource.
-	 * @param array $keys              Candidate keys.
-	 * @return string
-	 */
-	private function eventyay_first_present_text( $eventyay_resource, $keys ) {
-		$value = $this->eventyay_first_present_raw( $eventyay_resource, $keys );
-
-		return $this->eventyay_text_value( $value );
-	}
-
-	/**
-	 * Return the first non-empty rich text field from an Eventyay resource.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $eventyay_resource Eventyay resource.
-	 * @param array $keys              Candidate keys.
-	 * @return string
-	 * @phpstan-ignore method.unused
-	 */
-	private function eventyay_first_present_rich_text( $eventyay_resource, $keys ) {
-		$value = $this->eventyay_first_present_raw( $eventyay_resource, $keys );
-
-		return $this->eventyay_rich_text_value( $value );
-	}
-
-	/**
-	 * Return the first non-empty raw field from an Eventyay resource.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $eventyay_resource Eventyay resource.
-	 * @param array $keys              Candidate keys.
-	 * @return mixed
-	 */
-	private function eventyay_first_present_raw( $eventyay_resource, $keys ) {
-		foreach ( $keys as $key ) {
-			if ( ! array_key_exists( $key, $eventyay_resource ) ) {
-				continue;
-			}
-
-			if ( is_scalar( $eventyay_resource[ $key ] ) && '' !== trim( (string) $eventyay_resource[ $key ] ) ) {
-				return $eventyay_resource[ $key ];
-			}
-
-			if ( is_array( $eventyay_resource[ $key ] ) && ! empty( $eventyay_resource[ $key ] ) ) {
-				return $eventyay_resource[ $key ];
-			}
+		if ( $status < 400 || $status > 599 ) {
+			$status = 500;
 		}
 
-		return '';
+		wp_send_json_error( $response, $status );
 	}
 
 	/**
-	 * Convert an Eventyay URL-ish value into an absolute URL.
+	 * Resolve the Eventyay sync URL from POST data or saved dashboard settings.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param mixed  $value    Raw value.
-	 * @param string $base_url Eventyay base URL.
+	 * @param int $event_id Event post ID.
 	 * @return string
 	 */
-	private function eventyay_url_value( $value, $base_url ) {
-		if ( is_array( $value ) ) {
-			foreach ( array( 'url', 'href', 'download', 'thumbnail', 'image', 'en', 'default' ) as $key ) {
-				if ( ! empty( $value[ $key ] ) ) {
-					return $this->eventyay_url_value( $value[ $key ], $base_url );
-				}
+	private function get_eventyay_sync_url( $event_id ) {
+		$api_url = '';
+
+		// Nonce is verified in ajax_sync_eventyay() before this helper is called.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( isset( $_POST['eventyay_api_url'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$api_url = esc_url_raw( wp_unslash( $_POST['eventyay_api_url'] ) );
+		}
+
+		if ( empty( $api_url ) ) {
+			$settings = $this->read_dashboard_json_file( 'site-settings-' . absint( $event_id ) . '.json', array() );
+
+			if ( is_array( $settings ) && ! empty( $settings['eventyay_api_url'] ) ) {
+				$api_url = esc_url_raw( $settings['eventyay_api_url'] );
 			}
-
-			return '';
 		}
-
-		if ( ! is_scalar( $value ) ) {
-			return '';
-		}
-
-		$value = trim( (string) $value );
-		if ( '' === $value ) {
-			return '';
-		}
-
-		if ( wp_http_validate_url( $value ) ) {
-			return esc_url_raw( $value );
-		}
-
-		$base_url = untrailingslashit( esc_url_raw( $base_url ) );
-		if ( ! empty( $base_url ) && wp_http_validate_url( $base_url ) && 0 === strpos( $value, '/' ) ) {
-			return esc_url_raw( $base_url . $value );
-		}
-
-		return '';
-	}
 
 		/**
-		 * Convert an Eventyay location-ish value into display text.
+		 * Filters the Eventyay Open API URL used by dashboard sync.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param mixed $value Raw location value.
-		 * @return string
+		 * @param string $api_url  Eventyay API URL.
+		 * @param int    $event_id Event post ID.
 		 */
-	private function eventyay_location_text_value( $value ) {
-		if ( ! is_array( $value ) ) {
-			return $this->eventyay_text_value( $value );
+		return apply_filters( 'wpfaevent_eventyay_sync_url', $api_url, absint( $event_id ) );
+	}
+
+	/**
+	 * Persist the Eventyay sync URL into the dashboard settings JSON.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $event_id Event post ID.
+	 * @param string $api_url  Eventyay API URL.
+	 * @return true|WP_Error
+	 */
+	private function persist_eventyay_sync_url( $event_id, $api_url ) {
+		$filename = 'site-settings-' . absint( $event_id ) . '.json';
+		$settings = $this->read_dashboard_json_file( $filename, array() );
+
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
 		}
 
-		foreach ( array( 'name', 'title', 'label', 'location', 'address', 'full_address', 'full-address', 'formatted_address', 'formatted-address' ) as $key ) {
-			if ( ! empty( $value[ $key ] ) ) {
-				$text = $this->eventyay_text_value( $value[ $key ] );
+		$settings['eventyay_api_url'] = esc_url_raw( $api_url );
 
-				if ( '' !== $text ) {
-					return $text;
+		return $this->write_dashboard_json_file( $filename, $settings );
+	}
+
+	/**
+	 * Validate and complete a dashboard Eventyay API URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $api_url Raw API URL.
+	 * @return string|WP_Error
+	 */
+	private function prepare_eventyay_sync_url( $api_url ) {
+		$api_url = trim( $api_url );
+
+		if ( empty( $api_url ) || ! wp_http_validate_url( $api_url ) ) {
+			return new WP_Error(
+				'eventyay_invalid_url',
+				esc_html__( 'The Eventyay API URL is not a valid HTTP(S) URL.', 'wpfaevent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$parts  = wp_parse_url( $api_url );
+		$scheme = isset( $parts['scheme'] ) ? strtolower( $parts['scheme'] ) : '';
+
+		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+			return new WP_Error(
+				'eventyay_invalid_url_scheme',
+				esc_html__( 'The Eventyay API URL must use HTTP or HTTPS.', 'wpfaevent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$path = isset( $parts['path'] ) ? $parts['path'] : '';
+		if ( false !== strpos( $path, '/sessions' ) ) {
+			$query_args = array();
+			if ( ! empty( $parts['query'] ) ) {
+				wp_parse_str( $parts['query'], $query_args );
+			}
+
+			if ( empty( $query_args['include'] ) ) {
+				$api_url = add_query_arg( 'include', 'speakers,track', $api_url );
+			}
+
+			if ( empty( $query_args['page']['size'] ) ) {
+				$api_url = add_query_arg( 'page[size]', 200, $api_url );
+			}
+		}
+
+		return $api_url;
+	}
+
+	/**
+	 * Fetch and decode an Eventyay JSON:API document.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $api_url Eventyay API URL.
+	 * @return array|WP_Error
+	 */
+	private function fetch_eventyay_json( $api_url ) {
+		$response = wp_remote_get(
+			$api_url,
+			array(
+				'timeout'     => 20,
+				'redirection' => 3,
+				'headers'     => array(
+					'Accept' => 'application/vnd.api+json, application/json',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'eventyay_request_failed',
+				esc_html__( 'Eventyay request failed.', 'wpfaevent' ),
+				array(
+					'status'  => 502,
+					'details' => $response->get_error_message(),
+				)
+			);
+		}
+
+		$status = absint( wp_remote_retrieve_response_code( $response ) );
+		$body   = wp_remote_retrieve_body( $response );
+
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error(
+				'eventyay_http_error',
+				sprintf(
+					/* translators: %d: HTTP status code. */
+					esc_html__( 'Eventyay API returned HTTP %d.', 'wpfaevent' ),
+					$status
+				),
+				array(
+					'status'      => ( $status >= 400 && $status <= 599 ) ? $status : 502,
+					'http_status' => $status,
+					'body'        => $this->decode_eventyay_error_body( $body ),
+				)
+			);
+		}
+
+		if ( '' === trim( $body ) ) {
+			return new WP_Error(
+				'eventyay_empty_response',
+				esc_html__( 'Eventyay API returned an empty response.', 'wpfaevent' ),
+				array(
+					'status'      => 502,
+					'http_status' => $status,
+				)
+			);
+		}
+
+		$decoded = json_decode( $body, true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+			return new WP_Error(
+				'eventyay_malformed_json',
+				esc_html__( 'Eventyay API returned malformed JSON.', 'wpfaevent' ),
+				array(
+					'status'          => 502,
+					'http_status'     => $status,
+					'json_error'      => json_last_error_msg(),
+					'response_sample' => $this->truncate_string( $body ),
+				)
+			);
+		}
+
+		if ( ! array_key_exists( 'data', $decoded ) ) {
+			return new WP_Error(
+				'eventyay_invalid_jsonapi',
+				esc_html__( 'Eventyay API response does not contain a JSON:API data member.', 'wpfaevent' ),
+				array(
+					'status'      => 502,
+					'http_status' => $status,
+					'body'        => $decoded,
+				)
+			);
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Decode an Eventyay error body if possible.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $body Response body.
+	 * @return array|string
+	 */
+	private function decode_eventyay_error_body( $body ) {
+		$decoded = json_decode( $body, true );
+
+		if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+			return $decoded;
+		}
+
+		return $this->truncate_string( $body );
+	}
+
+	/**
+	 * Normalize Eventyay JSON:API sessions or speakers into dashboard speaker data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $payload JSON:API document.
+	 * @return array|WP_Error
+	 */
+	private function normalize_eventyay_payload( $payload ) {
+		$data = isset( $payload['data'] ) ? $payload['data'] : array();
+
+		if ( $this->is_jsonapi_resource( $data ) ) {
+			$data = array( $data );
+		}
+
+		if ( ! is_array( $data ) ) {
+			return new WP_Error(
+				'eventyay_invalid_data',
+				esc_html__( 'Eventyay API data member is not a resource list.', 'wpfaevent' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		$included      = $this->index_jsonapi_resources( isset( $payload['included'] ) ? $payload['included'] : array() );
+		$speakers      = array();
+		$session_count = 0;
+
+		foreach ( $data as $resource ) {
+			if ( ! $this->is_jsonapi_resource( $resource ) ) {
+				continue;
+			}
+
+			if ( $this->jsonapi_type_is( $resource, 'speaker' ) ) {
+				$speaker = $this->normalize_eventyay_speaker_resource( $resource );
+
+				if ( ! empty( $speaker['name'] ) ) {
+					$this->merge_eventyay_speaker( $speakers, $speaker, array() );
+				}
+
+				continue;
+			}
+
+			if ( ! $this->jsonapi_type_is( $resource, 'session' ) ) {
+				continue;
+			}
+
+			++$session_count;
+
+			$session      = $this->normalize_eventyay_session_resource( $resource, $included );
+			$speaker_refs = $this->get_jsonapi_relationship_resources( $resource, 'speakers' );
+
+			foreach ( $speaker_refs as $speaker_ref ) {
+				$speaker_resource = $this->resolve_jsonapi_resource( $speaker_ref, $included );
+
+				if ( ! $this->is_jsonapi_resource( $speaker_resource ) ) {
+					continue;
+				}
+
+				$speaker = $this->normalize_eventyay_speaker_resource( $speaker_resource );
+				if ( empty( $speaker['name'] ) ) {
+					continue;
+				}
+
+				if ( empty( $speaker['category'] ) && ! empty( $session['track'] ) ) {
+					$speaker['category'] = $session['track'];
+				}
+
+				$this->merge_eventyay_speaker( $speakers, $speaker, $session );
+			}
+		}
+
+		$speakers = array_values( $speakers );
+
+		if ( ! empty( $data ) && empty( $speakers ) ) {
+			return new WP_Error(
+				'eventyay_no_speakers',
+				esc_html__( 'No speaker records were found in the Eventyay response. Use a sessions URL with include=speakers,track or a speakers URL.', 'wpfaevent' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		return array(
+			'speakers'      => $speakers,
+			'session_count' => $session_count,
+		);
+	}
+
+	/**
+	 * Normalize a JSON:API session resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $session_resource Session resource.
+	 * @param array $included         Indexed included resources.
+	 * @return array
+	 */
+	private function normalize_eventyay_session_resource( $session_resource, $included ) {
+		$attributes = $this->get_jsonapi_attributes( $session_resource );
+		$starts_at  = $this->attribute_value( $attributes, array( 'starts-at', 'start-time', 'starts_at' ) );
+		$ends_at    = $this->attribute_value( $attributes, array( 'ends-at', 'end-time', 'ends_at' ) );
+		$track_name = '';
+		$track_refs = $this->get_jsonapi_relationship_resources( $session_resource, 'track' );
+
+		if ( ! empty( $track_refs ) ) {
+			$track = $this->resolve_jsonapi_resource( $track_refs[0], $included );
+			if ( $this->is_jsonapi_resource( $track ) ) {
+				$track_attributes = $this->get_jsonapi_attributes( $track );
+				$track_name       = $this->attribute_value( $track_attributes, array( 'name', 'title' ) );
+			}
+		}
+
+		return array(
+			'id'        => isset( $session_resource['id'] ) ? 'eventyay-session-' . sanitize_key( $session_resource['id'] ) : '',
+			'title'     => sanitize_text_field( $this->attribute_value( $attributes, array( 'title', 'subtitle', 'name' ) ) ),
+			'date'      => $this->format_eventyay_date( $starts_at ),
+			'time'      => $this->format_eventyay_time( $starts_at ),
+			'end_time'  => $this->format_eventyay_time( $ends_at ),
+			'starts_at' => $this->normalize_eventyay_datetime( $starts_at ),
+			'ends_at'   => $this->normalize_eventyay_datetime( $ends_at ),
+			'abstract'  => wp_kses_post( $this->attribute_value( $attributes, array( 'long-abstract', 'short-abstract', 'abstract', 'description' ) ) ),
+			'track'     => sanitize_text_field( $track_name ),
+			'source_id' => isset( $session_resource['id'] ) ? sanitize_text_field( $session_resource['id'] ) : '',
+		);
+	}
+
+	/**
+	 * Normalize a JSON:API speaker resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $speaker_resource Speaker resource.
+	 * @return array
+	 */
+	private function normalize_eventyay_speaker_resource( $speaker_resource ) {
+		$attributes = $this->get_jsonapi_attributes( $speaker_resource );
+		$source_id  = isset( $speaker_resource['id'] ) ? sanitize_text_field( $speaker_resource['id'] ) : '';
+		$name       = $this->attribute_value( $attributes, array( 'name', 'full-name', 'display-name' ) );
+
+		if ( empty( $name ) ) {
+			$name = trim(
+				$this->attribute_value( $attributes, array( 'first-name', 'first_name' ) ) . ' ' .
+				$this->attribute_value( $attributes, array( 'last-name', 'last_name' ) )
+			);
+		}
+
+		$position     = $this->attribute_value( $attributes, array( 'position', 'job-title', 'designation' ) );
+		$organization = $this->attribute_value( $attributes, array( 'organisation', 'organization', 'company' ) );
+		$category     = $this->attribute_value( $attributes, array( 'category', 'track' ) );
+
+		return array(
+			'id'                  => $source_id ? 'eventyay-' . sanitize_key( $source_id ) : 'eventyay-' . sanitize_title( $name ),
+			'eventyay_speaker_id' => $source_id,
+			'name'                => sanitize_text_field( $name ),
+			'title'               => sanitize_text_field( $position ? $position : $organization ),
+			'position'            => sanitize_text_field( $position ),
+			'organization'        => sanitize_text_field( $organization ),
+			'category'            => sanitize_text_field( $category ),
+			'image'               => esc_url_raw(
+				$this->attribute_value(
+					$attributes,
+					array(
+						'photo-url',
+						'thumbnail-image-url',
+						'small-image-url',
+						'icon-image-url',
+						'original-image-url',
+						'avatar-url',
+					)
+				)
+			),
+			'bio'                 => wp_kses_post( $this->attribute_value( $attributes, array( 'long-biography', 'short-biography', 'biography', 'speaking-experience' ) ) ),
+			'social'              => array(
+				'linkedin' => esc_url_raw( $this->attribute_value( $attributes, array( 'linkedin', 'linkedin-url' ) ) ),
+				'twitter'  => esc_url_raw( $this->attribute_value( $attributes, array( 'twitter', 'twitter-url' ) ) ),
+				'github'   => esc_url_raw( $this->attribute_value( $attributes, array( 'github', 'github-url' ) ) ),
+				'website'  => esc_url_raw( $this->attribute_value( $attributes, array( 'website', 'website-url' ) ) ),
+			),
+			'featured'            => $this->eventyay_speaker_is_featured( $attributes, $category ),
+			'featured_order'      => $this->eventyay_speaker_featured_order( $attributes ),
+			'sessions'            => array(),
+			'source'              => 'eventyay',
+		);
+	}
+
+	/**
+	 * Merge a speaker and optional session into a keyed speaker list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $speakers Speaker list keyed by normalized source.
+	 * @param array $speaker  Speaker data.
+	 * @param array $session  Session data.
+	 * @return void
+	 */
+	private function merge_eventyay_speaker( &$speakers, $speaker, $session ) {
+		$key = ! empty( $speaker['eventyay_speaker_id'] ) ? 'eventyay:' . $speaker['eventyay_speaker_id'] : 'name:' . sanitize_title( $speaker['name'] );
+
+		if ( empty( $speakers[ $key ] ) ) {
+			$speakers[ $key ] = $speaker;
+		} else {
+			foreach ( array( 'title', 'position', 'organization', 'category', 'image', 'bio' ) as $field ) {
+				if ( empty( $speakers[ $key ][ $field ] ) && ! empty( $speaker[ $field ] ) ) {
+					$speakers[ $key ][ $field ] = $speaker[ $field ];
+				}
+			}
+
+			foreach ( $speaker['social'] as $field => $value ) {
+				if ( empty( $speakers[ $key ]['social'][ $field ] ) && ! empty( $value ) ) {
+					$speakers[ $key ]['social'][ $field ] = $value;
 				}
 			}
 		}
 
-		$parts = array();
-		foreach ( array( 'street', 'street_address', 'street-address', 'address_line_1', 'address-line-1', 'line1', 'postal_code', 'postal-code', 'postcode', 'zip', 'city', 'region', 'state', 'country' ) as $key ) {
-			if ( empty( $value[ $key ] ) ) {
+		if ( ! empty( $speaker['featured'] ) ) {
+			$speakers[ $key ]['featured'] = true;
+		}
+
+		if ( ! empty( $speaker['featured_order'] ) ) {
+			$current_order = isset( $speakers[ $key ]['featured_order'] ) ? absint( $speakers[ $key ]['featured_order'] ) : 0;
+			$new_order     = absint( $speaker['featured_order'] );
+			if ( ! $current_order || $new_order < $current_order ) {
+				$speakers[ $key ]['featured_order'] = $new_order;
+			}
+		}
+
+		if ( empty( $session ) ) {
+			return;
+		}
+
+		$session_ids = wp_list_pluck( $speakers[ $key ]['sessions'], 'id' );
+		if ( empty( $session['id'] ) || ! in_array( $session['id'], $session_ids, true ) ) {
+			$speakers[ $key ]['sessions'][] = $session;
+		}
+	}
+
+	/**
+	 * Preserve dashboard-only speaker state across Eventyay syncs.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $imported Imported Eventyay speakers.
+	 * @param array $existing Existing dashboard speakers.
+	 * @return array
+	 */
+	private function merge_dashboard_speaker_state( $imported, $existing ) {
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$state = array();
+		foreach ( $existing as $speaker ) {
+			if ( ! is_array( $speaker ) ) {
 				continue;
 			}
 
-			$part = $this->eventyay_text_value( $value[ $key ] );
-			if ( '' !== $part ) {
-				$parts[] = $part;
+			foreach ( $this->get_dashboard_speaker_state_keys( $speaker ) as $key ) {
+				$state[ $key ] = array(
+					'featured'       => ! empty( $speaker['featured'] ),
+					'featured_order' => isset( $speaker['featured_order'] ) ? absint( $speaker['featured_order'] ) : null,
+					'image'          => isset( $speaker['image'] ) ? esc_url_raw( $speaker['image'] ) : '',
+				);
 			}
 		}
 
-		if ( ! empty( $parts ) ) {
-			return implode( ', ', array_values( array_unique( $parts ) ) );
+		foreach ( $imported as &$speaker ) {
+			foreach ( $this->get_dashboard_speaker_state_keys( $speaker ) as $key ) {
+				if ( ! isset( $state[ $key ] ) ) {
+					continue;
+				}
+
+				$speaker['featured'] = ! empty( $speaker['featured'] ) || $state[ $key ]['featured'];
+				if ( null !== $state[ $key ]['featured_order'] ) {
+					$speaker['featured_order'] = $state[ $key ]['featured_order'];
+				}
+				if ( empty( $speaker['image'] ) && ! empty( $state[ $key ]['image'] ) ) {
+					$speaker['image'] = $state[ $key ]['image'];
+				}
+				break;
+			}
+		}
+		unset( $speaker );
+
+		foreach ( $existing as $speaker ) {
+			if ( ! is_array( $speaker ) || $this->is_eventyay_dashboard_speaker( $speaker ) ) {
+				continue;
+			}
+
+			$imported[] = $speaker;
 		}
 
-		return $this->eventyay_text_value( $value );
+		return array_values( $imported );
+	}
+
+	/**
+	 * Get matching keys used to preserve dashboard speaker state.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $speaker Speaker data.
+	 * @return array
+	 */
+	private function get_dashboard_speaker_state_keys( $speaker ) {
+		$keys = array();
+
+		if ( ! empty( $speaker['eventyay_speaker_id'] ) ) {
+			$keys[] = 'eventyay:' . sanitize_text_field( $speaker['eventyay_speaker_id'] );
+		}
+
+		if ( ! empty( $speaker['id'] ) ) {
+			$keys[] = 'id:' . sanitize_text_field( $speaker['id'] );
+		}
+
+		if ( ! empty( $speaker['name'] ) ) {
+			$keys[] = 'name:' . sanitize_title( $speaker['name'] );
+		}
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	/**
+	 * Determine whether a dashboard speaker record originated from Eventyay.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $speaker Speaker data.
+	 * @return bool
+	 */
+	private function is_eventyay_dashboard_speaker( $speaker ) {
+		if ( isset( $speaker['source'] ) && 'eventyay' === $speaker['source'] ) {
+			return true;
+		}
+
+		return ! empty( $speaker['id'] ) && 0 === strpos( (string) $speaker['id'], 'eventyay-' );
+	}
+
+	/**
+	 * Upsert synced speakers into the maintained speaker CPT path.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $speakers Imported speakers.
+	 * @param int   $event_id Event post ID.
+	 * @return array
+	 */
+	private function sync_eventyay_speaker_posts( $speakers, $event_id ) {
+		$result         = array(
+			'created'      => 0,
+			'updated'      => 0,
+			'ids'          => array(),
+			'featured_ids' => array(),
+		);
+		$featured_posts = array();
+
+		$event_status   = $event_id ? get_post_status( $event_id ) : 'draft';
+		$speaker_status = 'publish' === $event_status ? 'publish' : 'draft';
+
+		foreach ( $speakers as $speaker ) {
+			$upsert = $this->upsert_eventyay_speaker_post( $speaker, $speaker_status );
+
+			if ( is_wp_error( $upsert ) || empty( $upsert['id'] ) ) {
+				continue;
+			}
+
+			$result['ids'][] = absint( $upsert['id'] );
+			if ( ! empty( $speaker['featured'] ) ) {
+				$featured_posts[] = array(
+					'id'    => absint( $upsert['id'] ),
+					'order' => isset( $speaker['featured_order'] ) ? absint( $speaker['featured_order'] ) : 0,
+					'name'  => isset( $speaker['name'] ) ? sanitize_text_field( $speaker['name'] ) : '',
+				);
+			}
+
+			if ( ! empty( $upsert['created'] ) ) {
+				++$result['created'];
+			} else {
+				++$result['updated'];
+			}
+		}
+
+		$result['ids'] = $this->sanitize_eventyay_post_id_list( $result['ids'] );
+		usort(
+			$featured_posts,
+			static function ( $speaker_a, $speaker_b ) {
+				if ( $speaker_a['order'] !== $speaker_b['order'] ) {
+					if ( ! $speaker_a['order'] ) {
+						return 1;
+					}
+
+					if ( ! $speaker_b['order'] ) {
+						return -1;
+					}
+
+					return $speaker_a['order'] < $speaker_b['order'] ? -1 : 1;
+				}
+
+				return strcasecmp( $speaker_a['name'], $speaker_b['name'] );
+			}
+		);
+		$result['featured_ids'] = $this->sanitize_eventyay_post_id_list( wp_list_pluck( $featured_posts, 'id' ) );
+
+		if ( $event_id && 'wpfa_event' === get_post_type( $event_id ) ) {
+			$previous_speakers = $this->get_eventyay_event_speaker_ids( $event_id );
+			$previous_featured = $this->get_eventyay_event_featured_speaker_ids( $event_id );
+			$manual_speakers   = array_values(
+				array_filter(
+					$previous_speakers,
+					function ( $speaker_id ) {
+						return ! $this->is_eventyay_speaker_post( $speaker_id );
+					}
+				)
+			);
+			$current_speakers  = $this->sanitize_eventyay_post_id_list( array_merge( $manual_speakers, $result['ids'] ) );
+			$manual_featured   = array_values(
+				array_filter(
+					$previous_featured,
+					function ( $speaker_id ) {
+						return ! $this->is_eventyay_speaker_post( $speaker_id );
+					}
+				)
+			);
+			$current_featured  = $this->sanitize_eventyay_post_id_list( array_merge( $manual_featured, $result['featured_ids'] ) );
+			$current_featured  = array_values( array_intersect( $current_featured, $current_speakers ) );
+
+			if ( empty( $current_speakers ) ) {
+				delete_post_meta( $event_id, 'wpfa_event_speakers' );
+			} else {
+				update_post_meta( $event_id, 'wpfa_event_speakers', $current_speakers );
+			}
+
+			if ( empty( $current_featured ) ) {
+				delete_post_meta( $event_id, 'wpfa_event_featured_speakers' );
+			} else {
+				update_post_meta( $event_id, 'wpfa_event_featured_speakers', $current_featured );
+			}
+			$this->sync_eventyay_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Determine whether a speaker post is managed by Eventyay import.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @return bool
+	 */
+	private function is_eventyay_speaker_post( $speaker_id ) {
+		$speaker_id = absint( $speaker_id );
+
+		return $speaker_id && '' !== trim( (string) get_post_meta( $speaker_id, '_wpfa_eventyay_speaker_id', true ) );
+	}
+
+	/**
+	 * Get normalized speaker IDs assigned to an event for Eventyay sync.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int>
+	 */
+	private function get_eventyay_event_speaker_ids( $event_id ) {
+		$speaker_ids = get_post_meta( $event_id, 'wpfa_event_speakers', true );
+
+		return $this->sanitize_eventyay_post_id_list( $speaker_ids );
+	}
+
+	/**
+	 * Get normalized featured speaker IDs assigned to an event for Eventyay sync.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int>
+	 */
+	private function get_eventyay_event_featured_speaker_ids( $event_id ) {
+		$speaker_ids = get_post_meta( $event_id, 'wpfa_event_featured_speakers', true );
+
+		return $this->sanitize_eventyay_post_id_list( $speaker_ids );
+	}
+
+	/**
+	 * Get normalized event IDs assigned to a speaker for Eventyay sync.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @return array<int>
+	 */
+	private function get_eventyay_speaker_event_ids( $speaker_id ) {
+		$event_ids = get_post_meta( $speaker_id, 'wpfa_speaker_events', true );
+
+		return $this->sanitize_eventyay_post_id_list( $event_ids );
+	}
+
+	/**
+	 * Sanitize, deduplicate, and reindex post IDs for Eventyay sync.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $post_ids Raw post IDs.
+	 * @return array<int>
+	 */
+	private function sanitize_eventyay_post_id_list( $post_ids ) {
+		if ( ! is_array( $post_ids ) ) {
+			return array();
+		}
+
+		$post_ids = array_map( 'absint', $post_ids );
+		$post_ids = array_filter( $post_ids );
+
+		return array_values( array_unique( $post_ids ) );
+	}
+
+	/**
+	 * Sync speaker-side event relationship meta after Eventyay import.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int        $event_id          Event post ID.
+	 * @param array<int> $previous_speakers Speaker IDs before sync.
+	 * @param array<int> $current_speakers  Speaker IDs after sync.
+	 * @return void
+	 */
+	private function sync_eventyay_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers ) {
+		$event_id          = absint( $event_id );
+		$previous_speakers = $this->sanitize_eventyay_post_id_list( $previous_speakers );
+		$current_speakers  = $this->sanitize_eventyay_post_id_list( $current_speakers );
+
+		if ( ! $event_id ) {
+			return;
+		}
+
+		foreach ( array_diff( $previous_speakers, $current_speakers ) as $speaker_id ) {
+			$this->remove_eventyay_event_from_speaker( $speaker_id, $event_id );
+		}
+
+		foreach ( $current_speakers as $speaker_id ) {
+			$this->add_eventyay_event_to_speaker( $speaker_id, $event_id );
+		}
+	}
+
+	/**
+	 * Add an event ID to a speaker's related events for Eventyay sync.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @param int $event_id   Event post ID.
+	 * @return void
+	 */
+	private function add_eventyay_event_to_speaker( $speaker_id, $event_id ) {
+		$speaker_id = absint( $speaker_id );
+		$event_id   = absint( $event_id );
+
+		if ( ! $speaker_id || ! $event_id || 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
+			return;
+		}
+
+		$event_ids   = $this->get_eventyay_speaker_event_ids( $speaker_id );
+		$event_ids[] = $event_id;
+
+		update_post_meta( $speaker_id, 'wpfa_speaker_events', $this->sanitize_eventyay_post_id_list( $event_ids ) );
+	}
+
+	/**
+	 * Remove an event ID from a speaker's related events for Eventyay sync.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @param int $event_id   Event post ID.
+	 * @return void
+	 */
+	private function remove_eventyay_event_from_speaker( $speaker_id, $event_id ) {
+		$speaker_id = absint( $speaker_id );
+		$event_id   = absint( $event_id );
+
+		if ( ! $speaker_id || ! $event_id ) {
+			return;
+		}
+
+		$event_ids = array_diff( $this->get_eventyay_speaker_event_ids( $speaker_id ), array( $event_id ) );
+		$event_ids = $this->sanitize_eventyay_post_id_list( $event_ids );
+
+		if ( empty( $event_ids ) ) {
+			delete_post_meta( $speaker_id, 'wpfa_speaker_events' );
+			return;
+		}
+
+		update_post_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
+	}
+
+	/**
+	 * Create or update one Eventyay speaker post.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $speaker Speaker data.
+	 * @return array|WP_Error
+	 */
+	private function upsert_eventyay_speaker_post( $speaker, $post_status = 'draft' ) {
+		if ( empty( $speaker['eventyay_speaker_id'] ) || empty( $speaker['name'] ) ) {
+			return new WP_Error(
+				'eventyay_speaker_missing_id',
+				esc_html__( 'Eventyay speaker is missing an ID or name.', 'wpfaevent' )
+			);
+		}
+
+		$allowed_statuses = array( 'draft', 'publish', 'pending', 'private' );
+		if ( ! in_array( $post_status, $allowed_statuses, true ) ) {
+			$post_status = 'draft';
+		}
+
+		$speaker_id = $this->find_eventyay_speaker_post( $speaker['eventyay_speaker_id'] );
+		$post_data  = array(
+			'post_title'   => sanitize_text_field( $speaker['name'] ),
+			'post_type'    => 'wpfa_speaker',
+			'post_status'  => $post_status,
+			'post_content' => wp_kses_post( $speaker['bio'] ),
+		);
+		$created    = false;
+
+		if ( $speaker_id ) {
+			$post_data['ID'] = $speaker_id;
+			$saved_id        = wp_update_post( $post_data, true );
+		} else {
+			$saved_id = wp_insert_post( $post_data, true );
+			$created  = true;
+		}
+
+		if ( is_wp_error( $saved_id ) ) {
+			return $saved_id;
+		}
+
+		$saved_id = absint( $saved_id );
+		if ( ! $saved_id ) {
+			return new WP_Error(
+				'eventyay_speaker_save_failed',
+				esc_html__( 'Could not save Eventyay speaker.', 'wpfaevent' )
+			);
+		}
+
+		$session = ! empty( $speaker['sessions'][0] ) && is_array( $speaker['sessions'][0] ) ? $speaker['sessions'][0] : array();
+		$social  = ! empty( $speaker['social'] ) && is_array( $speaker['social'] ) ? $speaker['social'] : array();
+
+		update_post_meta( $saved_id, '_wpfa_eventyay_speaker_id', sanitize_text_field( $speaker['eventyay_speaker_id'] ) );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_position', $speaker['position'] );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_organization', $speaker['organization'] );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_bio', $speaker['bio'] );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_headshot_url', $speaker['image'] );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_linkedin', isset( $social['linkedin'] ) ? $social['linkedin'] : '' );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_twitter', isset( $social['twitter'] ) ? $social['twitter'] : '' );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_github', isset( $social['github'] ) ? $social['github'] : '' );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_website', isset( $social['website'] ) ? $social['website'] : '' );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_talk_title', isset( $session['title'] ) ? $session['title'] : '' );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_talk_date', isset( $session['date'] ) ? $session['date'] : '' );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_talk_time', isset( $session['time'] ) ? $session['time'] : '' );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_talk_end_time', isset( $session['end_time'] ) ? $session['end_time'] : '' );
+		$this->update_or_delete_post_meta( $saved_id, 'wpfa_speaker_talk_abstract', isset( $session['abstract'] ) ? $session['abstract'] : '' );
+
+		if ( ! empty( $speaker['category'] ) && taxonomy_exists( 'wpfa_speaker_category' ) ) {
+			wp_set_object_terms( $saved_id, sanitize_text_field( $speaker['category'] ), 'wpfa_speaker_category' );
+		}
+
+		return array(
+			'id'      => $saved_id,
+			'created' => $created,
+		);
+	}
+
+	/**
+	 * Find an existing speaker post by Eventyay speaker ID.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $eventyay_speaker_id Eventyay speaker ID.
+	 * @return int
+	 */
+	private function find_eventyay_speaker_post( $eventyay_speaker_id ) {
+		$speaker_ids = get_posts(
+			array(
+				'post_type'      => 'wpfa_speaker',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Eventyay IDs are stored in speaker post meta for sync idempotency.
+				'meta_key'       => '_wpfa_eventyay_speaker_id',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Eventyay IDs are stored in speaker post meta for sync idempotency.
+				'meta_value'     => sanitize_text_field( $eventyay_speaker_id ),
+			)
+		);
+
+		return ! empty( $speaker_ids[0] ) ? absint( $speaker_ids[0] ) : 0;
 	}
 
 	/**
@@ -2132,7 +5152,6 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $jsonapi_resource JSON:API resource.
 	 * @return array
-	 * @phpstan-ignore method.unused
 	 */
 	private function get_jsonapi_attributes( $jsonapi_resource ) {
 		return isset( $jsonapi_resource['attributes'] ) && is_array( $jsonapi_resource['attributes'] ) ? $jsonapi_resource['attributes'] : array();
@@ -2146,7 +5165,6 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $attributes Attribute map.
 	 * @param array $keys       Candidate keys.
 	 * @return string
-	 * @phpstan-ignore method.unused
 	 */
 	private function attribute_value( $attributes, $keys ) {
 		foreach ( $keys as $key ) {
@@ -2159,6 +5177,97 @@ class Wpfaevent_Eventyay_Importer {
 	}
 
 	/**
+	 * Index JSON:API included resources by type and ID.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $resources Included resources.
+	 * @return array
+	 */
+	private function index_jsonapi_resources( $resources ) {
+		$index = array();
+
+		if ( ! is_array( $resources ) ) {
+			return $index;
+		}
+
+		foreach ( $resources as $resource ) {
+			if ( ! $this->is_jsonapi_resource( $resource ) ) {
+				continue;
+			}
+
+			$key           = $this->jsonapi_resource_key( $resource['type'], $resource['id'] );
+			$index[ $key ] = $resource;
+		}
+
+		return $index;
+	}
+
+	/**
+	 * Resolve a relationship identifier from included resources.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $resource_identifier JSON:API resource identifier.
+	 * @param array $included            Indexed included resources.
+	 * @return array
+	 */
+	private function resolve_jsonapi_resource( $resource_identifier, $included ) {
+		if ( ! $this->is_jsonapi_resource( $resource_identifier ) ) {
+			return array();
+		}
+
+		$type       = strtolower( (string) $resource_identifier['type'] );
+		$id         = (string) $resource_identifier['id'];
+		$candidates = array( $type );
+
+		if ( 's' === substr( $type, -1 ) ) {
+			$candidates[] = substr( $type, 0, -1 );
+		} else {
+			$candidates[] = $type . 's';
+		}
+
+		foreach ( array_unique( $candidates ) as $candidate_type ) {
+			$key = $this->jsonapi_resource_key( $candidate_type, $id );
+			if ( isset( $included[ $key ] ) ) {
+				return $included[ $key ];
+			}
+		}
+
+		if ( ! empty( $resource_identifier['attributes'] ) ) {
+			return $resource_identifier;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Get relationship resources as a list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $jsonapi_resource JSON:API resource.
+	 * @param string $name             Relationship name.
+	 * @return array
+	 */
+	private function get_jsonapi_relationship_resources( $jsonapi_resource, $name ) {
+		if ( empty( $jsonapi_resource['relationships'][ $name ] ) || ! is_array( $jsonapi_resource['relationships'][ $name ] ) ) {
+			return array();
+		}
+
+		$relationship = $jsonapi_resource['relationships'][ $name ];
+		if ( ! array_key_exists( 'data', $relationship ) || null === $relationship['data'] ) {
+			return array();
+		}
+
+		if ( $this->is_jsonapi_resource( $relationship['data'] ) ) {
+			return array( $relationship['data'] );
+		}
+
+		return is_array( $relationship['data'] ) ? $relationship['data'] : array();
+	}
+
+	/**
 	 * Determine whether an array resembles a JSON:API resource.
 	 *
 	 * @since 1.0.0
@@ -2168,6 +5277,39 @@ class Wpfaevent_Eventyay_Importer {
 	 */
 	private function is_jsonapi_resource( $maybe_resource ) {
 		return is_array( $maybe_resource ) && isset( $maybe_resource['type'], $maybe_resource['id'] );
+	}
+
+	/**
+	 * Compare a JSON:API resource type, accepting singular or plural forms.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $jsonapi_resource JSON:API resource.
+	 * @param string $type             Expected singular type.
+	 * @return bool
+	 */
+	private function jsonapi_type_is( $jsonapi_resource, $type ) {
+		if ( empty( $jsonapi_resource['type'] ) ) {
+			return false;
+		}
+
+		$resource_type = strtolower( (string) $jsonapi_resource['type'] );
+		$type          = strtolower( $type );
+
+		return $resource_type === $type || $resource_type === $type . 's';
+	}
+
+	/**
+	 * Build an index key for a JSON:API resource.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $type Resource type.
+	 * @param string $id   Resource ID.
+	 * @return string
+	 */
+	private function jsonapi_resource_key( $type, $id ) {
+		return strtolower( (string) $type ) . ':' . (string) $id;
 	}
 
 	/**
@@ -2284,6 +5426,136 @@ class Wpfaevent_Eventyay_Importer {
 		}
 
 		return $date->format( DATE_ATOM );
+	}
+
+	/**
+	 * Read a dashboard JSON file from the uploads data directory.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $filename File name.
+	 * @param mixed  $fallback Fallback value.
+	 * @return mixed
+	 */
+	private function read_dashboard_json_file( $filename, $fallback ) {
+		$path = $this->get_dashboard_json_path( $filename );
+		if ( is_wp_error( $path ) ) {
+			return $fallback;
+		}
+
+		$filesystem = $this->get_wp_filesystem();
+		if ( is_wp_error( $filesystem ) || ! $filesystem->exists( $path ) ) {
+			return $fallback;
+		}
+
+		$contents = $filesystem->get_contents( $path );
+		if ( false === $contents || '' === trim( $contents ) ) {
+			return $fallback;
+		}
+
+		$decoded = json_decode( $contents, true );
+
+		return ( JSON_ERROR_NONE === json_last_error() ) ? $decoded : $fallback;
+	}
+
+	/**
+	 * Write a dashboard JSON file into the uploads data directory.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $filename File name.
+	 * @param mixed  $data     Data to write.
+	 * @return true|WP_Error
+	 */
+	private function write_dashboard_json_file( $filename, $data ) {
+		$path = $this->get_dashboard_json_path( $filename );
+		if ( is_wp_error( $path ) ) {
+			return $path;
+		}
+
+		$filesystem = $this->get_wp_filesystem();
+		if ( is_wp_error( $filesystem ) ) {
+			return $filesystem;
+		}
+
+		$json = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		if ( false === $json ) {
+			return new WP_Error(
+				'eventyay_json_encode_failed',
+				esc_html__( 'Could not encode synced Eventyay dashboard data.', 'wpfaevent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$chmod_file = defined( 'FS_CHMOD_FILE' ) ? FS_CHMOD_FILE : 0644;
+		if ( ! $filesystem->put_contents( $path, $json, $chmod_file ) ) {
+			return new WP_Error(
+				'eventyay_json_write_failed',
+				esc_html__( 'Could not write synced Eventyay dashboard data to the dashboard data file.', 'wpfaevent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get a safe dashboard JSON path under the uploads data directory.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $filename File name.
+	 * @return string|WP_Error
+	 */
+	private function get_dashboard_json_path( $filename ) {
+		$upload_dir = wp_upload_dir();
+
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return new WP_Error(
+				'eventyay_upload_dir_failed',
+				esc_html__( 'Could not access the WordPress uploads directory.', 'wpfaevent' ),
+				array(
+					'status'  => 500,
+					'details' => $upload_dir['error'],
+				)
+			);
+		}
+
+		$data_dir = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data';
+		if ( ! wp_mkdir_p( $data_dir ) ) {
+			return new WP_Error(
+				'eventyay_data_dir_failed',
+				esc_html__( 'Could not create the dashboard data directory.', 'wpfaevent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return trailingslashit( $data_dir ) . sanitize_file_name( $filename );
+	}
+
+	/**
+	 * Initialize and return the WordPress filesystem API.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return WP_Filesystem_Base|WP_Error
+	 */
+	private function get_wp_filesystem() {
+		global $wp_filesystem;
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! WP_Filesystem() || ! $wp_filesystem ) {
+			return new WP_Error(
+				'eventyay_filesystem_failed',
+				esc_html__( 'Could not initialize the WordPress filesystem.', 'wpfaevent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return $wp_filesystem;
 	}
 
 	/**

--- a/assets/images/speaker-placeholder.svg
+++ b/assets/images/speaker-placeholder.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-labelledby="title desc">
+	<title id="title">Speaker placeholder</title>
+	<desc id="desc">A neutral speaker profile placeholder image.</desc>
+	<defs>
+		<linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+			<stop offset="0" stop-color="#f8d8d6"/>
+			<stop offset="0.58" stop-color="#f4f7fb"/>
+			<stop offset="1" stop-color="#dfe9f3"/>
+		</linearGradient>
+		<linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+			<stop offset="0" stop-color="#d51007"/>
+			<stop offset="1" stop-color="#b20d06"/>
+		</linearGradient>
+	</defs>
+	<rect width="600" height="600" fill="url(#bg)"/>
+	<circle cx="476" cy="118" r="96" fill="#fff" opacity="0.54"/>
+	<circle cx="96" cy="486" r="126" fill="#d51007" opacity="0.08"/>
+	<circle cx="300" cy="245" r="105" fill="#ffffff"/>
+	<circle cx="300" cy="245" r="78" fill="#d8e3ee"/>
+	<path d="M128 526c20-108 96-168 172-168s152 60 172 168" fill="#ffffff"/>
+	<path d="M164 526c24-77 82-116 136-116s112 39 136 116" fill="#d8e3ee"/>
+	<path d="M70 0h92v600H70z" fill="url(#accent)" opacity="0.92"/>
+	<path d="M92 120h48v240H92z" fill="#fff" opacity="0.18"/>
+</svg>

--- a/docs/speaker-data-model.md
+++ b/docs/speaker-data-model.md
@@ -29,17 +29,35 @@ Events store their assigned speakers in `wpfa_event_speakers` as an array of `wp
 
 When an event is saved, the event-speaker sync flow keeps both sides aligned:
 
-1. Read the previous `wpfa_event_speakers` value.
+1. Read the previous `wpfa_event_speakers` value and merge any reverse `wpfa_speaker_events` links already pointing to the event.
 2. Sanitize and save the current speaker IDs on the event.
 3. Add the event ID to every newly assigned speaker's `wpfa_speaker_events`.
 4. Remove the event ID from speakers that were removed from the event.
 
 The Speaker edit screen also exposes the same relationship from the speaker side. Saving the speaker's related events writes `wpfa_speaker_events` and syncs each selected or removed event's `wpfa_event_speakers` list.
 
-Speaker profile pages use `wpfa_speaker_events` first and also check `wpfa_event_speakers` as a fallback so older data can still render linked events.
+Speaker profile pages merge `wpfa_speaker_events` with events that reference the speaker through `wpfa_event_speakers`, so older one-sided data can still render linked published events.
 
 ## Session Data
 
 There is not yet a reusable Session CPT or session relationship model. Until that exists, the speaker profile displays the interim `wpfa_speaker_talk_*` metadata as "Sessions by this speaker".
 
 When a reusable session data model is added, speaker profiles should move from the interim talk fields to a dedicated session relationship and keep these fields only for migration/backward compatibility.
+
+## Eventyay Import Data Ownership
+
+Imported Eventyay data is written to dashboard JSON under `uploads/fossasia-data/`. Reimports follow these ownership rules:
+
+| Data | Reimport behaviour |
+| --- | --- |
+| Eventyay event metadata | Updated from Eventyay |
+| Eventyay speaker (`source = eventyay`) | Updated from Eventyay; post status follows linked event (`publish` only when event is published, otherwise `draft`) |
+| Manual speaker | Preserved and kept linked to the event |
+| Eventyay sponsor group or sponsor (`source = eventyay`) | Replaced on reimport |
+| Manual sponsor group | Preserved across reimport |
+| Eventyay exhibitor (`source = eventyay`) | Replaced on reimport |
+| Manual exhibitor | Preserved across reimport |
+| Featured speaker flag set manually | Preserved; Eventyay featured speakers are merged without removing manual featured selections |
+| Eventyay schedule (`source = eventyay`) | Replaced unless a manual schedule with a different source already exists |
+
+Manual records are identified by the absence of `source = eventyay` on the stored group, sponsor, exhibitor, or speaker post metadata.

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -206,6 +206,39 @@ class Wpfaevent_Meta_Event {
 			)
 		);
 
+		register_post_meta(
+			self::$post_type,
+			'wpfa_event_languages',
+			array(
+				'type'              => 'array',
+				'single'            => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type' => 'string',
+						),
+					),
+				),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_language_list' ),
+				'description'       => __( 'Event languages', 'wpfaevent' ),
+			)
+		);
+
+		foreach ( self::get_event_color_meta_fields() as $meta_key => $label ) {
+			register_post_meta(
+				self::$post_type,
+				$meta_key,
+				array(
+					'type'              => 'string',
+					'single'            => true,
+					'show_in_rest'      => true,
+					'sanitize_callback' => array( __CLASS__, 'sanitize_color_value' ),
+					'description'       => $label,
+				)
+			);
+		}
+
 		// Event speakers as an array of speaker IDs.
 		register_post_meta(
 			self::$post_type,
@@ -244,6 +277,79 @@ class Wpfaevent_Meta_Event {
 		$speaker_ids = array_filter( $speaker_ids );
 
 		return array_values( array_unique( $speaker_ids ) );
+	}
+
+	/**
+	 * Sync speaker-side event relationship meta after an event is saved.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int        $event_id          Event post ID.
+	 * @param array<int> $previous_speakers Speaker IDs before save.
+	 * @param array<int> $current_speakers  Speaker IDs after save.
+	 */
+	private static function sync_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers ) {
+		$event_id          = absint( $event_id );
+		$previous_speakers = self::sanitize_post_id_list(
+			array_merge(
+				self::sanitize_post_id_list( $previous_speakers ),
+				Wpfaevent_Meta_Speaker::get_speakers_linked_to_event( $event_id )
+			)
+		);
+		$current_speakers  = self::sanitize_post_id_list( $current_speakers );
+
+		if ( ! $event_id ) {
+			return;
+		}
+
+		foreach ( array_diff( $previous_speakers, $current_speakers ) as $speaker_id ) {
+			Wpfaevent_Meta_Speaker::remove_event_from_speaker( $speaker_id, $event_id, false );
+		}
+
+		foreach ( $current_speakers as $speaker_id ) {
+			Wpfaevent_Meta_Speaker::add_event_to_speaker( $speaker_id, $event_id, false );
+		}
+	}
+
+	/**
+	 * Sanitize, deduplicate, and reindex a list of post IDs.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $post_ids Raw post IDs.
+	 * @return array<int>
+	 */
+	public static function sanitize_post_id_list( $post_ids ) {
+		if ( is_array( $post_ids ) ) {
+			$normalized_post_ids = $post_ids;
+		} elseif ( is_scalar( $post_ids ) ) {
+			if ( is_string( $post_ids ) ) {
+				$post_ids = trim( $post_ids );
+			}
+
+			if ( '' === $post_ids ) {
+				return array();
+			}
+
+			$decoded_post_ids = is_string( $post_ids ) ? json_decode( $post_ids, true ) : null;
+
+			if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded_post_ids ) ) {
+				$normalized_post_ids = $decoded_post_ids;
+			} elseif ( JSON_ERROR_NONE === json_last_error() && is_scalar( $decoded_post_ids ) ) {
+				$normalized_post_ids = array( $decoded_post_ids );
+			} elseif ( is_string( $post_ids ) && false !== strpos( $post_ids, ',' ) ) {
+				$normalized_post_ids = array_map( 'trim', explode( ',', $post_ids ) );
+			} else {
+				$normalized_post_ids = array( $post_ids );
+			}
+		} else {
+			return array();
+		}
+
+		$post_ids = array_map( 'absint', $normalized_post_ids );
+		$post_ids = array_filter( $post_ids );
+
+		return array_values( array_unique( $post_ids ) );
 	}
 
 	/**
@@ -417,6 +523,119 @@ class Wpfaevent_Meta_Event {
 		}
 
 		return $datetime->format( DATE_ATOM );
+	}
+
+	/**
+	 * Event color meta fields imported from Eventyay settings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, string>
+	 */
+	public static function get_event_color_meta_fields() {
+		return array(
+			'wpfa_event_primary_color'          => __( 'Primary color', 'wpfaevent' ),
+			'wpfa_event_hover_button_color'     => __( 'Button hover color', 'wpfaevent' ),
+			'wpfa_event_theme_background_color' => __( 'Theme background color', 'wpfaevent' ),
+			'wpfa_event_theme_success_color'    => __( 'Theme success color', 'wpfaevent' ),
+			'wpfa_event_theme_danger_color'     => __( 'Theme danger color', 'wpfaevent' ),
+		);
+	}
+
+	/**
+	 * Sanitize event language values.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $languages Raw language list.
+	 * @return array<string>
+	 */
+	public static function sanitize_language_list( $languages ) {
+		if ( is_string( $languages ) ) {
+			$decoded = json_decode( $languages, true );
+			if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+				$languages = $decoded;
+			} else {
+				$languages = preg_split( '/[,|]/', $languages );
+			}
+		}
+
+		if ( is_scalar( $languages ) ) {
+			$languages = array( $languages );
+		}
+
+		if ( ! is_array( $languages ) ) {
+			return array();
+		}
+
+		$normalized = array();
+
+		foreach ( $languages as $language ) {
+			if ( is_array( $language ) ) {
+				foreach ( array( 'name', 'label', 'title', 'code', 'locale', 'language' ) as $key ) {
+					if ( ! empty( $language[ $key ] ) && is_scalar( $language[ $key ] ) ) {
+						$language = $language[ $key ];
+						break;
+					}
+				}
+			}
+
+			if ( ! is_scalar( $language ) ) {
+				continue;
+			}
+
+			$language = sanitize_text_field( (string) $language );
+			$language = trim( $language );
+
+			if ( '' !== $language ) {
+				$normalized[] = $language;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
+	}
+
+	/**
+	 * Sanitize an imported event color value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $color Raw color.
+	 * @return string
+	 */
+	public static function sanitize_color_value( $color ) {
+		if ( is_array( $color ) ) {
+			foreach ( array( 'value', 'color', 'hex', 'default' ) as $key ) {
+				if ( isset( $color[ $key ] ) ) {
+					return self::sanitize_color_value( $color[ $key ] );
+				}
+			}
+
+			return '';
+		}
+
+		if ( ! is_scalar( $color ) ) {
+			return '';
+		}
+
+		$color = trim( sanitize_text_field( (string) $color ) );
+		if ( '' === $color ) {
+			return '';
+		}
+
+		if ( preg_match( '/^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/', $color ) ) {
+			return strtoupper( $color );
+		}
+
+		if ( preg_match( '/^[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/', $color ) ) {
+			return '#' . strtoupper( $color );
+		}
+
+		if ( preg_match( '/^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(\s*,\s*(0|1|0?\.\d+))?\s*\)$/', $color ) ) {
+			return $color;
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/meta/class-wpfaevent-meta-speaker.php
+++ b/includes/meta/class-wpfaevent-meta-speaker.php
@@ -112,6 +112,344 @@ class Wpfaevent_Meta_Speaker {
 	}
 
 	/**
+	 * Register the Speaker Details meta box.
+	 *
+	 * @since 1.0.0
+	 */
+	public static function add_meta_boxes() {
+		add_meta_box(
+			'wpfa_speaker_details',
+			__( 'Speaker Details', 'wpfaevent' ),
+			array( __CLASS__, 'render_meta_box' ),
+			self::$post_type,
+			'normal',
+			'high'
+		);
+
+		remove_meta_box( 'postcustom', self::$post_type, 'normal' );
+	}
+
+	/**
+	 * Render the Speaker Details meta box.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Post $post Speaker post object.
+	 */
+	public static function render_meta_box( $post ) {
+		wp_nonce_field( 'wpfa_speaker_meta_nonce', 'wpfa_speaker_meta_nonce' );
+
+		$position     = get_post_meta( $post->ID, 'wpfa_speaker_position', true );
+		$organization = get_post_meta( $post->ID, 'wpfa_speaker_organization', true );
+		$bio          = get_post_meta( $post->ID, 'wpfa_speaker_bio', true );
+		$headshot_url = get_post_meta( $post->ID, 'wpfa_speaker_headshot_url', true );
+		?>
+		<table class="form-table">
+			<tr>
+				<th><label for="wpfa_speaker_position"><?php esc_html_e( 'Position/Title', 'wpfaevent' ); ?></label></th>
+				<td><input type="text" id="wpfa_speaker_position" name="wpfa_speaker_position" value="<?php echo esc_attr( $position ); ?>" class="regular-text"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_speaker_organization"><?php esc_html_e( 'Organization', 'wpfaevent' ); ?></label></th>
+				<td><input type="text" id="wpfa_speaker_organization" name="wpfa_speaker_organization" value="<?php echo esc_attr( $organization ); ?>" class="regular-text"></td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_speaker_bio"><?php esc_html_e( 'Biography', 'wpfaevent' ); ?></label></th>
+				<td>
+					<?php
+					wp_editor(
+						$bio,
+						'wpfa_speaker_bio',
+						array(
+							'textarea_name' => 'wpfa_speaker_bio',
+							'textarea_rows' => 10,
+							'media_buttons' => false,
+						)
+					);
+					?>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="wpfa_speaker_headshot_url"><?php esc_html_e( 'Headshot URL', 'wpfaevent' ); ?></label></th>
+				<td><input type="url" id="wpfa_speaker_headshot_url" name="wpfa_speaker_headshot_url" value="<?php echo esc_attr( $headshot_url ); ?>" class="regular-text" placeholder="https://"></td>
+			</tr>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Save Speaker Details meta box data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id Speaker post ID.
+	 */
+	public static function save_meta( $post_id ) {
+		$speaker_nonce = isset( $_POST['wpfa_speaker_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_speaker_meta_nonce'] ) ) : '';
+
+		if ( ! $speaker_nonce || ! wp_verify_nonce( $speaker_nonce, 'wpfa_speaker_meta_nonce' ) ) {
+			return;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		if ( isset( $_POST['wpfa_speaker_position'] ) ) {
+			update_post_meta( $post_id, 'wpfa_speaker_position', sanitize_text_field( wp_unslash( $_POST['wpfa_speaker_position'] ) ) );
+		}
+
+		if ( isset( $_POST['wpfa_speaker_organization'] ) ) {
+			update_post_meta( $post_id, 'wpfa_speaker_organization', sanitize_text_field( wp_unslash( $_POST['wpfa_speaker_organization'] ) ) );
+		}
+
+		if ( isset( $_POST['wpfa_speaker_bio'] ) ) {
+			update_post_meta( $post_id, 'wpfa_speaker_bio', wp_kses_post( wp_unslash( $_POST['wpfa_speaker_bio'] ) ) );
+		}
+
+		if ( isset( $_POST['wpfa_speaker_headshot_url'] ) ) {
+			update_post_meta( $post_id, 'wpfa_speaker_headshot_url', esc_url_raw( wp_unslash( $_POST['wpfa_speaker_headshot_url'] ) ) );
+		}
+	}
+
+	/**
+	 * Find speakers whose speaker-side event meta includes an event.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array<int>
+	 */
+	public static function get_speakers_linked_to_event( $event_id ) {
+		$event_id = absint( $event_id );
+
+		if ( ! $event_id ) {
+			return array();
+		}
+
+		$speaker_ids = get_posts(
+			array(
+				'post_type'      => self::$post_type,
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
+				'meta_query'     => array(
+					'relation' => 'OR',
+					array(
+						'key'     => 'wpfa_speaker_events',
+						'value'   => 'i:' . $event_id . ';',
+						'compare' => 'LIKE',
+					),
+					array(
+						'key'     => 'wpfa_speaker_events',
+						'value'   => '"' . $event_id . '"',
+						'compare' => 'LIKE',
+					),
+					array(
+						'key'     => 'wpfa_speaker_events',
+						'value'   => (string) $event_id,
+						'compare' => '=',
+					),
+				),
+			)
+		);
+
+		return Wpfaevent_Meta_Event::sanitize_post_id_list( $speaker_ids );
+	}
+
+	/**
+	 * Find all speakers with any event relationship.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int>
+	 */
+	public static function get_all_speakers_linked_to_events() {
+		$speaker_ids = get_posts(
+			array(
+				'post_type'      => self::$post_type,
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Speaker ownership is stored in post meta.
+				'meta_key'       => 'wpfa_speaker_events',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_compare -- Speaker ownership is stored in post meta.
+				'meta_compare'   => 'EXISTS',
+			)
+		);
+
+		return Wpfaevent_Meta_Event::sanitize_post_id_list( $speaker_ids );
+	}
+
+	/**
+	 * Find events whose event-side speaker meta includes a speaker.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int          $speaker_id  Speaker post ID.
+	 * @param string|array $post_status Event post status filter.
+	 * @return array<int>
+	 */
+	public static function get_events_referencing_speaker( $speaker_id, $post_status = 'any' ) {
+		$speaker_id = absint( $speaker_id );
+
+		if ( ! $speaker_id ) {
+			return array();
+		}
+
+		$event_ids = get_posts(
+			array(
+				'post_type'      => 'wpfa_event',
+				'post_status'    => $post_status,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Speaker-event links are stored in post meta.
+				'meta_query'     => array(
+					'relation' => 'OR',
+					array(
+						'key'     => 'wpfa_event_speakers',
+						'value'   => 'i:' . $speaker_id . ';',
+						'compare' => 'LIKE',
+					),
+					array(
+						'key'     => 'wpfa_event_speakers',
+						'value'   => '"' . $speaker_id . '"',
+						'compare' => 'LIKE',
+					),
+					array(
+						'key'     => 'wpfa_event_speakers',
+						'value'   => (string) $speaker_id,
+						'compare' => '=',
+					),
+				),
+			)
+		);
+
+		return Wpfaevent_Meta_Event::sanitize_post_id_list( $event_ids );
+	}
+
+	/**
+	 * Get normalized event IDs linked to a speaker from both relationship sides.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int          $speaker_id  Speaker post ID.
+	 * @param string|array $post_status Event post status filter.
+	 * @return array<int>
+	 */
+	public static function get_events_linked_to_speaker( $speaker_id, $post_status = 'publish' ) {
+		$speaker_id = absint( $speaker_id );
+
+		if ( ! $speaker_id || get_post_type( $speaker_id ) !== self::$post_type ) {
+			return array();
+		}
+
+		$event_ids = Wpfaevent_Meta_Event::sanitize_post_id_list(
+			array_merge(
+				self::get_speaker_event_ids( $speaker_id ),
+				self::get_events_referencing_speaker( $speaker_id, $post_status )
+			)
+		);
+
+		if ( empty( $event_ids ) || empty( $post_status ) || 'any' === $post_status ) {
+			return $event_ids;
+		}
+
+		$event_ids = get_posts(
+			array(
+				'post_type'      => 'wpfa_event',
+				'post_status'    => $post_status,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'post__in'       => $event_ids,
+				'orderby'        => 'post__in',
+				'no_found_rows'  => true,
+			)
+		);
+
+		return Wpfaevent_Meta_Event::sanitize_post_id_list( $event_ids );
+	}
+
+	/**
+	 * Add an event ID to a speaker's related events.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int  $speaker_id       Speaker post ID.
+	 * @param int  $event_id         Event post ID.
+	 * @param bool $check_capability Whether to require edit access to the speaker.
+	 */
+	public static function add_event_to_speaker( $speaker_id, $event_id, $check_capability = true ) {
+		$speaker_id = absint( $speaker_id );
+		$event_id   = absint( $event_id );
+
+		if ( ! $speaker_id || ! $event_id || get_post_type( $speaker_id ) !== self::$post_type ) {
+			return;
+		}
+
+		if ( $check_capability && ! current_user_can( 'edit_post', $speaker_id ) ) {
+			return;
+		}
+
+		$event_ids   = self::get_speaker_event_ids( $speaker_id );
+		$event_ids[] = $event_id;
+
+		update_post_meta( $speaker_id, 'wpfa_speaker_events', Wpfaevent_Meta_Event::sanitize_post_id_list( $event_ids ) );
+	}
+
+	/**
+	 * Remove an event ID from a speaker's related events.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int  $speaker_id       Speaker post ID.
+	 * @param int  $event_id         Event post ID.
+	 * @param bool $check_capability Whether to require edit access to the speaker.
+	 */
+	public static function remove_event_from_speaker( $speaker_id, $event_id, $check_capability = true ) {
+		$speaker_id = absint( $speaker_id );
+		$event_id   = absint( $event_id );
+
+		if ( ! $speaker_id || ! $event_id || get_post_type( $speaker_id ) !== self::$post_type ) {
+			return;
+		}
+
+		if ( $check_capability && ! current_user_can( 'edit_post', $speaker_id ) ) {
+			return;
+		}
+
+		$event_ids = array_diff( self::get_speaker_event_ids( $speaker_id ), array( $event_id ) );
+		$event_ids = Wpfaevent_Meta_Event::sanitize_post_id_list( $event_ids );
+
+		if ( empty( $event_ids ) ) {
+			delete_post_meta( $speaker_id, 'wpfa_speaker_events' );
+			return;
+		}
+
+		update_post_meta( $speaker_id, 'wpfa_speaker_events', $event_ids );
+	}
+
+	/**
+	 * Get normalized event IDs assigned to a speaker.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $speaker_id Speaker post ID.
+	 * @return array<int>
+	 */
+	public static function get_speaker_event_ids( $speaker_id ) {
+		return Wpfaevent_Meta_Event::sanitize_post_id_list( get_post_meta( $speaker_id, 'wpfa_speaker_events', true ) );
+	}
+
+	/**
 	 * Registers a single speaker string meta field.
 	 *
 	 * @since 1.0.0
@@ -143,13 +481,6 @@ class Wpfaevent_Meta_Speaker {
 	 * @return array Sanitized array of integers.
 	 */
 	public static function sanitize_event_ids( $event_ids ) {
-		if ( ! is_array( $event_ids ) ) {
-			return array();
-		}
-
-		$event_ids = array_map( 'absint', $event_ids );
-		$event_ids = array_filter( $event_ids );
-
-		return array_values( array_unique( $event_ids ) );
+		return Wpfaevent_Meta_Event::sanitize_post_id_list( $event_ids );
 	}
 }

--- a/tests/speaker-relationship-test.php
+++ b/tests/speaker-relationship-test.php
@@ -1,0 +1,318 @@
+<?php
+// phpcs:ignoreFile -- Standalone CLI test defines minimal WordPress stubs and executable assertions.
+/**
+ * Lightweight speaker/event relationship checks.
+ *
+ * Run with: php tests/speaker-relationship-test.php
+ *
+ * @package Wpfaevent
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['wpfa_relationship_test_meta']       = array();
+$GLOBALS['wpfa_relationship_test_post_types'] = array();
+$GLOBALS['wpfa_relationship_test_statuses']   = array();
+$GLOBALS['wpfa_relationship_test_can_edit']   = false;
+
+if ( ! function_exists( 'absint' ) ) {
+	/**
+	 * Minimal absint() fallback for standalone CLI tests.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return int
+	 */
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Minimal translation fallback for standalone CLI tests.
+	 *
+	 * @param string $text Text.
+	 * @return string
+	 */
+	function __( $text ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'get_post_type' ) ) {
+	/**
+	 * Read a stubbed post type.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string
+	 */
+	function get_post_type( $post_id ) {
+		return isset( $GLOBALS['wpfa_relationship_test_post_types'][ $post_id ] ) ? $GLOBALS['wpfa_relationship_test_post_types'][ $post_id ] : '';
+	}
+}
+
+if ( ! function_exists( 'get_post_meta' ) ) {
+	/**
+	 * Read stubbed post meta.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $key     Meta key.
+	 * @param bool   $single  Whether to return a single value.
+	 * @return mixed
+	 */
+	function get_post_meta( $post_id, $key, $single = false ) {
+		unset( $single );
+
+		return isset( $GLOBALS['wpfa_relationship_test_meta'][ $post_id ][ $key ] ) ? $GLOBALS['wpfa_relationship_test_meta'][ $post_id ][ $key ] : '';
+	}
+}
+
+if ( ! function_exists( 'update_post_meta' ) ) {
+	/**
+	 * Write stubbed post meta.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $key     Meta key.
+	 * @param mixed  $value   Meta value.
+	 * @return void
+	 */
+	function update_post_meta( $post_id, $key, $value ) {
+		$GLOBALS['wpfa_relationship_test_meta'][ $post_id ][ $key ] = $value;
+	}
+}
+
+if ( ! function_exists( 'delete_post_meta' ) ) {
+	/**
+	 * Delete stubbed post meta.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $key     Meta key.
+	 * @return void
+	 */
+	function delete_post_meta( $post_id, $key ) {
+		unset( $GLOBALS['wpfa_relationship_test_meta'][ $post_id ][ $key ] );
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	/**
+	 * Return the configured capability result.
+	 *
+	 * @return bool
+	 */
+	function current_user_can() {
+		return (bool) $GLOBALS['wpfa_relationship_test_can_edit'];
+	}
+}
+
+if ( ! function_exists( 'get_posts' ) ) {
+	/**
+	 * Query the in-memory post/meta fixtures used by this test.
+	 *
+	 * @param array $args Query args.
+	 * @return array<int>
+	 */
+	function get_posts( $args ) {
+		$post_type   = isset( $args['post_type'] ) ? $args['post_type'] : '';
+		$post_status = isset( $args['post_status'] ) ? $args['post_status'] : 'publish';
+		$ids         = isset( $args['post__in'] ) ? wpfa_relationship_test_normalize_ids( $args['post__in'] ) : array_keys( $GLOBALS['wpfa_relationship_test_post_types'] );
+
+		$results = array();
+
+		foreach ( $ids as $post_id ) {
+			if ( $post_type && get_post_type( $post_id ) !== $post_type ) {
+				continue;
+			}
+
+			if ( ! wpfa_relationship_test_status_matches( $post_id, $post_status ) ) {
+				continue;
+			}
+
+			if ( ! empty( $args['meta_query'] ) && ! wpfa_relationship_test_meta_matches( $post_id, $args['meta_query'] ) ) {
+				continue;
+			}
+
+			$results[] = $post_id;
+		}
+
+		return $results;
+	}
+}
+
+/**
+ * Normalize a fixture ID list.
+ *
+ * @param mixed $ids Raw IDs.
+ * @return array<int>
+ */
+function wpfa_relationship_test_normalize_ids( $ids ) {
+	if ( class_exists( 'Wpfaevent_Meta_Event' ) ) {
+		return Wpfaevent_Meta_Event::sanitize_post_id_list( $ids );
+	}
+
+	if ( ! is_array( $ids ) ) {
+		$ids = array( $ids );
+	}
+
+	$ids = array_map( 'absint', $ids );
+	$ids = array_filter( $ids );
+
+	return array_values( array_unique( $ids ) );
+}
+
+/**
+ * Check a fixture post status against a query status.
+ *
+ * @param int          $post_id     Post ID.
+ * @param string|array $post_status Query post status.
+ * @return bool
+ */
+function wpfa_relationship_test_status_matches( $post_id, $post_status ) {
+	if ( 'any' === $post_status ) {
+		return true;
+	}
+
+	$status = isset( $GLOBALS['wpfa_relationship_test_statuses'][ $post_id ] ) ? $GLOBALS['wpfa_relationship_test_statuses'][ $post_id ] : 'publish';
+
+	if ( is_array( $post_status ) ) {
+		return in_array( $status, $post_status, true );
+	}
+
+	return $status === $post_status;
+}
+
+/**
+ * Check whether a fixture post matches the relationship meta query.
+ *
+ * @param int   $post_id    Post ID.
+ * @param array $meta_query Meta query.
+ * @return bool
+ */
+function wpfa_relationship_test_meta_matches( $post_id, $meta_query ) {
+	foreach ( $meta_query as $clause ) {
+		if ( ! is_array( $clause ) || empty( $clause['key'] ) || ! array_key_exists( 'value', $clause ) ) {
+			continue;
+		}
+
+		$needle = absint( preg_replace( '/\D+/', '', (string) $clause['value'] ) );
+		$values = wpfa_relationship_test_normalize_ids( get_post_meta( $post_id, $clause['key'], true ) );
+
+		if ( $needle && in_array( $needle, $values, true ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Reset in-memory fixtures.
+ *
+ * @return void
+ */
+function wpfa_relationship_test_reset() {
+	$GLOBALS['wpfa_relationship_test_meta']       = array();
+	$GLOBALS['wpfa_relationship_test_post_types'] = array(
+		10  => 'wpfa_speaker',
+		11  => 'wpfa_speaker',
+		12  => 'wpfa_speaker',
+		100 => 'wpfa_event',
+		200 => 'wpfa_event',
+		300 => 'wpfa_event',
+	);
+	$GLOBALS['wpfa_relationship_test_statuses']   = array(
+		10  => 'publish',
+		11  => 'publish',
+		12  => 'publish',
+		100 => 'publish',
+		200 => 'publish',
+		300 => 'draft',
+	);
+	$GLOBALS['wpfa_relationship_test_can_edit']   = false;
+}
+
+/**
+ * Assert strict equality.
+ *
+ * @param mixed  $expected Expected value.
+ * @param mixed  $actual   Actual value.
+ * @param string $message  Failure message.
+ * @return void
+ */
+function wpfa_relationship_test_assert_same( $expected, $actual, $message ) {
+	if ( $expected === $actual ) {
+		return;
+	}
+
+	fwrite( STDERR, $message . PHP_EOL ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI test output.
+	fwrite( STDERR, 'Expected: ' . var_export( $expected, true ) . PHP_EOL ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export,WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI test output.
+	fwrite( STDERR, 'Actual: ' . var_export( $actual, true ) . PHP_EOL ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export,WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI test output.
+	exit( 1 );
+}
+
+require_once dirname( __DIR__ ) . '/includes/meta/class-wpfaevent-meta-event.php';
+require_once dirname( __DIR__ ) . '/includes/meta/class-wpfaevent-meta-speaker.php';
+
+wpfa_relationship_test_reset();
+$GLOBALS['wpfa_relationship_test_meta'][10]['wpfa_speaker_events'] = array( 100 );
+$GLOBALS['wpfa_relationship_test_meta'][200]['wpfa_event_speakers'] = array( 10 );
+$GLOBALS['wpfa_relationship_test_meta'][300]['wpfa_event_speakers'] = array( 10 );
+
+wpfa_relationship_test_assert_same(
+	array( 100, 200 ),
+	Wpfaevent_Meta_Speaker::get_events_linked_to_speaker( 10, 'publish' ),
+	'Speaker profiles should merge speaker-side links with published event-side references.'
+);
+
+wpfa_relationship_test_reset();
+Wpfaevent_Meta_Speaker::add_event_to_speaker( 11, 200 );
+wpfa_relationship_test_assert_same(
+	'',
+	get_post_meta( 11, 'wpfa_speaker_events', true ),
+	'Public add helper should keep the speaker capability guard by default.'
+);
+
+Wpfaevent_Meta_Speaker::add_event_to_speaker( 11, 200, false );
+wpfa_relationship_test_assert_same(
+	array( 200 ),
+	get_post_meta( 11, 'wpfa_speaker_events', true ),
+	'Internal sync should be able to add reverse links after event edit permission has passed.'
+);
+
+wpfa_relationship_test_reset();
+$GLOBALS['wpfa_relationship_test_meta'][10]['wpfa_speaker_events'] = array( 100 );
+$GLOBALS['wpfa_relationship_test_meta'][12]['wpfa_speaker_events'] = array( 100 );
+
+$sync_method = new ReflectionMethod( 'Wpfaevent_Meta_Event', 'sync_event_speaker_relationships' );
+if ( PHP_VERSION_ID < 80100 ) {
+	$sync_method->setAccessible( true );
+}
+$sync_method->invoke( null, 100, array( 10 ), array( 11 ) );
+
+wpfa_relationship_test_assert_same(
+	'',
+	get_post_meta( 10, 'wpfa_speaker_events', true ),
+	'Event sync should remove old event-side speaker reverse links.'
+);
+
+wpfa_relationship_test_assert_same(
+	'',
+	get_post_meta( 12, 'wpfa_speaker_events', true ),
+	'Event sync should remove stale reverse-only speaker links.'
+);
+
+wpfa_relationship_test_assert_same(
+	array( 100 ),
+	get_post_meta( 11, 'wpfa_speaker_events', true ),
+	'Event sync should add reverse links for current speakers.'
+);
+
+wpfa_relationship_test_assert_same(
+	array( 101, 102 ),
+	Wpfaevent_Meta_Speaker::sanitize_event_ids( '101, 102, invalid, 101' ),
+	'Speaker event meta sanitization should accept scalar ID lists consistently.'
+);
+
+echo 'Speaker relationship tests passed.' . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CLI test output.


### PR DESCRIPTION
Part 2 of the replacement split for #81.\n\nScope:\n- Adds Eventyay speaker import data handling.\n- Adds speaker/event relationship metadata sync.\n- Adds dashboard filtering foundations and speaker relationship tests.\n\nStacked on #127.