### PR TITLE
Split #81: Eventyay sessions import and schedule linking

### DIFF
--- a/includes/helpers/class-wpfaevent-schedule-helper.php
+++ b/includes/helpers/class-wpfaevent-schedule-helper.php
@@ -226,6 +226,195 @@ class Wpfaevent_Schedule_Helper {
 	}
 
 	/**
+	 * Get the public schedule page URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_schedule_page_url() {
+		$page = get_page_by_path( 'full-schedule' );
+
+		if ( $page instanceof WP_Post ) {
+			return get_permalink( $page );
+		}
+
+		$pages = get_pages(
+			array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Schedule page lookup by assigned template.
+				'meta_key'    => '_wp_page_template',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Schedule page lookup by assigned template.
+				'meta_value'  => 'page-schedule.php',
+				'number'      => 1,
+				'post_status' => 'publish',
+			)
+		);
+
+		$url = ! empty( $pages[0] ) ? get_permalink( $pages[0] ) : home_url( '/full-schedule/' );
+
+		return apply_filters( 'wpfaevent_schedule_page_url', $url );
+	}
+
+	/**
+	 * Ensure the public full schedule page exists.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool $check_capability Whether to require plugin settings access before creating the page.
+	 * @return int Page ID, or 0 when the page could not be ensured.
+	 */
+	public static function ensure_schedule_page( $check_capability = true ) {
+		if ( $check_capability && ! Wpfaevent_Roles::current_user_can_manage_settings() ) {
+			return 0;
+		}
+
+		$page_id = absint( get_option( 'wpfaevent_schedule_page_id', 0 ) );
+		if ( $page_id && 'page' === get_post_type( $page_id ) && 'trash' !== get_post_status( $page_id ) ) {
+			self::ensure_schedule_page_template( $page_id );
+
+			return $page_id;
+		}
+
+		$page = get_page_by_path( 'full-schedule' );
+		if ( $page instanceof WP_Post ) {
+			$page_id = absint( $page->ID );
+			self::ensure_schedule_page_template( $page_id );
+			update_option( 'wpfaevent_schedule_page_id', $page_id, false );
+
+			return $page_id;
+		}
+
+		$page_id = wp_insert_post(
+			array(
+				'post_title'     => __( 'Full Schedule', 'wpfaevent' ),
+				'post_name'      => 'full-schedule',
+				'post_type'      => 'page',
+				'post_status'    => 'publish',
+				'post_content'   => '',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			),
+			true
+		);
+
+		if ( is_wp_error( $page_id ) || ! $page_id ) {
+			return 0;
+		}
+
+		$page_id = absint( $page_id );
+		update_post_meta( $page_id, '_wp_page_template', 'page-schedule.php' );
+		update_post_meta( $page_id, '_wpfaevent_managed_page', 'schedule' );
+		update_option( 'wpfaevent_schedule_page_id', $page_id, false );
+
+		return $page_id;
+	}
+
+	/**
+	 * Ensure the schedule page uses the plugin schedule template.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $page_id Page ID.
+	 * @return void
+	 */
+	private static function ensure_schedule_page_template( $page_id ) {
+		$page_id = absint( $page_id );
+
+		if ( ! $page_id ) {
+			return;
+		}
+
+		$template = get_page_template_slug( $page_id );
+		if ( 'page-schedule.php' === $template ) {
+			return;
+		}
+
+		update_post_meta( $page_id, '_wp_page_template', 'page-schedule.php' );
+	}
+
+	/**
+	 * Build event-specific schedule session items from dashboard JSON.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int               $event_id         Event post ID.
+	 * @param DateTimeZone|null $display_timezone Target timezone.
+	 * @return array<string, mixed>
+	 */
+	public static function build_event_session_schedule( $event_id, $display_timezone = null ) {
+		$event_id = absint( $event_id );
+
+		if ( ! $event_id ) {
+			return array(
+				'items'  => array(),
+				'groups' => array(),
+			);
+		}
+
+		if ( ! $display_timezone instanceof DateTimeZone ) {
+			$display_timezone = wp_timezone();
+		}
+
+		$schedule_table = self::read_dashboard_json_file( 'schedule-' . $event_id . '.json', array() );
+		$schedule_rows  = isset( $schedule_table['data'] ) && is_array( $schedule_table['data'] ) ? $schedule_table['data'] : array();
+		$schedule_meta  = isset( $schedule_table['sessions'] ) && is_array( $schedule_table['sessions'] ) ? $schedule_table['sessions'] : array();
+		$schedule_head  = ! empty( $schedule_rows[0] ) && is_array( $schedule_rows[0] ) ? $schedule_rows[0] : array();
+		$schedule_body  = ! empty( $schedule_head ) ? array_slice( $schedule_rows, 1 ) : $schedule_rows;
+		$event_timezone = self::get_event_timezone_object( $event_id );
+		$items          = array();
+
+		foreach ( $schedule_body as $row_index => $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$row_meta       = isset( $schedule_meta[ $row_index ] ) && is_array( $schedule_meta[ $row_index ] ) ? $schedule_meta[ $row_index ] : array();
+			$start_datetime = isset( $row_meta['starts_at'] ) ? sanitize_text_field( $row_meta['starts_at'] ) : '';
+			$end_datetime   = isset( $row_meta['ends_at'] ) ? sanitize_text_field( $row_meta['ends_at'] ) : '';
+			$row_date       = isset( $row[0] ) ? sanitize_text_field( $row[0] ) : '';
+			$row_time       = isset( $row[1] ) ? sanitize_text_field( $row[1] ) : '';
+
+			$item = array(
+				'date'           => $row_date,
+				'date_label'     => self::format_schedule_session_date( $start_datetime, $row_date, $row_time, $display_timezone, $event_timezone ),
+				'time'           => $row_time,
+				'time_label'     => self::format_schedule_session_time( $start_datetime, $end_datetime, $row_date, $row_time, $display_timezone, $event_timezone ),
+				'title'          => ! empty( $row[2] ) ? sanitize_text_field( $row[2] ) : get_the_title( $event_id ),
+				'speakers'       => isset( $row[3] ) ? sanitize_text_field( $row[3] ) : '',
+				'track'          => isset( $row[4] ) ? sanitize_text_field( $row[4] ) : '',
+				'room'           => isset( $row[5] ) ? sanitize_text_field( $row[5] ) : '',
+				'start_datetime' => $start_datetime,
+				'end_datetime'   => $end_datetime,
+			);
+
+			$item['calendar_url'] = self::build_schedule_session_calendar_url( $event_id, $item, $event_timezone );
+
+			$time_parts         = preg_split( '/\s*-\s*/', $item['time_label'], 2 );
+			$item['time_start'] = isset( $time_parts[0] ) ? trim( $time_parts[0] ) : $item['time_label'];
+			$item['time_end']   = isset( $time_parts[1] ) ? trim( $time_parts[1] ) : '';
+
+			$items[] = $item;
+		}
+
+		$groups = array();
+
+		foreach ( $items as $item ) {
+			$day_key = ! empty( $item['date_label'] ) ? $item['date_label'] : __( 'TBD', 'wpfaevent' );
+
+			if ( ! isset( $groups[ $day_key ] ) ) {
+				$groups[ $day_key ] = array();
+			}
+
+			$groups[ $day_key ][] = $item;
+		}
+
+		return array(
+			'items'  => $items,
+			'groups' => $groups,
+		);
+	}
+
+	/**
 	 * Build a sortable schedule entry for an event.
 	 *
 	 * @since 1.0.0
@@ -274,6 +463,7 @@ class Wpfaevent_Schedule_Helper {
 				'location'     => sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) ),
 				'title'        => get_the_title( $event_id ),
 				'permalink'    => get_permalink( $event_id ),
+				'schedule_url' => add_query_arg( 'event', get_post_field( 'post_name', $event_id ), self::get_schedule_page_url() ),
 				'calendar_url' => $calendar_url,
 			);
 		}
@@ -287,7 +477,294 @@ class Wpfaevent_Schedule_Helper {
 			'location'     => sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) ),
 			'title'        => get_the_title( $event_id ),
 			'permalink'    => get_permalink( $event_id ),
+			'schedule_url' => add_query_arg( 'event', get_post_field( 'post_name', $event_id ), self::get_schedule_page_url() ),
 			'calendar_url' => $calendar_url,
+		);
+	}
+
+	/**
+	 * Read plugin-managed dashboard JSON.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $filename File name.
+	 * @param mixed  $fallback Fallback value.
+	 * @return mixed
+	 */
+	private static function read_dashboard_json_file( $filename, $fallback ) {
+		$upload_dir = wp_upload_dir();
+
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return $fallback;
+		}
+
+		$path = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/' . sanitize_file_name( $filename );
+
+		if ( ! file_exists( $path ) || ! is_readable( $path ) ) {
+			return $fallback;
+		}
+
+		if ( function_exists( 'wp_json_file_decode' ) ) {
+			$decoded = wp_json_file_decode( $path, array( 'associative' => true ) );
+
+			return is_array( $decoded ) ? $decoded : $fallback;
+		}
+
+		global $wp_filesystem;
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! WP_Filesystem() || ! $wp_filesystem ) {
+			return $fallback;
+		}
+
+		$contents = $wp_filesystem->get_contents( $path );
+		if ( false === $contents || '' === trim( $contents ) ) {
+			return $fallback;
+		}
+
+		$decoded = json_decode( $contents, true );
+
+		return ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) ? $decoded : $fallback;
+	}
+
+	/**
+	 * Get an event timezone object.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return DateTimeZone
+	 */
+	private static function get_event_timezone_object( $event_id ) {
+		$timezone_string = class_exists( 'Wpfaevent_Calendar' )
+			? Wpfaevent_Calendar::get_event_timezone_string( $event_id )
+			: wp_timezone_string();
+
+		try {
+			return new DateTimeZone( $timezone_string );
+		} catch ( Exception $exception ) {
+			return wp_timezone();
+		}
+	}
+
+	/**
+	 * Parse an imported schedule date-time value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $datetime Date-time value.
+	 * @return DateTimeImmutable|null
+	 */
+	private static function parse_schedule_datetime( $datetime ) {
+		$datetime = trim( (string) $datetime );
+
+		if ( '' === $datetime ) {
+			return null;
+		}
+
+		try {
+			return new DateTimeImmutable( $datetime );
+		} catch ( Exception $exception ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Split a human-entered time range.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $time Time or time range.
+	 * @return array<int, string>
+	 */
+	private static function split_schedule_time_range( $time ) {
+		$parts = preg_split( '/\s*-\s*/', trim( (string) $time ), 2 );
+
+		return array_values( array_filter( array_map( 'trim', is_array( $parts ) ? $parts : array() ) ) );
+	}
+
+	/**
+	 * Build a schedule fallback date-time from separate date and time values.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string       $date            Date value.
+	 * @param string       $time            Time value.
+	 * @param DateTimeZone $source_timezone Source timezone.
+	 * @return DateTimeImmutable|null
+	 */
+	private static function build_schedule_fallback_datetime( $date, $time, $source_timezone ) {
+		$date = class_exists( 'Wpfaevent_Meta_Event' )
+			? Wpfaevent_Meta_Event::sanitize_date_value( $date )
+			: sanitize_text_field( $date );
+
+		$time_parts = self::split_schedule_time_range( $time );
+		$time       = isset( $time_parts[0] ) ? $time_parts[0] : '';
+
+		if ( '' === $date || '' === $time ) {
+			return null;
+		}
+
+		try {
+			return new DateTimeImmutable( trim( $date . ' ' . $time ), $source_timezone );
+		} catch ( Exception $exception ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Format an imported session date.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string       $start_datetime  Imported start date-time.
+	 * @param string       $fallback_date   Fallback date.
+	 * @param string       $fallback_time   Fallback time.
+	 * @param DateTimeZone $display_timezone Display timezone.
+	 * @param DateTimeZone $event_timezone   Event timezone.
+	 * @return string
+	 */
+	private static function format_schedule_session_date( $start_datetime, $fallback_date, $fallback_time, $display_timezone, $event_timezone ) {
+		$start = self::parse_schedule_datetime( $start_datetime );
+
+		if ( $start ) {
+			return wp_date( get_option( 'date_format' ), $start->getTimestamp(), $display_timezone );
+		}
+
+		$fallback = self::build_schedule_fallback_datetime( $fallback_date, $fallback_time, $event_timezone );
+
+		return $fallback ? wp_date( get_option( 'date_format' ), $fallback->getTimestamp(), $display_timezone ) : sanitize_text_field( $fallback_date );
+	}
+
+	/**
+	 * Format an imported session time.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string       $start_datetime  Imported start date-time.
+	 * @param string       $end_datetime    Imported end date-time.
+	 * @param string       $fallback_date   Fallback date.
+	 * @param string       $fallback_time   Fallback time.
+	 * @param DateTimeZone $display_timezone Display timezone.
+	 * @param DateTimeZone $event_timezone   Event timezone.
+	 * @return string
+	 */
+	private static function format_schedule_session_time( $start_datetime, $end_datetime, $fallback_date, $fallback_time, $display_timezone, $event_timezone ) {
+		$start       = self::parse_schedule_datetime( $start_datetime );
+		$end         = self::parse_schedule_datetime( $end_datetime );
+		$start_label = $start ? wp_date( get_option( 'time_format' ), $start->getTimestamp(), $display_timezone ) : '';
+		$end_label   = $end ? wp_date( get_option( 'time_format' ), $end->getTimestamp(), $display_timezone ) : '';
+
+		if ( ! $start_label ) {
+			$time_parts     = self::split_schedule_time_range( $fallback_time );
+			$fallback_start = self::build_schedule_fallback_datetime( $fallback_date, isset( $time_parts[0] ) ? $time_parts[0] : '', $event_timezone );
+			$fallback_end   = self::build_schedule_fallback_datetime( $fallback_date, isset( $time_parts[1] ) ? $time_parts[1] : '', $event_timezone );
+			$start_label    = $fallback_start ? wp_date( get_option( 'time_format' ), $fallback_start->getTimestamp(), $display_timezone ) : '';
+			$end_label      = $fallback_end ? wp_date( get_option( 'time_format' ), $fallback_end->getTimestamp(), $display_timezone ) : '';
+		}
+
+		if ( $start_label && $end_label && $start_label !== $end_label ) {
+			return $start_label . ' - ' . $end_label;
+		}
+
+		return $start_label ? $start_label : sanitize_text_field( $fallback_time );
+	}
+
+	/**
+	 * Build a Google Calendar URL for one imported session.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int          $event_id       Event post ID.
+	 * @param array        $item           Schedule item.
+	 * @param DateTimeZone $event_timezone Event timezone.
+	 * @return string
+	 */
+	private static function build_schedule_session_calendar_url( $event_id, $item, $event_timezone ) {
+		if ( ! class_exists( 'Wpfaevent_Calendar' ) ) {
+			return '';
+		}
+
+		$time_parts            = self::split_schedule_time_range( isset( $item['time'] ) ? $item['time'] : '' );
+		$start                 = self::parse_schedule_datetime( isset( $item['start_datetime'] ) ? $item['start_datetime'] : '' );
+		$end                   = self::parse_schedule_datetime( isset( $item['end_datetime'] ) ? $item['end_datetime'] : '' );
+		$event_title           = get_the_title( $event_id );
+		$event_url             = esc_url_raw( get_post_meta( $event_id, 'wpfa_event_url', true ) );
+		$location              = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_location', true ) );
+		$event_timezone_string = Wpfaevent_Calendar::get_event_timezone_string( $event_id );
+		$all_day               = false;
+		$start_date            = '';
+		$end_date              = '';
+
+		if ( ! $start ) {
+			$start = self::build_schedule_fallback_datetime(
+				isset( $item['date'] ) ? $item['date'] : '',
+				isset( $time_parts[0] ) ? $time_parts[0] : '',
+				$event_timezone
+			);
+		}
+
+		if ( $start && ! $end && ! empty( $time_parts[1] ) ) {
+			$end = self::build_schedule_fallback_datetime( isset( $item['date'] ) ? $item['date'] : '', $time_parts[1], $event_timezone );
+		}
+
+		if ( $start && $end && $end <= $start ) {
+			$end = $end->modify( '+1 day' );
+		}
+
+		if ( ! $start && empty( $time_parts[0] ) ) {
+			$start_date = class_exists( 'Wpfaevent_Meta_Event' )
+				? Wpfaevent_Meta_Event::sanitize_date_value( isset( $item['date'] ) ? $item['date'] : '' )
+				: '';
+			$end_date   = $start_date;
+			$all_day    = '' !== $start_date;
+		}
+
+		if ( ! $start && ! $all_day ) {
+			return '';
+		}
+
+		$details = array_filter(
+			array(
+				$event_title ? sprintf(
+					/* translators: %s: event title. */
+					__( 'Event: %s', 'wpfaevent' ),
+					$event_title
+				) : '',
+				! empty( $item['speakers'] ) ? sprintf(
+					/* translators: %s: speaker names. */
+					__( 'Speakers: %s', 'wpfaevent' ),
+					$item['speakers']
+				) : '',
+				! empty( $item['track'] ) ? sprintf(
+					/* translators: %s: session track. */
+					__( 'Track: %s', 'wpfaevent' ),
+					$item['track']
+				) : '',
+				! empty( $item['room'] ) ? sprintf(
+					/* translators: %s: session room. */
+					__( 'Room: %s', 'wpfaevent' ),
+					$item['room']
+				) : '',
+			)
+		);
+
+		return Wpfaevent_Calendar::build_google_calendar_url(
+			array(
+				'title'           => ! empty( $item['title'] ) ? $item['title'] : $event_title,
+				'description'     => implode( "\n", $details ),
+				'location'        => ! empty( $item['room'] ) ? $item['room'] : $location,
+				'url'             => $event_url,
+				'timezone_string' => $event_timezone_string,
+				'all_day'         => $all_day,
+				'start_date'      => $start_date,
+				'end_date'        => $end_date,
+				'start_datetime'  => $all_day ? null : $start,
+				'end_datetime'    => $all_day ? null : $end,
+			)
 		);
 	}
 

--- a/public/class-wpfaevent-public.php
+++ b/public/class-wpfaevent-public.php
@@ -63,8 +63,8 @@ class Wpfaevent_Public {
 			return true;
 		}
 
-		if ( class_exists( 'Wpfaevent_Templates' ) ) {
-			return ! empty( Wpfaevent_Templates::get_active_template_keys() );
+		if ( class_exists( 'Wpfaevent_Templates' ) && ! empty( Wpfaevent_Templates::get_active_template_keys() ) ) {
+			return true;
 		}
 
 		$wpfa_templates = array(
@@ -72,6 +72,9 @@ class Wpfaevent_Public {
 			'page-events.php',
 			'page-past-events.php',
 			'page-schedule.php',
+			'page-additional-information.php',
+			'page-partner.php',
+			'public/partials/additional-information-page.php',
 			'page-speakers.php',
 			'page-landing.php',
 		);
@@ -82,7 +85,7 @@ class Wpfaevent_Public {
 			}
 		}
 
-		return false;
+		return is_post_type_archive( array( 'wpfa_event', 'wpfa_speaker' ) );
 	}
 
 	/**
@@ -98,8 +101,6 @@ class Wpfaevent_Public {
 					return true;
 				}
 			}
-
-			return false;
 		}
 
 		$paginated_templates = array(
@@ -115,7 +116,7 @@ class Wpfaevent_Public {
 			}
 		}
 
-		return false;
+		return is_post_type_archive( array( 'wpfa_event', 'wpfa_speaker' ) );
 	}
 
 	/**
@@ -126,8 +127,8 @@ class Wpfaevent_Public {
 	 * @return   bool             True if the template is active.
 	 */
 	private function is_wpfa_template_file_active( $template ) {
-		if ( class_exists( 'Wpfaevent_Templates' ) ) {
-			return Wpfaevent_Templates::is_template_file_active( $template );
+		if ( class_exists( 'Wpfaevent_Templates' ) && Wpfaevent_Templates::is_template_file_active( $template ) ) {
+			return true;
 		}
 
 		return is_page_template( $template );
@@ -178,32 +179,34 @@ class Wpfaevent_Public {
 	 * @return   array<string, mixed> Script data for the Events template.
 	 */
 	private function get_events_script_data() {
-		return array(
-			'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
-			'adminNonce' => wp_create_nonce( 'wpfa_events_ajax' ),
-			'isAdmin'    => current_user_can( 'manage_options' ),
-			'i18n'       => array(
-				'addEventTitle'      => __( 'Create a New Event', 'wpfaevent' ),
-				'editEventTitle'     => __( 'Edit Event', 'wpfaevent' ),
-				'addEventButton'     => __( 'Create Card', 'wpfaevent' ),
-				'editEventButton'    => __( 'Save Changes', 'wpfaevent' ),
-				'creating'           => __( 'Creating...', 'wpfaevent' ),
-				'saving'             => __( 'Saving...', 'wpfaevent' ),
-				'loading'            => __( 'Loading...', 'wpfaevent' ),
-				/* translators: %s: The name of the event being deleted. */
-				'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
-				'deleteSuccess'      => __( 'Event deleted successfully. The page will now reload.', 'wpfaevent' ),
-				'deleteError'        => __( 'Error deleting event', 'wpfaevent' ),
-				'deleteErrorGeneric' => __( 'Error deleting event. Please try again.', 'wpfaevent' ),
-				'addSuccess'         => __( 'Event created successfully. The page will now reload.', 'wpfaevent' ),
-				'addError'           => __( 'Error creating event', 'wpfaevent' ),
-				'addErrorGeneric'    => __( 'Error creating event. Please try again.', 'wpfaevent' ),
-				'updateSuccess'      => __( 'Event updated successfully. The page will now reload.', 'wpfaevent' ),
-				'updateError'        => __( 'Error updating event', 'wpfaevent' ),
-				'updateErrorGeneric' => __( 'Error updating event. Please try again.', 'wpfaevent' ),
-				'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
-				'loadError'          => __( 'Error loading event data', 'wpfaevent' ),
+		return array_merge(
+			array(
+				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+				'adminNonce' => wp_create_nonce( 'wpfa_events_ajax' ),
+				'i18n'       => array(
+					'addEventTitle'      => __( 'Create a New Event', 'wpfaevent' ),
+					'editEventTitle'     => __( 'Edit Event', 'wpfaevent' ),
+					'addEventButton'     => __( 'Create Card', 'wpfaevent' ),
+					'editEventButton'    => __( 'Save Changes', 'wpfaevent' ),
+					'creating'           => __( 'Creating...', 'wpfaevent' ),
+					'saving'             => __( 'Saving...', 'wpfaevent' ),
+					'loading'            => __( 'Loading...', 'wpfaevent' ),
+					/* translators: %s: The name of the event being deleted. */
+					'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
+					'deleteSuccess'      => __( 'Event deleted successfully. The page will now reload.', 'wpfaevent' ),
+					'deleteError'        => __( 'Error deleting event', 'wpfaevent' ),
+					'deleteErrorGeneric' => __( 'Error deleting event. Please try again.', 'wpfaevent' ),
+					'addSuccess'         => __( 'Event created successfully. The page will now reload.', 'wpfaevent' ),
+					'addError'           => __( 'Error creating event', 'wpfaevent' ),
+					'addErrorGeneric'    => __( 'Error creating event. Please try again.', 'wpfaevent' ),
+					'updateSuccess'      => __( 'Event updated successfully. The page will now reload.', 'wpfaevent' ),
+					'updateError'        => __( 'Error updating event', 'wpfaevent' ),
+					'updateErrorGeneric' => __( 'Error updating event. Please try again.', 'wpfaevent' ),
+					'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
+					'loadError'          => __( 'Error loading event data', 'wpfaevent' ),
+				),
 			),
+			Wpfaevent_Roles::get_frontend_script_capabilities()
 		);
 	}
 
@@ -261,6 +264,17 @@ class Wpfaevent_Public {
 		);
 
 		wp_register_style(
+			$this->plugin_name . '-event',
+			WPFAEVENT_URL . 'public/css/templates/event.css',
+			array(
+				$this->plugin_name,
+				$this->plugin_name . '-navigation',
+			),
+			$this->version,
+			'all'
+		);
+
+		wp_register_style(
 			$this->plugin_name . '-past-events',
 			WPFAEVENT_URL . 'public/css/templates/past-events.css',
 			array(
@@ -285,7 +299,7 @@ class Wpfaevent_Public {
 
 		wp_register_script(
 			$this->plugin_name . '-speakers',
-			plugin_dir_url( __FILE__ ) . 'js/wpfaevent-speakers.js',
+			WPFAEVENT_URL . 'public/js/wpfaevent-speakers.js',
 			array( 'jquery' ),
 			$this->version,
 			true
@@ -294,35 +308,37 @@ class Wpfaevent_Public {
 		wp_localize_script(
 			$this->plugin_name . '-speakers',
 			'wpfaeventSpeakersConfig',
-			array(
-				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
-				'adminNonce' => wp_create_nonce( 'wpfa_speakers_ajax' ),
-				'isAdmin'    => current_user_can( 'manage_options' ),
-				'i18n'       => array(
-					/* translators: %s: speaker name. */
-					'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
-					'deleteSuccess'      => __( 'Speaker deleted successfully. The page will now reload.', 'wpfaevent' ),
-					'deleteError'        => __( 'Error deleting speaker', 'wpfaevent' ),
-					'deleteErrorGeneric' => __( 'Error deleting speaker. Please try again.', 'wpfaevent' ),
-					'addSuccess'         => __( 'Speaker added successfully. The page will now reload.', 'wpfaevent' ),
-					'addError'           => __( 'Error adding speaker', 'wpfaevent' ),
-					'addErrorGeneric'    => __( 'Error adding speaker. Please try again.', 'wpfaevent' ),
-					'updateSuccess'      => __( 'Speaker updated successfully. The page will now reload.', 'wpfaevent' ),
-					'updateError'        => __( 'Error updating speaker', 'wpfaevent' ),
-					'updateErrorGeneric' => __( 'Error updating speaker. Please try again.', 'wpfaevent' ),
-					'loadError'          => __( 'Error loading speaker data', 'wpfaevent' ),
-					'fetchError'         => __( 'Error fetching speaker data', 'wpfaevent' ),
-					'fetchErrorGeneric'  => __( 'Error fetching speaker data. Please try again.', 'wpfaevent' ),
-					'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
-					/* translators: %d: number of speakers shown. */
-					'resultsCount'       => __( 'Showing %d speakers', 'wpfaevent' ),
+			array_merge(
+				array(
+					'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+					'adminNonce' => wp_create_nonce( 'wpfa_speakers_ajax' ),
+					'i18n'       => array(
+						/* translators: %s: speaker name. */
+						'confirmDelete'      => __( 'Are you sure you want to delete "%s"? This action cannot be undone.', 'wpfaevent' ),
+						'deleteSuccess'      => __( 'Speaker deleted successfully. The page will now reload.', 'wpfaevent' ),
+						'deleteError'        => __( 'Error deleting speaker', 'wpfaevent' ),
+						'deleteErrorGeneric' => __( 'Error deleting speaker. Please try again.', 'wpfaevent' ),
+						'addSuccess'         => __( 'Speaker added successfully. The page will now reload.', 'wpfaevent' ),
+						'addError'           => __( 'Error adding speaker', 'wpfaevent' ),
+						'addErrorGeneric'    => __( 'Error adding speaker. Please try again.', 'wpfaevent' ),
+						'updateSuccess'      => __( 'Speaker updated successfully. The page will now reload.', 'wpfaevent' ),
+						'updateError'        => __( 'Error updating speaker', 'wpfaevent' ),
+						'updateErrorGeneric' => __( 'Error updating speaker. Please try again.', 'wpfaevent' ),
+						'loadError'          => __( 'Error loading speaker data', 'wpfaevent' ),
+						'fetchError'         => __( 'Error fetching speaker data', 'wpfaevent' ),
+						'fetchErrorGeneric'  => __( 'Error fetching speaker data. Please try again.', 'wpfaevent' ),
+						'noPermission'       => __( 'You do not have permission to perform this action.', 'wpfaevent' ),
+						/* translators: %d: number of speakers shown. */
+						'resultsCount'       => __( 'Showing %d speakers', 'wpfaevent' ),
+					),
 				),
+				Wpfaevent_Roles::get_frontend_script_capabilities()
 			)
 		);
 
 		wp_register_script(
 			$this->plugin_name . '-events',
-			plugin_dir_url( __FILE__ ) . 'js/wpfaevent-events.js',
+			WPFAEVENT_URL . 'public/js/wpfaevent-events.js',
 			array( 'jquery' ),
 			$this->version,
 			true
@@ -386,7 +402,7 @@ class Wpfaevent_Public {
 			array(
 				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
 				'adminNonce' => wp_create_nonce( 'wpfa_events_ajax' ), // Same nonce as events.
-				'isAdmin'    => current_user_can( 'manage_options' ),
+				'isAdmin'    => Wpfaevent_Roles::current_user_can_manage_site_branding(),
 				'i18n'       => array(
 					'saving'            => __( 'Saving...', 'wpfaevent' ),
 					'saveFooter'        => __( 'Save Footer', 'wpfaevent' ),
@@ -407,22 +423,24 @@ class Wpfaevent_Public {
 			wp_enqueue_style( $this->plugin_name . '-code-of-conduct' );
 		}
 
-		if ( $this->is_wpfa_template_file_active( 'page-speakers.php' ) ) {
+		if ( $this->is_wpfa_template_file_active( 'page-speakers.php' ) || is_post_type_archive( 'wpfa_speaker' ) ) {
 			wp_enqueue_style( $this->plugin_name . '-speakers' );
 			wp_enqueue_script( $this->plugin_name . '-speakers' );
 		}
 
-		if ( is_singular( 'wpfa_speaker' ) ) {
-			wp_enqueue_style(
-				$this->plugin_name . '-speakers',
-				plugin_dir_url( __DIR__ ) . 'public/css/templates/speakers.css',
-				array(
-					$this->plugin_name,
-					$this->plugin_name . '-navigation',
-				),
-				$this->version,
-				'all'
-			);
+		if ( is_singular( 'wpfa_speaker' ) || is_singular( 'wpfa_event' ) ) {
+			wp_enqueue_style( $this->plugin_name . '-speakers' );
+		}
+
+		if (
+			is_singular( 'wpfa_event' )
+			|| is_post_type_archive( 'wpfa_event' )
+			|| $this->is_wpfa_template_file_active( 'page-schedule.php' )
+			|| $this->is_wpfa_template_file_active( 'page-additional-information.php' )
+			|| $this->is_wpfa_template_file_active( 'public/partials/additional-information-page.php' )
+			|| $this->is_wpfa_template_file_active( 'page-partner.php' )
+		) {
+			wp_enqueue_style( $this->plugin_name . '-event' );
 		}
 
 		// Past Events template.
@@ -492,6 +510,17 @@ class Wpfaevent_Public {
 		 * class.
 		 */
 
+		if ( ! $this->is_wpfa_template() ) {
+			return;
+		}
+
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/wpfaevent-public.js', array( 'jquery' ), $this->version, false );
+		wp_localize_script(
+			$this->plugin_name,
+			'wpfaeventPublic',
+			array(
+				'speakerPlaceholderAlt' => __( 'Speaker photo placeholder', 'wpfaevent' ),
+			)
+		);
 	}
 }

--- a/public/css/templates/event.css
+++ b/public/css/templates/event.css
@@ -1,0 +1,3088 @@
+/* ==========================================================================
+   Event Detail Template
+   ========================================================================== */
+
+.wpfaevent.wpfa-event-template,
+.wpfaevent.wpfa-schedule-template {
+	--event-primary: var(--brand, #D51007);
+	--event-primary-dark: #b20d06;
+	--event-ink: #243447;
+	--event-line: #dfe6ee;
+	--event-soft: #f4f7fb;
+	--event-panel: #fff;
+	--event-muted: #657386;
+	--event-shadow: 0 10px 28px rgba(36, 52, 71, 0.1);
+	--event-radius: 6px;
+	--event-success: #2f8f5b;
+	--event-danger: #D51007;
+
+	background: var(--event-soft);
+	color: var(--event-ink);
+	font-size: 16px;
+	font-weight: 400;
+	letter-spacing: 0;
+	line-height: 1.5;
+	overflow-x: hidden;
+}
+
+.wpfaevent.wpfa-event-template,
+.wpfaevent.wpfa-schedule-template,
+.wpfaevent.wpfa-event-template *,
+.wpfaevent.wpfa-schedule-template *,
+.wpfaevent.wpfa-event-template *::before,
+.wpfaevent.wpfa-schedule-template *::before,
+.wpfaevent.wpfa-event-template *::after,
+.wpfaevent.wpfa-schedule-template *::after {
+	box-sizing: border-box;
+}
+
+.wpfaevent.wpfa-event-template .nav {
+	border-bottom: 1px solid rgba(213, 16, 7, 0.16);
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.wpfaevent .wpfa-event-detail {
+	background:
+		linear-gradient(180deg, rgba(213, 16, 7, 0.06), rgba(244, 247, 251, 0) 440px),
+		var(--event-soft);
+	min-height: 70vh;
+}
+
+.wpfaevent .wpfa-event-hero {
+	background:
+		linear-gradient(135deg, #8f0a05 0%, #D51007 52%, #f15b53 100%);
+	color: #fff;
+	overflow: hidden;
+	padding: 56px 0 52px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-hero::before,
+.wpfaevent .wpfa-event-hero::after {
+	background: rgba(255, 255, 255, 0.11);
+	border-radius: 50%;
+	content: "";
+	position: absolute;
+}
+
+.wpfaevent .wpfa-event-hero::before {
+	height: 320px;
+	right: -120px;
+	top: -100px;
+	width: 320px;
+}
+
+.wpfaevent .wpfa-event-hero::after {
+	bottom: -150px;
+	height: 420px;
+	left: -160px;
+	width: 420px;
+}
+
+.wpfaevent .wpfa-event-hero-inner {
+	align-items: stretch;
+	display: grid;
+	gap: 32px;
+	grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+	position: relative;
+	z-index: 1;
+}
+
+.wpfaevent .wpfa-event-hero-copy {
+	align-self: center;
+	max-width: 820px;
+}
+
+.wpfaevent .wpfa-event-kicker {
+	color: rgba(255, 255, 255, 0.78);
+	font-size: 0.9rem;
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1.25;
+	margin: 0 0 12px;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-hero h1 {
+	color: #fff;
+	font-size: clamp(2.4rem, 6vw, 5.4rem);
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 0.98;
+	margin: 0;
+	max-width: 900px;
+	text-shadow: 0 2px 16px rgba(0, 0, 0, 0.18);
+}
+
+.wpfaevent .wpfa-event-hero-text {
+	color: rgba(255, 255, 255, 0.9);
+	font-size: 1.12rem;
+	font-weight: 400;
+	line-height: 1.7;
+	margin-top: 22px;
+	max-width: 720px;
+}
+
+.wpfaevent .wpfa-event-hero-text p {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-meta-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-top: 24px;
+}
+
+.wpfaevent .wpfa-event-meta-list span {
+	align-items: center;
+	background: rgba(255, 255, 255, 0.16);
+	border: 1px solid rgba(255, 255, 255, 0.25);
+	border-radius: var(--event-radius);
+	color: #fff;
+	display: inline-flex;
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.25;
+	min-height: 38px;
+	padding: 8px 12px;
+}
+
+.wpfaevent .wpfa-event-ticket-panel {
+	align-self: center;
+	background: var(--event-panel);
+	border-radius: var(--event-radius);
+	box-shadow: 0 18px 46px rgba(9, 42, 71, 0.22);
+	color: var(--event-ink);
+	display: flex;
+	flex-direction: column;
+	padding: 22px;
+}
+
+.wpfaevent .wpfa-event-ticket-head {
+	align-items: center;
+	display: flex;
+	gap: 16px;
+	justify-content: space-between;
+	margin-bottom: 16px;
+}
+
+.wpfaevent .wpfa-event-ticket-head p,
+.wpfaevent .wpfa-event-ticket-head strong {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-ticket-head p {
+	color: var(--event-muted);
+	font-size: 0.95rem;
+	font-weight: 800;
+	line-height: 1.25;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-ticket-head strong {
+	background: #e8f4ff;
+	border-radius: 999px;
+	color: var(--event-primary-dark);
+	font-size: 0.92rem;
+	font-weight: 800;
+	line-height: 1.2;
+	padding: 5px 10px;
+}
+
+.wpfaevent .wpfa-event-register {
+	align-items: center;
+	background: var(--event-primary);
+	border-radius: var(--event-radius);
+	box-shadow: 0 8px 18px rgba(213, 16, 7, 0.2);
+	color: #fff;
+	display: flex;
+	font-size: 1.12rem;
+	font-weight: 800;
+	justify-content: center;
+	line-height: 1.2;
+	min-height: 46px;
+	padding: 12px 18px;
+	text-align: center;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-register:hover {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-calendar-link {
+	align-items: center;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: flex;
+	font-size: 1.02rem;
+	font-weight: 800;
+	justify-content: center;
+	line-height: 1.2;
+	margin-top: 10px;
+	min-height: 42px;
+	padding: 10px 16px;
+	text-align: center;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-calendar-link:hover,
+.wpfaevent .wpfa-event-calendar-link:focus {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-calendar-download {
+	align-items: center;
+	color: var(--event-muted);
+	display: inline-flex;
+	font-size: 0.95rem;
+	font-weight: 800;
+	justify-content: center;
+	line-height: 1.2;
+	margin-top: 10px;
+	min-height: 32px;
+	text-align: center;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-calendar-download:hover,
+.wpfaevent .wpfa-event-calendar-download:focus {
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-facts {
+	border-top: 1px solid var(--event-line);
+	display: grid;
+	gap: 0;
+	margin: 18px 0 0;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-facts div {
+	align-items: baseline;
+	border-bottom: 1px solid var(--event-line);
+	display: grid;
+	column-gap: 18px;
+	grid-template-columns: minmax(96px, max-content) minmax(0, 1fr);
+	padding: 12px 0;
+}
+
+.wpfaevent .wpfa-event-facts div:last-child {
+	border-bottom: 0;
+}
+
+.wpfaevent .wpfa-event-facts dt,
+.wpfaevent .wpfa-event-facts dd {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-facts dt {
+	color: var(--event-muted);
+	font-size: 0.9rem;
+	font-weight: 800;
+	line-height: 1.35;
+	text-transform: uppercase;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-event-facts dd {
+	color: var(--event-ink);
+	font-size: 1.08rem;
+	font-weight: 700;
+	line-height: 1.35;
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-section-nav {
+	background: #fff;
+	border-bottom: 1px solid var(--event-line);
+	position: sticky;
+	top: 66px;
+	z-index: 30;
+}
+
+.admin-bar .wpfaevent .wpfa-event-section-nav {
+	top: 98px;
+}
+
+.wpfaevent .wpfa-event-section-nav .container {
+	display: flex;
+	gap: 8px;
+	padding-bottom: 10px;
+	padding-top: 10px;
+}
+
+.wpfaevent .wpfa-event-section-nav a {
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	font-size: 0.92rem;
+	font-weight: 800;
+	padding: 9px 12px;
+}
+
+.wpfaevent .wpfa-event-section-nav a:hover {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown {
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown-toggle {
+	background: transparent;
+	border: 0;
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	cursor: pointer;
+	font: inherit;
+	font-size: 0.92rem;
+	font-weight: 800;
+	padding: 9px 12px;
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown-toggle:hover,
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown:hover .wpfa-event-nav-dropdown-toggle {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown-content {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: none;
+	left: 0;
+	min-width: 180px;
+	padding: 8px 0;
+	position: absolute;
+	top: calc(100% + 4px);
+	z-index: 40;
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown:hover .wpfa-event-nav-dropdown-content,
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown:focus-within .wpfa-event-nav-dropdown-content {
+	display: block;
+}
+
+.wpfaevent .wpfa-event-section-nav .wpfa-event-nav-dropdown-content a {
+	border-radius: 0;
+	display: block;
+	padding: 10px 14px;
+}
+
+.wpfaevent .wpfa-schedule {
+	padding: 48px 0 72px;
+}
+
+.wpfaevent .wpfa-schedule-head {
+	align-items: start;
+	display: grid;
+	gap: 20px 32px;
+	grid-template-columns: minmax(260px, 1fr) minmax(0, auto);
+	margin-bottom: 28px;
+}
+
+.wpfaevent .wpfa-schedule-head > div:first-child {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-schedule-head h1 {
+	margin: 0 0 8px;
+}
+
+.wpfaevent .wpfa-schedule-head p {
+	color: var(--event-muted, #5b636a);
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-controls {
+	align-items: end;
+	display: grid;
+	gap: 12px;
+	justify-items: end;
+	min-width: 0;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-schedule-view-switch {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	display: inline-flex;
+	gap: 3px;
+	padding: 3px;
+}
+
+.wpfaevent .wpfa-schedule-view-switch a {
+	align-items: center;
+	border-radius: calc(var(--event-radius) - 1px);
+	color: var(--event-muted);
+	display: inline-flex;
+	font-size: 0.88rem;
+	font-weight: 900;
+	justify-content: center;
+	line-height: 1.2;
+	min-height: 34px;
+	min-width: 86px;
+	padding: 8px 12px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-schedule-view-switch a:hover,
+.wpfaevent .wpfa-schedule-view-switch a:focus {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-schedule-view-switch a.is-active {
+	background: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-schedule-filter-form {
+	align-items: end;
+	display: grid;
+	gap: 10px 12px;
+	grid-template-columns: minmax(260px, 456px) auto;
+	justify-content: flex-end;
+}
+
+.wpfaevent .wpfa-schedule-filter-form.has-language-filter {
+	grid-template-columns: minmax(190px, 260px) minmax(260px, 456px) auto;
+}
+
+.wpfaevent .wpfa-schedule-filter-form label {
+	display: grid;
+	gap: 5px;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-schedule-filter-form span {
+	color: var(--event-muted);
+	font-size: 0.72rem;
+	font-weight: 800;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-schedule-filter-form select {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-ink);
+	height: 40px;
+	line-height: 1.2;
+	min-height: 40px;
+	min-width: 0;
+	padding: 8px 10px;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-schedule-filter-form button {
+	align-items: center;
+	align-self: end;
+	background: var(--event-primary);
+	border: 1px solid var(--event-primary);
+	border-radius: var(--event-radius);
+	color: #fff;
+	display: inline-flex;
+	font-weight: 800;
+	height: 40px;
+	justify-content: center;
+	line-height: 1.2;
+	min-height: 40px;
+	min-width: 112px;
+	padding: 9px 14px;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-schedule-filter-form button:hover,
+.wpfaevent .wpfa-schedule-filter-form button:focus {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-schedule-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin: 0 0 24px;
+}
+
+.wpfaevent .wpfa-schedule-tabs a {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	font-weight: 800;
+	padding: 9px 14px;
+}
+
+.wpfaevent .wpfa-schedule-tabs a.is-active {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-schedule-group + .wpfa-schedule-group {
+	margin-top: 28px;
+}
+
+.wpfaevent .wpfa-schedule-date {
+	font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+	margin: 0 0 12px;
+}
+
+.wpfaevent .wpfa-schedule-items {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-schedule-item {
+	background: #fff;
+	border: 1px solid var(--event-line, #dfe6ee);
+	border-radius: 12px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px 14px;
+	margin-bottom: 10px;
+	padding: 14px 16px;
+}
+
+.wpfaevent .wpfa-schedule-time,
+.wpfaevent .wpfa-schedule-location,
+.wpfaevent .wpfa-schedule-language {
+	color: var(--event-muted, #5b636a);
+}
+
+.wpfaevent .wpfa-schedule-time::before,
+.wpfaevent .wpfa-schedule-location::before,
+.wpfaevent .wpfa-schedule-language::before {
+	content: '•';
+	margin-right: 8px;
+}
+
+.wpfaevent .wpfa-schedule-item .wpfa-calendar-action {
+	margin-left: auto;
+}
+
+.wpfaevent .wpfa-schedule-actions {
+	display: inline-flex;
+	gap: 10px;
+	margin-left: auto;
+}
+
+.wpfaevent .wpfa-schedule-actions a {
+	color: var(--event-primary-dark);
+	font-weight: 800;
+}
+
+.wpfaevent .wpfa-schedule-calendar {
+	align-items: start;
+	display: grid;
+	gap: 22px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day {
+	display: grid;
+	grid-template-columns: minmax(132px, 172px) minmax(0, 1fr);
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day-head {
+	align-content: start;
+	align-self: start;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius) 0 0 var(--event-radius);
+	border-right: 0;
+	box-shadow: 0 8px 20px rgba(36, 52, 71, 0.06);
+	display: grid;
+	gap: 10px;
+	min-height: 100%;
+	padding: 18px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day-head::before {
+	background: var(--event-primary);
+	border-radius: 999px;
+	content: "";
+	height: 36px;
+	position: absolute;
+	right: -2px;
+	top: 18px;
+	width: 4px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day-head h2,
+.wpfaevent .wpfa-schedule-calendar-day-head h3 {
+	color: var(--event-ink);
+	font-size: 1rem;
+	font-weight: 900;
+	line-height: 1.25;
+	margin: 0;
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-schedule-calendar-day-head span {
+	background: #edf5fc;
+	border: 1px solid #d7e8f6;
+	border-radius: var(--event-radius);
+	color: #315a78;
+	flex: 0 0 auto;
+	justify-self: start;
+	font-size: 0.78rem;
+	font-weight: 900;
+	line-height: 1.2;
+	padding: 6px 8px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slots {
+	display: grid;
+	gap: 12px;
+	min-width: 0;
+	padding-left: 18px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slots::before {
+	background: var(--event-primary);
+	bottom: 10px;
+	content: "";
+	left: 0;
+	opacity: 0.28;
+	position: absolute;
+	top: 10px;
+	width: 2px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-left: 4px solid var(--event-primary);
+	border-radius: var(--event-radius);
+	box-shadow: 0 8px 20px rgba(36, 52, 71, 0.07);
+	display: grid;
+	gap: 8px 16px;
+	grid-template-columns: minmax(104px, 148px) minmax(0, 1fr) auto;
+	min-width: 0;
+	position: relative;
+	padding: 16px 18px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot::before {
+	background: #fff;
+	border: 3px solid var(--event-primary);
+	border-radius: 50%;
+	box-shadow: 0 0 0 4px rgba(213, 16, 7, 0.1);
+	content: "";
+	height: 12px;
+	left: -26px;
+	position: absolute;
+	top: 21px;
+	width: 12px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot time {
+	align-items: center;
+	align-self: start;
+	background: #f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: calc(var(--event-radius) - 1px);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.84rem;
+	font-weight: 900;
+	justify-content: center;
+	line-height: 1.2;
+	min-height: 36px;
+	padding: 6px 9px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot h3,
+.wpfaevent .wpfa-schedule-calendar-slot h4 {
+	color: var(--event-ink);
+	font-size: 1.04rem;
+	font-weight: 900;
+	grid-column: 2;
+	line-height: 1.35;
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot h3 a,
+.wpfaevent .wpfa-schedule-calendar-slot h4 a {
+	color: inherit;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot h3 a:hover,
+.wpfaevent .wpfa-schedule-calendar-slot h3 a:focus,
+.wpfaevent .wpfa-schedule-calendar-slot h4 a:hover,
+.wpfaevent .wpfa-schedule-calendar-slot h4 a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-schedule-calendar-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	grid-column: 2;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-schedule-calendar-meta li {
+	background: #f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	font-size: 0.8rem;
+	font-weight: 700;
+	line-height: 1.25;
+	padding: 5px 8px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	grid-column: 3;
+	grid-row: 1 / span 3;
+	margin-top: 2px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-actions a {
+	color: var(--event-primary-dark);
+	font-size: 0.86rem;
+	font-weight: 900;
+}
+
+.wpfaevent .wpfa-schedule-calendar-actions a:hover,
+.wpfaevent .wpfa-schedule-calendar-actions a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot .wpfa-schedule-session-calendar {
+	align-self: start;
+	grid-column: 3;
+	grid-row: 1 / span 3;
+	margin-top: 2px;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-event-section {
+	padding: 48px 0;
+}
+
+.wpfaevent .wpfa-event-section + .wpfa-event-section {
+	border-top: 1px solid rgba(223, 230, 238, 0.85);
+}
+
+.wpfaevent .wpfa-event-section-layout {
+	display: grid;
+	gap: 32px;
+	grid-template-columns: minmax(180px, 260px) minmax(0, 1fr);
+}
+
+.wpfaevent .wpfa-event-section-label p {
+	color: var(--event-primary);
+	font-size: 0.78rem;
+	font-weight: 900;
+	margin: 0 0 8px;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-section h2 {
+	color: var(--event-ink);
+	font-size: clamp(1.7rem, 3.2vw, 2.5rem);
+	letter-spacing: 0;
+	line-height: 1.1;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-rich-text {
+	color: #3f4d5e;
+	font-size: 1.02rem;
+	line-height: 1.75;
+	max-width: 78ch;
+}
+
+.wpfaevent .wpfa-event-rich-text p:first-child {
+	margin-top: 0;
+}
+
+.wpfaevent .wpfa-event-rich-text p:last-child {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-event-additional-preview,
+.wpfaevent .wpfa-event-custom-tab-content,
+.wpfaevent .wpfa-additional-information-body {
+	max-width: 900px;
+}
+
+.wpfaevent .wpfa-event-section-head {
+	align-items: end;
+	display: flex;
+	gap: 20px;
+	justify-content: space-between;
+	margin-bottom: 24px;
+}
+
+.wpfaevent .wpfa-event-section-head h2,
+.wpfaevent .wpfa-event-section-head p {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-section-head p,
+.wpfaevent .wpfa-empty-state {
+	color: var(--event-muted);
+}
+
+.wpfaevent .wpfa-event-section-head a {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	flex: 0 0 auto;
+	font-weight: 800;
+	padding: 10px 14px;
+}
+
+.wpfaevent .wpfa-event-section-head a:hover {
+	background: #edf5fc;
+}
+
+.wpfaevent .wpfa-event-section-actions {
+	align-items: end;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	justify-content: flex-end;
+}
+
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch {
+	align-self: end;
+}
+
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch a {
+	background: transparent;
+	border: 0;
+	border-radius: calc(var(--event-radius) - 1px);
+	color: var(--event-muted);
+	flex: 0 1 auto;
+	padding: 8px 12px;
+}
+
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch a:hover,
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch a:focus {
+	background: #edf5fc;
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-section-actions .wpfa-schedule-view-switch a.is-active {
+	background: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-timezone-form {
+	align-items: end;
+	display: flex;
+	flex: 0 1 420px;
+	gap: 10px;
+	justify-content: flex-end;
+	min-width: 260px;
+}
+
+.wpfaevent .wpfa-event-timezone-form label {
+	display: grid;
+	flex: 1 1 240px;
+	gap: 6px;
+	margin: 0;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-event-timezone-form span {
+	color: var(--event-muted);
+	font-size: 0.78rem;
+	font-weight: 800;
+	line-height: 1.2;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-timezone-form select {
+	appearance: none;
+	background:
+		linear-gradient(45deg, transparent 50%, var(--event-muted) 50%) calc(100% - 18px) 19px / 6px 6px no-repeat,
+		linear-gradient(135deg, var(--event-muted) 50%, transparent 50%) calc(100% - 12px) 19px / 6px 6px no-repeat,
+		#fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-ink);
+	font: inherit;
+	min-height: 42px;
+	min-width: 0;
+	padding: 8px 34px 8px 11px;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-timezone-form select:focus {
+	border-color: var(--event-primary);
+	box-shadow: 0 0 0 3px rgba(213, 16, 7, 0.14);
+	outline: none;
+}
+
+.wpfaevent .wpfa-event-timezone-form button {
+	background: var(--event-primary);
+	border: 0;
+	border-radius: var(--event-radius);
+	color: #fff;
+	cursor: pointer;
+	font: inherit;
+	font-weight: 800;
+	min-height: 42px;
+	padding: 8px 14px;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-event-timezone-form button:hover,
+.wpfaevent .wpfa-event-timezone-form button:focus {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-additional-information {
+	background:
+		linear-gradient(180deg, #fff 0%, var(--event-soft) 520px),
+		var(--event-soft);
+	min-height: 70vh;
+}
+
+.wpfaevent .wpfa-additional-information-hero {
+	background: #f8fbf9;
+	border-bottom: 1px solid var(--event-line);
+	padding: 46px 0 48px;
+}
+
+@supports (background: color-mix(in srgb, red 10%, white)) {
+	.wpfaevent .wpfa-additional-information-hero {
+		background:
+			linear-gradient(
+				135deg,
+				color-mix(in srgb, var(--event-primary) 14%, #fff) 0%,
+				#fff 64%,
+				color-mix(in srgb, var(--event-primary) 7%, #fff) 100%
+			);
+		border-bottom-color: color-mix(in srgb, var(--event-primary) 18%, var(--event-line));
+	}
+}
+
+.wpfaevent .wpfa-additional-information-hero .wpfa-event-kicker {
+	color: var(--event-primary);
+	margin-bottom: 14px;
+}
+
+.wpfaevent .wpfa-additional-information-hero h1 {
+	color: var(--event-ink);
+	font-size: clamp(2.1rem, 5vw, 4rem);
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1;
+	margin: 0;
+	max-width: 860px;
+}
+
+.wpfaevent .wpfa-additional-information-hero p:last-child {
+	color: var(--event-muted);
+	font-size: 1.02rem;
+	line-height: 1.7;
+	margin: 18px 0 0;
+	max-width: 760px;
+}
+
+.wpfaevent .wpfa-additional-information-detail {
+	padding-top: 34px;
+}
+
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs {
+	margin-bottom: 30px;
+}
+
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs a {
+	color: var(--event-ink);
+}
+
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs a:hover,
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs a:focus {
+	background: #f6faf7;
+	color: var(--event-ink);
+}
+
+.wpfaevent.wpfa-additional-information-template .wpfa-schedule-tabs a.is-active {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-additional-information-detail .wpfa-event-section-head {
+	border-bottom: 1px solid var(--event-line);
+	margin-bottom: 22px;
+	padding-bottom: 22px;
+}
+
+.wpfaevent .wpfa-additional-information-body {
+	border-left: 4px solid var(--event-primary);
+	padding-left: 20px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speakers-grid {
+	grid-template-columns: repeat(auto-fit, minmax(280px, 360px));
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-card {
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	opacity: 1;
+	transform: none;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-card:hover {
+	box-shadow: 0 16px 34px rgba(36, 52, 71, 0.14);
+	transform: translateY(-3px);
+}
+
+.wpfaevent .wpfa-event-featured-speakers {
+	margin-bottom: 32px;
+}
+
+.wpfaevent .wpfa-event-featured-speakers h3,
+.wpfaevent .wpfa-event-regular-speakers h3,
+.wpfaevent .wpfa-event-speaker-list h3 {
+	color: var(--event-ink);
+	font-size: 1.05rem;
+	font-weight: 900;
+	letter-spacing: 0;
+	line-height: 1.25;
+	margin: 0 0 14px;
+}
+
+.wpfaevent .wpfa-event-regular-speakers {
+	border-top: 1px solid var(--event-line);
+	margin-top: 28px;
+	padding-top: 24px;
+}
+
+.wpfaevent .wpfa-event-featured-speakers + .wpfa-event-regular-speakers {
+	border-top: 1px solid var(--event-line);
+}
+
+.wpfaevent .wpfa-event-speaker-list {
+	border-top: 1px solid var(--event-line);
+	margin-top: 28px;
+	padding-top: 24px;
+}
+
+.wpfaevent .wpfa-event-speaker-list ul {
+	display: grid;
+	gap: 10px;
+	grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-event-speaker-list li {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	min-width: 0;
+	padding: 14px 16px;
+}
+
+.wpfaevent .wpfa-event-speaker-list a,
+.wpfaevent .wpfa-event-speaker-list strong {
+	color: var(--event-ink);
+	font-size: 0.98rem;
+	font-weight: 800;
+	line-height: 1.25;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-speaker-list a:hover,
+.wpfaevent .wpfa-event-speaker-list a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-speaker-list span {
+	color: var(--event-muted);
+	font-size: 0.88rem;
+	line-height: 1.35;
+}
+
+.wpfaevent .wpfa-event-speaker-limit-note,
+.wpfaevent .wpfa-event-schedule-preview-note {
+	color: var(--event-muted);
+	font-size: 0.94rem;
+	font-weight: 700;
+	margin: 14px 0 0;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-photo {
+	background: #eaf1f8;
+	height: 190px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-meta {
+	padding: 18px 18px 14px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-name {
+	font-size: 1.22rem;
+	letter-spacing: 0;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-name a {
+	color: var(--event-ink);
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-expand {
+	background: #fff;
+	max-height: none;
+	opacity: 1;
+	padding: 0 18px 18px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-bio {
+	color: #3f4d5e;
+	margin: 0 0 14px;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-session {
+	background: #f7fafc;
+	border-left-color: var(--event-primary);
+	margin: 12px 0 0;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-session h4 {
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-timeline {
+	display: grid;
+	gap: 14px;
+}
+
+.wpfaevent .wpfa-schedule-program {
+	display: grid;
+	gap: 28px;
+}
+
+.wpfaevent .wpfa-schedule-day {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: calc(var(--event-radius) + 4px);
+	box-shadow: var(--event-shadow);
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-schedule-day-head {
+	align-items: center;
+	background: linear-gradient(180deg, #fff 0%, #f8fafc 100%);
+	border-bottom: 1px solid var(--event-line);
+	display: flex;
+	gap: 16px;
+	justify-content: space-between;
+	padding: 18px 22px;
+}
+
+.wpfaevent .wpfa-schedule-day-head h2,
+.wpfaevent .wpfa-schedule-day-head h3 {
+	color: var(--event-ink);
+	font-size: 1.15rem;
+	font-weight: 900;
+	line-height: 1.2;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-day-head p {
+	color: var(--event-muted);
+	font-size: 0.88rem;
+	font-weight: 700;
+	margin: 4px 0 0;
+}
+
+.wpfaevent .wpfa-schedule-day-sessions {
+	display: grid;
+}
+
+.wpfaevent .wpfa-schedule-session {
+	display: grid;
+	gap: 18px;
+	grid-template-columns: 132px minmax(0, 1fr);
+	padding: 20px 22px;
+	position: relative;
+	transition: background 0.2s ease;
+}
+
+.wpfaevent .wpfa-schedule-session:hover {
+	background: #fbfcfd;
+}
+
+.wpfaevent .wpfa-schedule-session + .wpfa-schedule-session {
+	border-top: 1px solid var(--event-line);
+}
+
+.wpfaevent .wpfa-schedule-session-timecol {
+	padding-left: 18px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-schedule-session-timecol::before {
+	background: var(--event-primary);
+	border-radius: 50%;
+	box-shadow: 0 0 0 4px rgba(213, 16, 7, 0.12);
+	content: '';
+	height: 10px;
+	left: 0;
+	position: absolute;
+	top: 0.45rem;
+	width: 10px;
+}
+
+.wpfaevent .wpfa-schedule-session-timecol::after {
+	background: var(--event-line);
+	bottom: -20px;
+	content: '';
+	left: 4px;
+	position: absolute;
+	top: 1.35rem;
+	width: 2px;
+}
+
+.wpfaevent .wpfa-schedule-session:last-child .wpfa-schedule-session-timecol::after {
+	display: none;
+}
+
+.wpfaevent .wpfa-schedule-session-start {
+	color: var(--event-ink);
+	display: block;
+	font-size: 1rem;
+	font-variant-numeric: tabular-nums;
+	font-weight: 900;
+	line-height: 1.2;
+}
+
+.wpfaevent .wpfa-schedule-session-end {
+	color: var(--event-muted);
+	display: block;
+	font-size: 0.82rem;
+	font-variant-numeric: tabular-nums;
+	font-weight: 700;
+	margin-top: 4px;
+}
+
+.wpfaevent .wpfa-schedule-session-end::before {
+	content: '– ';
+}
+
+.wpfaevent .wpfa-schedule-session-main {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-schedule-session-title {
+	color: var(--event-ink);
+	font-size: 1.08rem;
+	font-weight: 900;
+	line-height: 1.35;
+	margin: 0 0 12px;
+}
+
+.wpfaevent .wpfa-schedule-session-details {
+	display: grid;
+	gap: 8px 18px;
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-detail {
+	display: grid;
+	gap: 2px;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-detail dt {
+	color: var(--event-muted);
+	font-size: 0.72rem;
+	font-weight: 800;
+	letter-spacing: 0.06em;
+	margin: 0;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-schedule-detail dd {
+	color: var(--event-ink);
+	font-size: 0.92rem;
+	font-weight: 700;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-session-calendar {
+	align-items: center;
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.88rem;
+	font-weight: 800;
+	gap: 6px;
+	margin-top: 14px;
+}
+
+.wpfaevent .wpfa-schedule-session-calendar::before {
+	content: '+';
+	display: inline-block;
+	font-size: 1rem;
+	font-weight: 900;
+	line-height: 1;
+}
+
+.wpfaevent .wpfa-schedule-session-calendar:hover,
+.wpfaevent .wpfa-schedule-session-calendar:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-session {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: grid;
+	gap: 18px;
+	grid-template-columns: minmax(150px, 190px) minmax(0, 1fr);
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-event-session-time {
+	background: #f7fafc;
+	border-right: 1px solid var(--event-line);
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: 18px;
+}
+
+.wpfaevent .wpfa-event-session-time span {
+	color: var(--event-muted);
+	font-size: 0.82rem;
+	font-weight: 800;
+	margin-bottom: 6px;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-session-time strong {
+	color: var(--event-primary-dark);
+	font-size: 1.15rem;
+}
+
+.wpfaevent .wpfa-event-session-body {
+	padding: 18px 18px 18px 0;
+}
+
+.wpfaevent .wpfa-event-session-body h3 {
+	color: var(--event-ink);
+	font-size: 1.2rem;
+	line-height: 1.3;
+	margin: 0 0 10px;
+}
+
+.wpfaevent .wpfa-event-session-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.wpfaevent .wpfa-event-session-meta span {
+	background: #edf5fc;
+	border-radius: var(--event-radius);
+	color: #315a78;
+	font-size: 0.88rem;
+	font-weight: 700;
+	padding: 6px 9px;
+}
+
+.wpfaevent .wpfa-event-session-calendar-link {
+	align-items: center;
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.9rem;
+	font-weight: 800;
+	margin-top: 12px;
+}
+
+.wpfaevent .wpfa-event-session-calendar-link:hover,
+.wpfaevent .wpfa-event-session-calendar-link:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-partner-groups {
+	display: grid;
+	gap: 34px;
+}
+
+.wpfaevent .wpfa-event-partner-group {
+	border-top: 1px solid var(--event-line);
+	padding-top: 24px;
+}
+
+.wpfaevent .wpfa-event-partner-group:first-child {
+	border-top: 0;
+	padding-top: 0;
+}
+
+.wpfaevent .wpfa-event-partner-group h3 {
+	align-items: center;
+	color: var(--event-primary-dark);
+	display: flex;
+	font-size: 1.05rem;
+	font-weight: 900;
+	gap: 10px;
+	letter-spacing: 0;
+	line-height: 1.25;
+	margin: 0 0 14px;
+}
+
+.wpfaevent .wpfa-event-partner-group h3::before {
+	background: var(--event-primary);
+	border-radius: 999px;
+	content: "";
+	display: block;
+	height: 18px;
+	width: 4px;
+}
+
+.wpfaevent .wpfa-event-partner-grid,
+.wpfaevent .wpfa-event-exhibitor-grid {
+	display: grid;
+	gap: 20px;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+}
+
+.wpfaevent .wpfa-event-exhibitor-grid {
+	grid-template-columns: repeat(auto-fill, minmax(min(100%, 360px), 1fr));
+}
+
+.wpfaevent .wpfa-event-partner-card,
+.wpfaevent .wpfa-event-exhibitor-card {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	overflow: hidden;
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-partner-card {
+	display: grid;
+	gap: 0;
+	grid-template-rows: auto 1fr;
+	min-height: 100%;
+	transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.wpfaevent .wpfa-event-partner-card::before {
+	background: linear-gradient(90deg, var(--event-primary), var(--event-primary-dark));
+	content: "";
+	height: 4px;
+	inset: 0 0 auto;
+	position: absolute;
+	z-index: 1;
+}
+
+.wpfaevent .wpfa-event-partner-logo {
+	align-items: center;
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.68), rgba(247, 250, 252, 0.95)),
+		#f7fafc;
+	border-bottom: 1px solid var(--event-line);
+	display: flex;
+	justify-content: center;
+	min-height: 148px;
+	padding: 28px 24px 22px;
+}
+
+.wpfaevent .wpfa-event-partner-logo img {
+	display: block;
+	max-height: var(--partner-logo-size, 160px);
+	max-width: 100%;
+	object-fit: contain;
+}
+
+.wpfaevent .wpfa-event-partner-body,
+.wpfaevent .wpfa-event-exhibitor-body {
+	padding: 18px;
+}
+
+.wpfaevent .wpfa-event-partner-body {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card {
+	display: flex;
+	flex-direction: column;
+	min-height: 188px;
+	transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card::before {
+	background: linear-gradient(180deg, var(--event-primary), var(--event-primary-dark));
+	content: "";
+	inset: 0 auto 0 0;
+	position: absolute;
+	width: 4px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card:hover,
+.wpfaevent .wpfa-event-exhibitor-card:focus-within {
+	border-color: var(--event-primary);
+	box-shadow: 0 16px 34px rgba(36, 52, 71, 0.14);
+	transform: translateY(-2px);
+}
+
+.wpfaevent .wpfa-event-exhibitor-card.has-banner::before {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-summary {
+	cursor: pointer;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 18px;
+	justify-content: space-between;
+	list-style: none;
+	padding: 22px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card.has-banner .wpfa-event-exhibitor-summary {
+	padding-top: 0;
+}
+
+.wpfaevent .wpfa-event-exhibitor-summary::-webkit-details-marker {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-summary::marker {
+	content: "";
+}
+
+.wpfaevent .wpfa-event-exhibitor-body {
+	border-top: 1px solid var(--event-line);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 16px 22px 20px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-main {
+	align-items: center;
+	display: grid;
+	gap: 16px;
+	grid-template-columns: auto minmax(0, 1fr);
+}
+
+.wpfaevent .wpfa-event-exhibitor-card.has-banner .wpfa-event-exhibitor-main {
+	align-items: end;
+	margin-top: -36px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-copy {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-event-exhibitor-eyebrow {
+	color: var(--event-primary-dark);
+	font-size: 0.74rem;
+	font-weight: 900;
+	letter-spacing: 0.08em;
+	line-height: 1.2;
+	margin: 0 0 5px;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-exhibitor-toggle {
+	align-items: center;
+	align-self: flex-start;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.84rem;
+	font-weight: 900;
+	gap: 8px;
+	line-height: 1;
+	padding: 8px 10px;
+	transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.wpfaevent .wpfa-event-exhibitor-toggle::after {
+	content: "+";
+	font-size: 1rem;
+	line-height: 1;
+}
+
+.wpfaevent .wpfa-event-exhibitor-toggle-open,
+.wpfaevent .wpfa-event-exhibitor-card[open] .wpfa-event-exhibitor-toggle-closed {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link {
+	color: inherit;
+	display: flex;
+	flex-direction: column;
+	min-height: 168px;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link:hover,
+.wpfaevent .wpfa-event-exhibitor-card-link:focus-visible {
+	color: inherit;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link .wpfa-event-exhibitor-toggle-open {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link .wpfa-event-exhibitor-toggle-closed {
+	display: inline;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card-link .wpfa-event-exhibitor-toggle::after {
+	content: "→";
+}
+
+.wpfaevent .wpfa-event-exhibitor-name {
+	color: var(--event-ink);
+	display: block;
+	font-size: 1.12rem;
+	font-weight: 900;
+	line-height: 1.25;
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-partner-card-link {
+	color: inherit;
+	display: grid;
+	grid-template-rows: auto 1fr;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-partner-card-link:hover,
+.wpfaevent .wpfa-event-partner-card-link:focus-visible {
+	border-color: var(--event-primary);
+	box-shadow: 0 16px 34px rgba(36, 52, 71, 0.14);
+	color: inherit;
+	text-decoration: none;
+	transform: translateY(-2px);
+}
+
+.wpfaevent .wpfa-event-partner-card-link:focus-visible,
+.wpfaevent .wpfa-event-exhibitor-card-link:focus-visible {
+	outline: 3px solid var(--event-primary);
+	outline-offset: 3px;
+}
+
+.wpfaevent .wpfa-event-partner-view-details {
+	align-self: flex-start;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.84rem;
+	font-weight: 900;
+	line-height: 1;
+	margin-top: 12px;
+	padding: 8px 10px;
+}
+
+.wpfaevent .wpfa-event-partner-view-details::after {
+	content: "→";
+	margin-left: 8px;
+}
+
+.wpfaevent .wpfa-event-partner-card-link:hover .wpfa-event-partner-view-details,
+.wpfaevent .wpfa-event-partner-card-link:focus-visible .wpfa-event-partner-view-details,
+.wpfaevent .wpfa-event-exhibitor-card-link:hover .wpfa-event-exhibitor-toggle,
+.wpfaevent .wpfa-event-exhibitor-card-link:focus-visible .wpfa-event-exhibitor-toggle {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-partner-detail {
+	background:
+		linear-gradient(180deg, rgba(33, 133, 208, 0.08), rgba(244, 247, 251, 0) 430px),
+		var(--event-soft);
+	min-height: 70vh;
+}
+
+.wpfaevent .wpfa-partner-detail-hero {
+	background:
+		linear-gradient(135deg, rgba(36, 52, 71, 0.22), rgba(36, 52, 71, 0)),
+		linear-gradient(135deg, var(--event-primary-dark), var(--event-primary));
+	color: #fff;
+	overflow: hidden;
+	padding: 58px 0 84px;
+	position: relative;
+}
+
+.wpfaevent .wpfa-partner-detail-hero::before {
+	background:
+		linear-gradient(115deg, rgba(255, 255, 255, 0.12) 0 18%, transparent 18% 100%),
+		linear-gradient(115deg, transparent 0 64%, rgba(255, 255, 255, 0.1) 64% 72%, transparent 72% 100%);
+	content: "";
+	inset: 0;
+	position: absolute;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-inner {
+	align-items: end;
+	display: grid;
+	gap: 28px;
+	grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+	position: relative;
+	z-index: 1;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-copy {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-hero .wpfa-event-kicker {
+	color: rgba(255, 255, 255, 0.82);
+}
+
+.wpfaevent .wpfa-partner-detail-hero h1 {
+	color: #fff;
+	font-size: 3.25rem;
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1;
+	margin: 0;
+	max-width: 880px;
+	overflow-wrap: anywhere;
+	text-shadow: 0 2px 18px rgba(0, 0, 0, 0.18);
+}
+
+.wpfaevent .wpfa-partner-detail-lead {
+	color: rgba(255, 255, 255, 0.88);
+	font-size: 1.05rem;
+	line-height: 1.65;
+	margin: 18px 0 0;
+	max-width: 660px;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-meta {
+	background: rgba(255, 255, 255, 0.14);
+	border: 1px solid rgba(255, 255, 255, 0.26);
+	border-radius: var(--event-radius);
+	box-shadow: 0 16px 34px rgba(36, 52, 71, 0.18);
+	display: grid;
+	gap: 7px;
+	padding: 18px;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-meta span,
+.wpfaevent .wpfa-partner-detail-hero-meta em {
+	color: rgba(255, 255, 255, 0.78);
+	font-size: 0.82rem;
+	font-style: normal;
+	font-weight: 800;
+	line-height: 1.35;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-meta span {
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-partner-detail-hero-meta strong {
+	color: #fff;
+	font-size: 1.24rem;
+	line-height: 1.25;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-partner-detail-body {
+	margin-top: -44px;
+	padding: 0 0 68px;
+	position: relative;
+	z-index: 2;
+}
+
+.wpfaevent .wpfa-partner-detail-banner {
+	display: block;
+	height: 210px;
+	object-fit: cover;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-partner-detail-card {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: grid;
+	grid-template-columns: minmax(260px, 0.38fr) minmax(0, 1fr);
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-partner-detail-media {
+	background:
+		linear-gradient(180deg, #fff, #f7fafc);
+	border-right: 1px solid var(--event-line);
+	display: grid;
+	grid-template-rows: auto 1fr auto;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-partner-detail.no-banner .wpfa-partner-detail-media {
+	grid-template-rows: 1fr auto;
+}
+
+.wpfaevent .wpfa-partner-detail-identity {
+	align-content: center;
+	display: grid;
+	gap: 18px;
+	justify-items: start;
+	padding: 28px;
+}
+
+.wpfaevent .wpfa-partner-detail-identity-copy {
+	display: grid;
+	gap: 5px;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-identity-copy span {
+	color: var(--event-primary-dark);
+	font-size: 0.78rem;
+	font-weight: 900;
+	letter-spacing: 0;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-partner-detail-identity-copy strong {
+	color: var(--event-ink);
+	font-size: 1.2rem;
+	font-weight: 900;
+	line-height: 1.25;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-partner-detail-logo {
+	align-items: center;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: 0 12px 26px rgba(36, 52, 71, 0.08);
+	display: flex;
+	height: 112px;
+	justify-content: center;
+	padding: 20px;
+	width: 148px;
+}
+
+.wpfaevent .wpfa-partner-detail-logo img {
+	display: block;
+	max-height: 100%;
+	max-width: 100%;
+	object-fit: contain;
+}
+
+.wpfaevent .wpfa-partner-detail-content {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	padding: 34px;
+}
+
+.wpfaevent .wpfa-partner-detail-header {
+	margin-bottom: 18px;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-content .wpfa-event-kicker {
+	color: var(--event-primary-dark);
+	margin-bottom: 8px;
+}
+
+.wpfaevent .wpfa-partner-detail-meta,
+.wpfaevent .wpfa-partner-detail-group {
+	color: #667788;
+	font-size: 0.94rem;
+	margin: 6px 0 0;
+}
+
+.wpfaevent .wpfa-partner-detail-group {
+	border-top: 1px solid var(--event-line);
+	margin: 0;
+	padding: 16px 28px;
+}
+
+.wpfaevent .wpfa-partner-detail-description {
+	color: #33465c;
+	font-size: 1.02rem;
+	line-height: 1.72;
+	margin-top: 0;
+	max-width: 760px;
+}
+
+.wpfaevent .wpfa-partner-detail-description p {
+	margin: 0 0 16px;
+}
+
+.wpfaevent .wpfa-partner-detail-description p:last-child {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-empty {
+	background: #f8fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	margin: 0;
+	padding: 16px;
+}
+
+.wpfaevent .wpfa-partner-detail-links {
+	margin-top: 24px;
+	padding-top: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-links a {
+	min-height: 42px;
+	padding: 11px 14px;
+}
+
+.wpfaevent .wpfa-partner-detail-links a:first-child {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-partner-detail-back {
+	margin: 24px 0 0;
+}
+
+.wpfaevent .wpfa-partner-detail-back a {
+	align-items: center;
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-weight: 900;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-partner-detail-back a::before {
+	content: "←";
+	margin-right: 8px;
+}
+
+.wpfaevent .wpfa-partner-detail-back a:hover,
+.wpfaevent .wpfa-partner-detail-back a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card[open] .wpfa-event-exhibitor-toggle-open {
+	display: inline;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card[open] .wpfa-event-exhibitor-toggle::after {
+	content: "-";
+}
+
+.wpfaevent .wpfa-event-partner-body h4,
+.wpfaevent .wpfa-event-exhibitor-body h3,
+.wpfaevent .wpfa-partner-detail-header h2 {
+	color: var(--event-ink);
+	font-size: 1.12rem;
+	font-weight: 900;
+	letter-spacing: 0;
+	line-height: 1.25;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-partner-detail-header h2 {
+	font-size: 2rem;
+	line-height: 1.12;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-partner-body a,
+.wpfaevent .wpfa-event-exhibitor-body h3 a {
+	color: var(--event-ink);
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-partner-body a:hover,
+.wpfaevent .wpfa-event-partner-body a:focus,
+.wpfaevent .wpfa-event-exhibitor-body h3 a:hover,
+.wpfaevent .wpfa-event-exhibitor-body h3 a:focus {
+	color: var(--event-primary);
+	text-decoration: underline;
+}
+
+.wpfaevent .wpfa-event-partner-description {
+	color: #3f4d5e;
+	font-size: 0.94rem;
+	line-height: 1.55;
+	margin-top: 2px;
+}
+
+.wpfaevent .wpfa-event-partner-description p {
+	margin: 0 0 10px;
+}
+
+.wpfaevent .wpfa-event-partner-description p:last-child {
+	margin-bottom: 0;
+}
+
+.wpfaevent .wpfa-event-exhibitor-banner {
+	background: #f7fafc;
+	border-bottom: 1px solid var(--event-line);
+	display: block;
+	height: 150px;
+	object-fit: cover;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-exhibitor-logo {
+	align-items: center;
+	background: #f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	display: flex;
+	height: 70px;
+	justify-content: center;
+	padding: 12px;
+	width: 88px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-card.has-banner .wpfa-event-exhibitor-logo {
+	background: #fff;
+	box-shadow: 0 10px 24px rgba(36, 52, 71, 0.12);
+	height: 78px;
+	width: 96px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-logo img {
+	display: block;
+	max-height: 100%;
+	max-width: 100%;
+	object-fit: contain;
+}
+
+.wpfaevent .wpfa-event-exhibitor-placeholder {
+	align-items: center;
+	background:
+		linear-gradient(135deg, #fff, var(--event-soft)),
+		#f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: flex;
+	font-size: 1.25rem;
+	font-weight: 900;
+	height: 64px;
+	justify-content: center;
+	width: 64px;
+}
+
+.wpfaevent .wpfa-partner-detail-media .wpfa-event-exhibitor-placeholder {
+	font-size: 2.1rem;
+	height: 112px;
+	width: 112px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: auto;
+	padding-top: 4px;
+}
+
+.wpfaevent .wpfa-event-exhibitor-links a {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	font-size: 0.86rem;
+	font-weight: 800;
+	padding: 8px 11px;
+	text-decoration: none;
+}
+
+.wpfaevent .wpfa-event-exhibitor-links a:hover,
+.wpfaevent .wpfa-event-exhibitor-links a:focus {
+	background: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-empty-state {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	margin: 0;
+	padding: 22px;
+}
+
+/* ==========================================================================
+   Event Archive Template
+   ========================================================================== */
+
+.wpfaevent .wpfa-event-archive {
+	background:
+		linear-gradient(180deg, rgba(213, 16, 7, 0.05), rgba(244, 247, 251, 0) 520px),
+		var(--event-soft);
+	min-height: 70vh;
+}
+
+.wpfaevent .wpfa-event-directory-hero {
+	background: var(--event-primary);
+	color: #fff;
+	padding: 58px 0 92px;
+}
+
+.wpfaevent .wpfa-event-directory-hero-inner {
+	align-items: end;
+	display: grid;
+	gap: 28px;
+	grid-template-columns: minmax(0, 1fr) minmax(170px, 220px);
+}
+
+.wpfaevent .wpfa-event-directory-hero-inner > *,
+.wpfaevent .wpfa-event-filter-form > *,
+.wpfaevent .wpfa-event-filter-grid > *,
+.wpfaevent .wpfa-event-directory-card > *,
+.wpfaevent .wpfa-event-directory-card-main > * {
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-event-directory-hero h1 {
+	color: #fff;
+	font-size: clamp(2.15rem, 5vw, 4.5rem);
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1;
+	margin: 0;
+	max-width: 980px;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-directory-lead {
+	color: rgba(255, 255, 255, 0.88);
+	font-size: 1.05rem;
+	line-height: 1.7;
+	margin: 20px 0 0;
+	max-width: 720px;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-directory-count {
+	border: 1px solid rgba(255, 255, 255, 0.3);
+	border-radius: var(--event-radius);
+	display: grid;
+	gap: 4px;
+	padding: 18px;
+	text-align: left;
+}
+
+.wpfaevent .wpfa-event-directory-count strong {
+	color: #fff;
+	font-size: 2.3rem;
+	line-height: 1;
+}
+
+.wpfaevent .wpfa-event-directory-count span {
+	color: rgba(255, 255, 255, 0.82);
+	font-size: 0.88rem;
+	font-weight: 800;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-directory-controls {
+	margin-top: -54px;
+	position: relative;
+	z-index: 2;
+}
+
+.wpfaevent .wpfa-event-filter-form {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: grid;
+	gap: 20px;
+	padding: 24px;
+}
+
+.wpfaevent .wpfa-event-filter-head {
+	align-items: start;
+	display: flex;
+	gap: 18px;
+	justify-content: space-between;
+}
+
+.wpfaevent .wpfa-event-filter-head h2,
+.wpfaevent .wpfa-event-filter-head p {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-filter-head h2 {
+	color: var(--event-ink);
+	font-size: 1.35rem;
+	line-height: 1.25;
+}
+
+.wpfaevent .wpfa-event-filter-head p {
+	color: var(--event-muted);
+	margin-top: 6px;
+}
+
+.wpfaevent .wpfa-event-reset {
+	align-items: center;
+	border: 1px solid rgba(213, 16, 7, 0.22);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-weight: 800;
+	min-height: 38px;
+	padding: 8px 12px;
+}
+
+.wpfaevent .wpfa-event-reset:hover {
+	background: rgba(213, 16, 7, 0.07);
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-filter-grid {
+	align-items: end;
+	display: grid;
+	gap: 14px;
+	grid-template-columns: minmax(260px, 1.35fr) repeat(4, minmax(170px, 1fr));
+}
+
+.wpfaevent .wpfa-event-field {
+	display: grid;
+	gap: 8px;
+	min-width: 0;
+}
+
+.wpfaevent .wpfa-event-field span,
+.wpfaevent .wpfa-event-when-filter legend {
+	color: var(--event-muted);
+	font-size: 0.78rem;
+	font-weight: 800;
+	line-height: 1.2;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-field input,
+.wpfaevent .wpfa-event-field select {
+	appearance: none;
+	background: #f9fbfd;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-ink);
+	font: inherit;
+	min-height: 46px;
+	min-width: 0;
+	padding: 10px 12px;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-field select {
+	background-image:
+		linear-gradient(45deg, transparent 50%, var(--event-muted) 50%),
+		linear-gradient(135deg, var(--event-muted) 50%, transparent 50%);
+	background-position:
+		calc(100% - 18px) 20px,
+		calc(100% - 12px) 20px;
+	background-repeat: no-repeat;
+	background-size: 6px 6px;
+	padding-right: 34px;
+}
+
+.wpfaevent .wpfa-event-field input:focus,
+.wpfaevent .wpfa-event-field select:focus {
+	background: #fff;
+	border-color: var(--event-primary);
+	box-shadow: 0 0 0 3px rgba(213, 16, 7, 0.14);
+	outline: none;
+}
+
+.wpfaevent .wpfa-event-filter-bottom {
+	align-items: end;
+	display: grid;
+	gap: 16px;
+	grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.wpfaevent .wpfa-event-when-filter {
+	border: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin: 0;
+	min-width: 0;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-event-when-filter legend {
+	flex: 0 0 100%;
+	margin-bottom: 2px;
+	padding: 0;
+}
+
+.wpfaevent .wpfa-event-when-filter label {
+	display: inline-flex;
+	margin: 0;
+	position: relative;
+}
+
+.wpfaevent .wpfa-event-when-filter input {
+	height: 1px;
+	opacity: 0;
+	position: absolute;
+	width: 1px;
+}
+
+.wpfaevent .wpfa-event-when-filter span {
+	align-items: center;
+	background: #f6f9fc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-ink);
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 0.92rem;
+	font-weight: 800;
+	min-height: 40px;
+	padding: 8px 13px;
+}
+
+.wpfaevent .wpfa-event-when-filter input:checked + span {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-when-filter input:focus + span {
+	box-shadow: 0 0 0 3px rgba(213, 16, 7, 0.16);
+}
+
+.wpfaevent .wpfa-event-filter-submit {
+	background: var(--event-primary);
+	border: 0;
+	border-radius: var(--event-radius);
+	box-shadow: 0 8px 18px rgba(213, 16, 7, 0.2);
+	color: #fff;
+	cursor: pointer;
+	font: inherit;
+	font-weight: 800;
+	max-width: 100%;
+	min-height: 46px;
+	min-width: 170px;
+	padding: 11px 18px;
+	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-event-filter-submit:hover,
+.wpfaevent .wpfa-event-filter-submit:focus {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-directory-results {
+	padding: 42px 0 64px;
+}
+
+.wpfaevent .wpfa-event-results-head {
+	align-items: end;
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 18px;
+}
+
+.wpfaevent .wpfa-event-results-head h2,
+.wpfaevent .wpfa-event-results-head p {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-results-head h2 {
+	font-size: 1.75rem;
+	line-height: 1.2;
+}
+
+.wpfaevent .wpfa-event-results-head p {
+	color: var(--event-muted);
+	margin-top: 5px;
+}
+
+.wpfaevent .wpfa-event-card-grid {
+	display: grid;
+	gap: 16px;
+}
+
+.wpfaevent .wpfa-event-directory-card {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(156px, 190px);
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-event-directory-card:hover {
+	box-shadow: 0 16px 36px rgba(36, 52, 71, 0.14);
+}
+
+.wpfaevent .wpfa-event-directory-card-main {
+	color: inherit;
+	display: grid;
+	grid-template-columns: minmax(170px, 220px) minmax(0, 1fr);
+	min-height: 210px;
+}
+
+.wpfaevent .wpfa-event-directory-card-main:hover {
+	color: inherit;
+}
+
+.wpfaevent .wpfa-event-card-media {
+	background: #f1f5f9;
+	border-right: 1px solid var(--event-line);
+	display: grid;
+	min-height: 210px;
+	overflow: hidden;
+	place-items: stretch;
+}
+
+.wpfaevent .wpfa-event-card-media img {
+	height: 100%;
+	object-fit: cover;
+	width: 100%;
+}
+
+.wpfaevent .wpfa-event-card-date {
+	align-content: center;
+	background:
+		linear-gradient(180deg, rgba(213, 16, 7, 0.12), rgba(213, 16, 7, 0)),
+		#fff;
+	color: var(--event-primary-dark);
+	display: grid;
+	gap: 8px;
+	justify-items: center;
+	min-height: 100%;
+	padding: 24px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-event-card-date span {
+	font-size: 0.85rem;
+	font-weight: 900;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-card-date strong {
+	font-size: clamp(1.2rem, 2vw, 1.55rem);
+	letter-spacing: 0;
+	line-height: 1.2;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-card-body {
+	display: grid;
+	gap: 12px;
+	padding: 24px;
+}
+
+.wpfaevent .wpfa-event-card-topline,
+.wpfaevent .wpfa-event-card-meta,
+.wpfaevent .wpfa-event-badges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.wpfaevent .wpfa-event-card-topline span,
+.wpfaevent .wpfa-event-badges span {
+	align-items: center;
+	background: #edf5fc;
+	border-radius: var(--event-radius);
+	color: #315a78;
+	display: inline-flex;
+	font-size: 0.8rem;
+	font-weight: 800;
+	min-height: 28px;
+	padding: 5px 9px;
+}
+
+.wpfaevent .wpfa-event-card-topline .wpfa-event-status {
+	background: rgba(213, 16, 7, 0.1);
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-card-topline .wpfa-event-status.is-past {
+	background: #eef2f6;
+	color: #536273;
+}
+
+.wpfaevent .wpfa-event-card-body h3 {
+	color: var(--event-ink);
+	font-size: clamp(1.35rem, 2vw, 1.75rem);
+	letter-spacing: 0;
+	line-height: 1.15;
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-directory-card-main:hover h3 {
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-card-meta {
+	color: var(--event-muted);
+	font-weight: 700;
+}
+
+.wpfaevent .wpfa-event-card-meta span {
+	max-width: 100%;
+	overflow-wrap: anywhere;
+}
+
+.wpfaevent .wpfa-event-card-body p {
+	color: #3f4d5e;
+	line-height: 1.65;
+	margin: 0;
+	max-width: 70ch;
+}
+
+.wpfaevent .wpfa-event-card-actions {
+	background: #f9fbfd;
+	border-left: 1px solid var(--event-line);
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	justify-content: center;
+	padding: 18px;
+}
+
+.wpfaevent .wpfa-event-card-actions a {
+	align-items: center;
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-weight: 800;
+	justify-content: center;
+	min-height: 40px;
+	padding: 8px 12px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-event-card-actions a:first-child {
+	background: var(--event-primary);
+	border-color: var(--event-primary);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-card-actions a:hover {
+	background: rgba(213, 16, 7, 0.08);
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-card-actions a:first-child:hover {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-empty-state {
+	background: #fff;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	box-shadow: var(--event-shadow);
+	padding: 34px;
+	text-align: center;
+}
+
+.wpfaevent .wpfa-event-empty-state h3 {
+	color: var(--event-ink);
+	margin: 0 0 8px;
+}
+
+.wpfaevent .wpfa-event-empty-state p {
+	color: var(--event-muted);
+	margin: 0 auto 18px;
+	max-width: 520px;
+}
+
+.wpfaevent .wpfa-event-empty-state a {
+	background: var(--event-primary);
+	border-radius: var(--event-radius);
+	color: #fff;
+	display: inline-flex;
+	font-weight: 800;
+	min-height: 42px;
+	padding: 10px 14px;
+}
+
+.wpfaevent .wpfa-event-empty-state a:hover {
+	background: var(--event-primary-dark);
+	color: #fff;
+}
+
+@media (max-width: 1180px) {
+	.wpfaevent .wpfa-schedule-head {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-controls {
+		justify-items: start;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form {
+		justify-content: stretch;
+	}
+}
+
+@media (max-width: 900px) {
+	.wpfaevent .wpfa-event-hero-inner,
+	.wpfaevent .wpfa-event-section-layout,
+	.wpfaevent .wpfa-event-session,
+	.wpfaevent .wpfa-schedule-session,
+	.wpfaevent .wpfa-partner-detail-hero-inner,
+	.wpfaevent .wpfa-partner-detail-card {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-ticket-panel {
+		align-self: stretch;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero-meta {
+		max-width: 360px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-media {
+		border-bottom: 1px solid var(--event-line);
+		border-right: 0;
+	}
+
+	.wpfaevent .wpfa-partner-detail.no-banner .wpfa-partner-detail-media {
+		grid-template-rows: auto auto;
+	}
+
+	.wpfaevent .wpfa-event-facts div {
+		column-gap: 28px;
+		grid-template-columns: minmax(126px, 0.28fr) minmax(0, 1fr);
+	}
+
+	.wpfaevent .wpfa-event-section-nav {
+		top: 64px;
+	}
+
+	.wpfaevent .wpfa-schedule-session {
+		gap: 12px;
+		padding: 16px 18px;
+	}
+
+	.wpfaevent .wpfa-schedule-session-timecol {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		padding-left: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-session-timecol::before,
+	.wpfaevent .wpfa-schedule-session-timecol::after {
+		display: none;
+	}
+
+	.wpfaevent .wpfa-schedule-session-end::before {
+		content: '– ';
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-day {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-day-head {
+		border-radius: var(--event-radius) var(--event-radius) 0 0;
+		border-right: 1px solid var(--event-line);
+		min-height: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-day-head::before,
+	.wpfaevent .wpfa-schedule-calendar-slots::before,
+	.wpfaevent .wpfa-schedule-calendar-slot::before {
+		display: none;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slots {
+		gap: 0;
+		padding-left: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slot {
+		border-left-width: 1px;
+		border-radius: 0;
+		box-shadow: none;
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slot + .wpfa-schedule-calendar-slot {
+		border-top: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slot:last-child {
+		border-radius: 0 0 var(--event-radius) var(--event-radius);
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-slot h3,
+	.wpfaevent .wpfa-schedule-calendar-slot h4,
+	.wpfaevent .wpfa-schedule-calendar-meta,
+	.wpfaevent .wpfa-schedule-calendar-actions,
+	.wpfaevent .wpfa-schedule-calendar-slot .wpfa-schedule-session-calendar {
+		grid-column: 1;
+		grid-row: auto;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-actions {
+		margin-top: 4px;
+	}
+
+	.wpfaevent .wpfa-event-session-time {
+		border-bottom: 1px solid var(--event-line);
+		border-right: 0;
+	}
+
+	.wpfaevent .wpfa-event-session-body {
+		padding: 0 18px 18px;
+	}
+
+	.wpfaevent .wpfa-event-directory-hero-inner,
+	.wpfaevent .wpfa-event-directory-card,
+	.wpfaevent .wpfa-event-directory-card-main {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-filter-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.wpfaevent .wpfa-event-directory-hero {
+		padding-bottom: 82px;
+	}
+
+	.wpfaevent .wpfa-event-directory-count {
+		max-width: 240px;
+	}
+
+	.wpfaevent .wpfa-event-card-media {
+		border-bottom: 1px solid var(--event-line);
+		border-right: 0;
+		min-height: 180px;
+	}
+
+	.wpfaevent .wpfa-event-card-actions {
+		border-left: 0;
+		border-top: 1px solid var(--event-line);
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form.has-language-filter {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (max-width: 760px) {
+	.wpfaevent.wpfa-event-template .container {
+		box-sizing: border-box;
+		max-width: 100%;
+		padding-left: 20px;
+		padding-right: 20px;
+		width: auto;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-inner {
+		align-items: flex-start;
+		flex-wrap: wrap;
+		gap: 10px;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		min-width: 0;
+		padding-bottom: 4px;
+		width: 100%;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-links-main,
+	.wpfaevent.wpfa-event-template .nav-links-secondary {
+		display: flex;
+		flex: 1 1 100%;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-links a {
+		font-size: 0.84rem;
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
+		white-space: nowrap;
+	}
+
+	.wpfaevent.wpfa-event-template .nav-links-secondary .btn {
+		padding-left: 0.75rem;
+		padding-right: 0.75rem;
+	}
+
+	.wpfaevent .wpfa-event-hero {
+		padding: 40px 0;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero {
+		padding: 44px 0 72px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero h1 {
+		font-size: 2.35rem;
+	}
+
+	.wpfaevent .wpfa-partner-detail-body {
+		margin-top: -34px;
+		padding-bottom: 48px;
+	}
+
+	.wpfaevent .wpfa-event-section {
+		padding: 36px 0;
+	}
+
+	.wpfaevent .wpfa-partner-detail-body.wpfa-event-section {
+		padding-bottom: 48px;
+		padding-top: 0;
+	}
+
+	.wpfaevent .wpfa-event-section-head {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.wpfaevent .wpfa-event-timezone-form {
+		align-items: stretch;
+		flex-direction: column;
+		min-width: 0;
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-section-actions,
+	.wpfaevent .wpfa-schedule-filter-form {
+		align-items: stretch;
+		grid-template-columns: 1fr;
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-schedule-controls,
+	.wpfaevent .wpfa-schedule-view-switch {
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-schedule-view-switch a {
+		flex: 1 1 0;
+		min-width: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form.has-language-filter {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form button,
+	.wpfaevent .wpfa-schedule-filter-form select {
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-timezone-form button {
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-section-nav .container {
+		overflow-x: auto;
+	}
+
+	.wpfaevent .wpfa-event-meta-list {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.wpfaevent .wpfa-event-meta-list span {
+		max-width: 100%;
+		min-width: 0;
+	}
+
+	.wpfaevent .wpfa-event-directory-hero {
+		padding: 40px 0 72px;
+	}
+
+	.wpfaevent .wpfa-event-directory-hero h1 {
+		font-size: 2rem;
+		max-width: calc(100vw - 40px);
+		width: 100%;
+		word-break: break-word;
+	}
+
+	.wpfaevent .wpfa-event-directory-lead,
+	.wpfaevent .wpfa-event-directory-count,
+	.wpfaevent .wpfa-event-filter-form,
+	.wpfaevent .wpfa-event-directory-card {
+		max-width: calc(100vw - 40px);
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-filter-form {
+		padding: 18px;
+	}
+
+	.wpfaevent .wpfa-event-filter-head,
+	.wpfaevent .wpfa-event-results-head {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.wpfaevent .wpfa-event-filter-bottom {
+		align-items: stretch;
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-filter-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-filter-submit {
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-card-body {
+		padding: 20px;
+	}
+
+	.wpfaevent .wpfa-event-card-actions a {
+		flex: 1 1 148px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-content,
+	.wpfaevent .wpfa-partner-detail-identity {
+		padding: 24px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-group {
+		padding-left: 24px;
+		padding-right: 24px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-header h2 {
+		font-size: 1.72rem;
+	}
+}
+
+@media (max-width: 480px) {
+	.wpfaevent.wpfa-event-template .nav-links-secondary {
+		display: none;
+	}
+}
+
+@media (max-width: 520px) {
+	.wpfaevent .wpfa-event-facts div {
+		align-items: start;
+		gap: 4px;
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-event-facts dt {
+		white-space: normal;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero h1 {
+		font-size: 2rem;
+	}
+
+	.wpfaevent .wpfa-partner-detail-hero-meta,
+	.wpfaevent .wpfa-partner-detail-card,
+	.wpfaevent .wpfa-partner-detail-back {
+		max-width: 350px;
+		width: calc(100vw - 40px);
+	}
+
+	.wpfaevent .wpfa-partner-detail-identity {
+		gap: 14px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-logo,
+	.wpfaevent .wpfa-partner-detail-media .wpfa-event-exhibitor-placeholder {
+		height: 92px;
+		width: 112px;
+	}
+
+	.wpfaevent .wpfa-partner-detail-links a {
+		justify-content: center;
+		width: 100%;
+	}
+
+	.wpfaevent .wpfa-event-directory-hero h1,
+	.wpfaevent .wpfa-event-directory-lead,
+	.wpfaevent .wpfa-event-directory-count,
+	.wpfaevent .wpfa-event-filter-form,
+	.wpfaevent .wpfa-event-directory-card {
+		max-width: 350px;
+		width: calc(100vw - 40px);
+	}
+}

--- a/public/js/wpfaevent-public.js
+++ b/public/js/wpfaevent-public.js
@@ -29,4 +29,44 @@
 	 * practising this, we should strive to set a better example in our own work.
 	 */
 
+	$(function() {
+		$('.wpfa-event-timezone-select').on('change', function() {
+			if (this.form) {
+				this.form.submit();
+			}
+		});
+
+		const speakerPlaceholderSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Speaker placeholder"><defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#f8d8d6"/><stop offset="0.58" stop-color="#f4f7fb"/><stop offset="1" stop-color="#dfe9f3"/></linearGradient><linearGradient id="accent" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#d51007"/><stop offset="1" stop-color="#b20d06"/></linearGradient></defs><rect width="600" height="600" fill="url(#bg)"/><circle cx="476" cy="118" r="96" fill="#fff" opacity="0.54"/><circle cx="96" cy="486" r="126" fill="#d51007" opacity="0.08"/><circle cx="300" cy="245" r="105" fill="#ffffff"/><circle cx="300" cy="245" r="78" fill="#d8e3ee"/><path d="M128 526c20-108 96-168 172-168s152 60 172 168" fill="#ffffff"/><path d="M164 526c24-77 82-116 136-116s112 39 136 116" fill="#d8e3ee"/><path d="M70 0h92v600H70z" fill="url(#accent)" opacity="0.92"/><path d="M92 120h48v240H92z" fill="#fff" opacity="0.18"/></svg>';
+		const speakerPlaceholderSrc = 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(speakerPlaceholderSvg);
+		const getSpeakerPlaceholderAlt = function() {
+			const settings = window.wpfaeventPublic || {};
+
+			if (typeof settings.speakerPlaceholderAlt === 'string' && settings.speakerPlaceholderAlt.trim()) {
+				return settings.speakerPlaceholderAlt;
+			}
+
+			return 'Speaker photo placeholder';
+		};
+
+		const applySpeakerPlaceholder = function() {
+			if (!this || this.classList.contains('wpfa-speaker-placeholder-img') || this.src === speakerPlaceholderSrc) {
+				return;
+			}
+
+			this.removeAttribute('srcset');
+			this.removeAttribute('sizes');
+			this.classList.add('wpfa-speaker-placeholder-img');
+			this.alt = getSpeakerPlaceholderAlt();
+			this.src = speakerPlaceholderSrc;
+		};
+
+		$('.wpfa-speaker-photo img:not(.wpfa-speaker-placeholder-img), .wpfa-speaker-profile-photo img:not(.wpfa-speaker-placeholder-img)')
+			.on('error', applySpeakerPlaceholder)
+			.each(function() {
+				if (this.complete && this.naturalWidth === 0) {
+					applySpeakerPlaceholder.call(this);
+				}
+			});
+	});
+
 })( jQuery );

--- a/public/templates/page-schedule.php
+++ b/public/templates/page-schedule.php
@@ -23,20 +23,92 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$wpfaevent_is_embed         = ! empty( $GLOBALS['wpfaevent_template_embed'] );
-$wpfaevent_use_theme_layout = ! $wpfaevent_is_embed && ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() );
+$wpfaevent_is_embed = ! empty( $GLOBALS['wpfaevent_template_embed'] );
+$events_per_page    = max( 1, (int) apply_filters( 'wpfa_schedule_events_per_page', 20 ) );
+$current_page       = max( 1, (int) get_query_var( 'paged', 1 ) );
+$schedule_page_url  = get_permalink();
 
-if ( $wpfaevent_use_theme_layout ) {
-	get_header();
+if ( ! $schedule_page_url && class_exists( 'Wpfaevent_Schedule_Helper' ) ) {
+	$schedule_page_url = Wpfaevent_Schedule_Helper::get_schedule_page_url();
 }
 
-$events_per_page = max( 1, (int) apply_filters( 'wpfa_schedule_events_per_page', 20 ) );
-$current_page    = max( 1, (int) get_query_var( 'paged', 1 ) );
+$read_filter_value = static function ( $key, $type = 'text' ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- These are read-only schedule filters.
+	if ( ! isset( $_GET[ $key ] ) ) {
+		return '';
+	}
 
-$site_timezone_string           = wp_timezone_string();
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized by type below.
+	$value = wp_unslash( $_GET[ $key ] );
+
+	if ( is_array( $value ) ) {
+		return '';
+	}
+
+	if ( 'slug' === $type ) {
+		return sanitize_title( $value );
+	}
+
+	if ( 'int' === $type ) {
+		return absint( $value );
+	}
+
+	return sanitize_text_field( $value );
+};
+
+$current_language     = $read_filter_value( 'language', 'slug' );
+$current_event_filter = $read_filter_value( 'event' );
+$current_view         = $read_filter_value( 'view', 'slug' );
+$query_page           = $read_filter_value( 'paged', 'int' );
+
+if ( $query_page ) {
+	$current_page = max( 1, $query_page );
+}
+
+if ( ! in_array( $current_view, array( 'list', 'calendar' ), true ) ) {
+	$current_view = 'list';
+}
+
+$resolve_event_filter = static function ( $event_filter ) {
+	$event_filter = trim( (string) $event_filter );
+
+	if ( '' === $event_filter ) {
+		return 0;
+	}
+
+	if ( is_numeric( $event_filter ) ) {
+		$event_id = absint( $event_filter );
+
+		return ( $event_id && 'wpfa_event' === get_post_type( $event_id ) ) ? $event_id : 0;
+	}
+
+	$events = get_posts(
+		array(
+			'name'           => sanitize_title( $event_filter ),
+			'post_type'      => 'wpfa_event',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		)
+	);
+
+	return ! empty( $events[0] ) ? absint( $events[0] ) : 0;
+};
+
+$selected_event_id   = $resolve_event_filter( $current_event_filter );
+$selected_event_slug = $selected_event_id ? get_post_field( 'post_name', $selected_event_id ) : '';
+
+$site_timezone_string    = wp_timezone_string();
+$primary_timezone_string = $site_timezone_string;
+
+if ( $selected_event_id && class_exists( 'Wpfaevent_Calendar' ) ) {
+	$primary_timezone_string = Wpfaevent_Calendar::get_event_timezone_string( $selected_event_id );
+}
+
 $selected_schedule_timezone_str = class_exists( 'Wpfaevent_Schedule_Helper' )
-	? Wpfaevent_Schedule_Helper::get_selected_timezone_string( $site_timezone_string )
-	: $site_timezone_string;
+	? Wpfaevent_Schedule_Helper::get_selected_timezone_string( $primary_timezone_string )
+	: $primary_timezone_string;
 
 try {
 	$selected_schedule_timezone = new DateTimeZone( $selected_schedule_timezone_str );
@@ -46,16 +118,84 @@ try {
 }
 
 $schedule_timezone_options = class_exists( 'Wpfaevent_Schedule_Helper' )
-	? Wpfaevent_Schedule_Helper::get_timezone_options( $site_timezone_string )
-	: array( $site_timezone_string, 'UTC' );
+	? Wpfaevent_Schedule_Helper::get_timezone_options( $primary_timezone_string )
+	: array( $primary_timezone_string, 'UTC' );
 
-$format_timezone_label = static function ( $timezone_string ) use ( $site_timezone_string ) {
+$build_schedule_view_url = static function ( $view ) use ( $schedule_page_url, $selected_event_slug, $current_language, $selected_schedule_timezone_str, $primary_timezone_string ) {
+	$args = array();
+
+	if ( $selected_event_slug ) {
+		$args['event'] = $selected_event_slug;
+	}
+
+	if ( $current_language ) {
+		$args['language'] = $current_language;
+	}
+
+	if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $primary_timezone_string ) {
+		$args['schedule_tz'] = $selected_schedule_timezone_str;
+	}
+
+	if ( 'calendar' === $view ) {
+		$args['view'] = 'calendar';
+	}
+
+	return add_query_arg( $args, $schedule_page_url );
+};
+
+$format_timezone_label = static function ( $timezone_string ) use ( $primary_timezone_string ) {
 	return class_exists( 'Wpfaevent_Schedule_Helper' )
-		? Wpfaevent_Schedule_Helper::format_timezone_label( $timezone_string, $site_timezone_string )
+		? Wpfaevent_Schedule_Helper::format_timezone_label( $timezone_string, $primary_timezone_string )
 		: str_replace( '_', ' ', $timezone_string );
 };
 
-$event_ids       = get_posts(
+$format_language_label = static function ( $language ) {
+	$language = trim( (string) $language );
+
+	if ( '' === $language ) {
+		return '';
+	}
+
+	$normalized = strtolower( str_replace( '_', '-', $language ) );
+	$labels     = array(
+		'ar'          => __( 'Arabic', 'wpfaevent' ),
+		'bn'          => __( 'Bengali', 'wpfaevent' ),
+		'bg'          => __( 'Bulgarian', 'wpfaevent' ),
+		'ca'          => __( 'Catalan', 'wpfaevent' ),
+		'cs'          => __( 'Czech', 'wpfaevent' ),
+		'da'          => __( 'Danish', 'wpfaevent' ),
+		'de'          => __( 'German', 'wpfaevent' ),
+		'en'          => __( 'English', 'wpfaevent' ),
+		'en-ca'       => __( 'English (Canada)', 'wpfaevent' ),
+		'es'          => __( 'Spanish', 'wpfaevent' ),
+		'fr'          => __( 'French', 'wpfaevent' ),
+		'gu'          => __( 'Gujarati', 'wpfaevent' ),
+		'hi'          => __( 'Hindi', 'wpfaevent' ),
+		'it'          => __( 'Italian', 'wpfaevent' ),
+		'ja'          => __( 'Japanese', 'wpfaevent' ),
+		'ko'          => __( 'Korean', 'wpfaevent' ),
+		'nl'          => __( 'Dutch', 'wpfaevent' ),
+		'nl-informal' => __( 'Dutch (Informal)', 'wpfaevent' ),
+		'pt'          => __( 'Portuguese', 'wpfaevent' ),
+		'ru'          => __( 'Russian', 'wpfaevent' ),
+		'si'          => __( 'Sinhala', 'wpfaevent' ),
+		'ta'          => __( 'Tamil', 'wpfaevent' ),
+		'zh-hans'     => __( 'Chinese (Simplified)', 'wpfaevent' ),
+		'zh-hant'     => __( 'Chinese (Traditional)', 'wpfaevent' ),
+	);
+
+	if ( isset( $labels[ $normalized ] ) ) {
+		return $labels[ $normalized ];
+	}
+
+	if ( false === strpos( $language, ' ' ) && preg_match( '/^[a-z]{2,3}(?:[-_][a-z0-9]+)*$/i', $language ) ) {
+		return ucwords( str_replace( '-', ' ', $normalized ) );
+	}
+
+	return $language;
+};
+
+$event_ids              = get_posts(
 	array(
 		'post_type'      => 'wpfa_event',
 		'post_status'    => 'publish',
@@ -64,18 +204,54 @@ $event_ids       = get_posts(
 		'no_found_rows'  => true,
 	)
 );
-$schedule_events = array();
+$schedule_events        = array();
+$languages              = array();
+$filtered_event_ids     = array();
+$is_event_schedule      = (bool) $selected_event_id;
+$event_session_schedule = array(
+	'items'  => array(),
+	'groups' => array(),
+);
 
 foreach ( $event_ids as $event_id ) {
-	$entry = class_exists( 'Wpfaevent_Schedule_Helper' )
-		? Wpfaevent_Schedule_Helper::build_event_schedule_entry( $event_id, $selected_schedule_timezone )
-		: null;
+	$event_id        = absint( $event_id );
+	$event_languages = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::sanitize_language_list( get_post_meta( $event_id, 'wpfa_event_languages', true ) ) : array();
+	$language_keys   = array_map( 'sanitize_title', $event_languages );
 
-	if ( ! $entry ) {
+	if ( $selected_event_id && $selected_event_id !== $event_id ) {
 		continue;
 	}
 
-	$schedule_events[] = $entry;
+	foreach ( $event_languages as $language ) {
+		$languages[ sanitize_title( $language ) ] = $format_language_label( $language );
+	}
+
+	if ( $current_language && ! in_array( $current_language, $language_keys, true ) ) {
+		continue;
+	}
+
+	$filtered_event_ids[] = $event_id;
+
+	if ( ! $is_event_schedule ) {
+		$entry = class_exists( 'Wpfaevent_Schedule_Helper' )
+			? Wpfaevent_Schedule_Helper::build_event_schedule_entry( $event_id, $selected_schedule_timezone )
+			: null;
+
+		if ( ! $entry ) {
+			continue;
+		}
+
+		$entry['languages']      = $event_languages;
+		$entry['language_keys']  = $language_keys;
+		$entry['language_label'] = implode( ', ', array_map( $format_language_label, $event_languages ) );
+		$schedule_events[]       = $entry;
+	}
+}
+
+asort( $languages );
+
+if ( $is_event_schedule && in_array( $selected_event_id, $filtered_event_ids, true ) && class_exists( 'Wpfaevent_Schedule_Helper' ) ) {
+	$event_session_schedule = Wpfaevent_Schedule_Helper::build_event_session_schedule( $selected_event_id, $selected_schedule_timezone );
 }
 
 usort(
@@ -111,6 +287,29 @@ foreach ( $paged_schedule_events as $schedule_event ) {
 	$groups[ $group_key ]['events'][] = $schedule_event;
 }
 
+$selected_event_title = $selected_event_id ? get_the_title( $selected_event_id ) : '';
+$event_style_attr     = '';
+
+if ( $selected_event_id && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+	$event_colors        = Wpfaevent_Meta_Event::get_event_colors( $selected_event_id );
+	$event_color_var_map = array(
+		'wpfa_event_primary_color'          => '--event-primary',
+		'wpfa_event_hover_button_color'     => '--event-primary-dark',
+		'wpfa_event_theme_background_color' => '--event-soft',
+		'wpfa_event_theme_success_color'    => '--event-success',
+		'wpfa_event_theme_danger_color'     => '--event-danger',
+	);
+	$event_style_vars    = array();
+
+	foreach ( $event_color_var_map as $meta_key => $css_var ) {
+		if ( ! empty( $event_colors[ $meta_key ] ) ) {
+			$event_style_vars[] = $css_var . ': ' . $event_colors[ $meta_key ];
+		}
+	}
+
+	$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
+}
+
 $site_logo_url = get_option( 'wpfa_site_logo_url', '' );
 if ( empty( $site_logo_url ) ) {
 	$site_logo_url = WPFAEVENT_URL . 'assets/images/logo.png';
@@ -127,9 +326,12 @@ $header_vars = array(
 	'register_button_text' => __( 'Register', 'wpfaevent' ),
 );
 
-$schedule_page_url = get_permalink();
+$filter_form_classes = 'wpfa-schedule-filter-form';
+if ( ! empty( $languages ) ) {
+	$filter_form_classes .= ' has-language-filter';
+}
 ?>
-<?php if ( ! $wpfaevent_is_embed && ! $wpfaevent_use_theme_layout ) : ?>
+<?php if ( ! $wpfaevent_is_embed ) : ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
@@ -137,7 +339,7 @@ $schedule_page_url = get_permalink();
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<?php wp_head(); ?>
 </head>
-<body <?php body_class( 'wpfaevent wpfa-schedule-template' ); ?>>
+<body <?php body_class( 'wpfaevent wpfa-schedule-template' ); ?><?php echo $event_style_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped when built. ?>>
 	<?php wp_body_open(); ?>
 
 <div id="page" class="site">
@@ -158,100 +360,367 @@ $schedule_page_url = get_permalink();
 <?php endif; ?>
 
 <?php if ( $wpfaevent_is_embed ) : ?>
-<section class="wpfa-schedule">
+	<section class="wpfa-schedule">
 <?php else : ?>
-<main class="wpfa-schedule">
+	<main class="wpfa-schedule">
 <?php endif; ?>
-	<div class="container">
-		<div class="wpfa-schedule-head">
-			<div>
-				<h1><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></h1>
-				<p><?php esc_html_e( 'Upcoming events grouped by start date.', 'wpfaevent' ); ?></p>
+		<div class="container">
+			<div class="wpfa-schedule-head">
+				<div>
+					<?php if ( $is_event_schedule && $selected_event_title ) : ?>
+						<h1><?php echo esc_html( $selected_event_title ); ?></h1>
+						<p><?php esc_html_e( 'Event schedule grouped by session date.', 'wpfaevent' ); ?></p>
+					<?php else : ?>
+						<h1><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></h1>
+						<p><?php esc_html_e( 'Upcoming events grouped by start date.', 'wpfaevent' ); ?></p>
+					<?php endif; ?>
+				</div>
+				<?php if ( ! empty( $event_ids ) ) : ?>
+					<div class="wpfa-schedule-controls">
+						<nav class="wpfa-schedule-view-switch" aria-label="<?php esc_attr_e( 'Schedule view', 'wpfaevent' ); ?>">
+							<a
+								class="<?php echo esc_attr( 'list' === $current_view ? 'is-active' : '' ); ?>"
+								href="<?php echo esc_url( $build_schedule_view_url( 'list' ) ); ?>"
+								<?php if ( 'list' === $current_view ) : ?>
+									aria-current="page"
+								<?php endif; ?>
+							>
+								<?php esc_html_e( 'List', 'wpfaevent' ); ?>
+							</a>
+							<a
+								class="<?php echo esc_attr( 'calendar' === $current_view ? 'is-active' : '' ); ?>"
+								href="<?php echo esc_url( $build_schedule_view_url( 'calendar' ) ); ?>"
+								<?php if ( 'calendar' === $current_view ) : ?>
+									aria-current="page"
+								<?php endif; ?>
+							>
+								<?php esc_html_e( 'Calendar', 'wpfaevent' ); ?>
+							</a>
+						</nav>
+						<form class="<?php echo esc_attr( $filter_form_classes ); ?>" action="<?php echo esc_url( $schedule_page_url ); ?>" method="get">
+							<?php if ( $selected_event_slug ) : ?>
+								<input type="hidden" name="event" value="<?php echo esc_attr( $selected_event_slug ); ?>">
+							<?php endif; ?>
+							<?php if ( 'calendar' === $current_view ) : ?>
+								<input type="hidden" name="view" value="calendar">
+							<?php endif; ?>
+							<?php if ( ! empty( $languages ) ) : ?>
+								<label for="wpfa-schedule-language">
+									<span><?php esc_html_e( 'Language', 'wpfaevent' ); ?></span>
+									<select id="wpfa-schedule-language" name="language">
+										<option value=""><?php esc_html_e( 'All languages', 'wpfaevent' ); ?></option>
+										<?php foreach ( $languages as $language_key => $language_label ) : ?>
+											<option value="<?php echo esc_attr( $language_key ); ?>" <?php selected( $current_language, $language_key ); ?>>
+												<?php echo esc_html( $language_label ); ?>
+											</option>
+										<?php endforeach; ?>
+									</select>
+								</label>
+							<?php endif; ?>
+							<label for="wpfa-schedule-timezone">
+								<span><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></span>
+								<select id="wpfa-schedule-timezone" class="wpfa-event-timezone-select" name="schedule_tz">
+									<?php foreach ( $schedule_timezone_options as $timezone_option ) : ?>
+										<option value="<?php echo esc_attr( $timezone_option ); ?>" <?php selected( $selected_schedule_timezone_str, $timezone_option ); ?>>
+											<?php echo esc_html( $format_timezone_label( $timezone_option ) ); ?>
+										</option>
+									<?php endforeach; ?>
+								</select>
+							</label>
+							<button type="submit"><?php esc_html_e( 'Apply', 'wpfaevent' ); ?></button>
+						</form>
+					</div>
+				<?php endif; ?>
 			</div>
-			<?php if ( ! empty( $schedule_events ) ) : ?>
-				<form class="wpfa-event-timezone-form" action="<?php echo esc_url( $schedule_page_url ); ?>" method="get">
-					<label for="wpfa-schedule-timezone">
-						<span><?php esc_html_e( 'Timezone', 'wpfaevent' ); ?></span>
-						<select id="wpfa-schedule-timezone" class="wpfa-event-timezone-select" name="schedule_tz">
-							<?php foreach ( $schedule_timezone_options as $timezone_option ) : ?>
-								<option value="<?php echo esc_attr( $timezone_option ); ?>" <?php selected( $selected_schedule_timezone_str, $timezone_option ); ?>>
-									<?php echo esc_html( $format_timezone_label( $timezone_option ) ); ?>
-								</option>
+
+			<?php if ( $is_event_schedule ) : ?>
+				<?php if ( ! empty( $event_session_schedule['groups'] ) ) : ?>
+					<?php if ( 'calendar' === $current_view ) : ?>
+						<div class="wpfa-schedule-calendar" role="list">
+							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading">
+									<header class="wpfa-schedule-calendar-day-head">
+										<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading"><?php echo esc_html( $day_label ); ?></h2>
+										<span>
+											<?php
+											printf(
+												/* translators: %d: number of sessions on this day. */
+												esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+												absint( count( $day_sessions ) )
+											);
+											?>
+										</span>
+									</header>
+									<div class="wpfa-schedule-calendar-slots">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-calendar-slot">
+												<?php if ( ! empty( $item['time_label'] ) ) : ?>
+													<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+												<?php endif; ?>
+												<h3><?php echo esc_html( $item['title'] ); ?></h3>
+												<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+													<ul class="wpfa-schedule-calendar-meta">
+														<?php if ( ! empty( $item['speakers'] ) ) : ?>
+															<li><?php echo esc_html( $item['speakers'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['room'] ) ) : ?>
+															<li><?php echo esc_html( $item['room'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['track'] ) ) : ?>
+															<li><?php echo esc_html( $item['track'] ); ?></li>
+														<?php endif; ?>
+													</ul>
+												<?php endif; ?>
+												<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+													<?php
+													$session_calendar_label = sprintf(
+														/* translators: %s: session title. */
+														__( 'Add %s to Google Calendar', 'wpfaevent' ),
+														$item['title']
+													);
+													?>
+													<a
+														class="wpfa-schedule-session-calendar"
+														href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+														target="_blank"
+														rel="noopener"
+														aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+													>
+														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+													</a>
+												<?php endif; ?>
+											</article>
+										<?php endforeach; ?>
+									</div>
+								</section>
 							<?php endforeach; ?>
-						</select>
-					</label>
-					<button type="submit"><?php esc_html_e( 'Convert', 'wpfaevent' ); ?></button>
-				</form>
+						</div>
+					<?php else : ?>
+						<div class="wpfa-schedule-program">
+							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+									<header class="wpfa-schedule-day-head">
+										<div>
+											<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h2>
+											<p>
+												<?php
+												printf(
+													/* translators: %d: number of sessions on this day. */
+													esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+													absint( count( $day_sessions ) )
+												);
+												?>
+											</p>
+										</div>
+									</header>
+
+									<div class="wpfa-schedule-day-sessions" role="list">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-session" role="listitem">
+												<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+													<?php if ( ! empty( $item['time_start'] ) ) : ?>
+														<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+															<?php echo esc_html( $item['time_start'] ); ?>
+														</time>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['time_end'] ) ) : ?>
+														<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
+													<?php endif; ?>
+												</div>
+
+												<div class="wpfa-schedule-session-main">
+													<h3 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h3>
+
+													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+														<dl class="wpfa-schedule-session-details">
+															<?php if ( ! empty( $item['speakers'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Speaker', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['speakers'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['room'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Room', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['room'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['track'] ) ) : ?>
+																<div class="wpfa-schedule-detail">
+																	<dt><?php esc_html_e( 'Track', 'wpfaevent' ); ?></dt>
+																	<dd><?php echo esc_html( $item['track'] ); ?></dd>
+																</div>
+															<?php endif; ?>
+														</dl>
+													<?php endif; ?>
+
+													<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+														<?php
+														$session_calendar_label = sprintf(
+															/* translators: %s: session title. */
+															__( 'Add %s to Google Calendar', 'wpfaevent' ),
+															$item['title']
+														);
+														?>
+														<a
+															class="wpfa-schedule-session-calendar"
+															href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+															target="_blank"
+															rel="noopener"
+															aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+														>
+															<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+														</a>
+													<?php endif; ?>
+												</div>
+											</article>
+										<?php endforeach; ?>
+									</div>
+								</section>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+				<?php else : ?>
+					<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
+				<?php endif; ?>
+			<?php elseif ( $groups ) : ?>
+				<?php if ( 'calendar' === $current_view ) : ?>
+					<div class="wpfa-schedule-calendar" role="list">
+						<?php foreach ( $groups as $group ) : ?>
+							<section class="wpfa-schedule-calendar-day" role="listitem">
+								<header class="wpfa-schedule-calendar-day-head">
+									<h2><?php echo esc_html( $group['date'] ); ?></h2>
+									<span>
+										<?php
+										printf(
+											/* translators: %d: number of events on this day. */
+											esc_html( _n( '%d event', '%d events', count( $group['events'] ), 'wpfaevent' ) ),
+											absint( count( $group['events'] ) )
+										);
+										?>
+									</span>
+								</header>
+								<div class="wpfa-schedule-calendar-slots">
+									<?php foreach ( $group['events'] as $schedule_event ) : ?>
+										<article class="wpfa-schedule-calendar-slot">
+											<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
+												<time><?php echo esc_html( $schedule_event['time_label'] ); ?></time>
+											<?php endif; ?>
+											<h3>
+												<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
+													<?php echo esc_html( $schedule_event['title'] ); ?>
+												</a>
+											</h3>
+											<?php if ( ! empty( $schedule_event['location'] ) || ! empty( $schedule_event['language_label'] ) ) : ?>
+												<ul class="wpfa-schedule-calendar-meta">
+													<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
+														<li><?php echo esc_html( $schedule_event['location'] ); ?></li>
+													<?php endif; ?>
+													<?php if ( ! empty( $schedule_event['language_label'] ) ) : ?>
+														<li><?php echo esc_html( $schedule_event['language_label'] ); ?></li>
+													<?php endif; ?>
+												</ul>
+											<?php endif; ?>
+											<div class="wpfa-schedule-calendar-actions">
+												<a href="<?php echo esc_url( $schedule_event['schedule_url'] ); ?>"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></a>
+												<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
+													<?php
+													$calendar_label = sprintf(
+														/* translators: %s: event title. */
+														__( 'Add %s to Google Calendar', 'wpfaevent' ),
+														$schedule_event['title']
+													);
+													?>
+													<a
+														href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
+														target="_blank"
+														rel="noopener"
+														aria-label="<?php echo esc_attr( $calendar_label ); ?>"
+													>
+														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+													</a>
+												<?php endif; ?>
+											</div>
+										</article>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endforeach; ?>
+					</div>
+				<?php else : ?>
+					<?php foreach ( $groups as $group ) : ?>
+						<section class="wpfa-schedule-group">
+							<h2 class="wpfa-schedule-date"><?php echo esc_html( $group['date'] ); ?></h2>
+							<ul class="wpfa-schedule-items">
+								<?php foreach ( $group['events'] as $schedule_event ) : ?>
+									<li class="wpfa-schedule-item">
+										<strong>
+											<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
+												<?php echo esc_html( $schedule_event['title'] ); ?>
+											</a>
+										</strong>
+										<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
+											<span class="wpfa-schedule-time"><?php echo esc_html( $schedule_event['time_label'] ); ?></span>
+										<?php endif; ?>
+										<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
+											<span class="wpfa-schedule-location"><?php echo esc_html( $schedule_event['location'] ); ?></span>
+										<?php endif; ?>
+										<?php if ( ! empty( $schedule_event['language_label'] ) ) : ?>
+											<span class="wpfa-schedule-language"><?php echo esc_html( $schedule_event['language_label'] ); ?></span>
+										<?php endif; ?>
+										<span class="wpfa-schedule-actions">
+											<a href="<?php echo esc_url( $schedule_event['schedule_url'] ); ?>"><?php esc_html_e( 'Schedule', 'wpfaevent' ); ?></a>
+										</span>
+										<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
+											<?php
+											$calendar_label = sprintf(
+												/* translators: %s: event title. */
+												__( 'Add %s to Google Calendar', 'wpfaevent' ),
+												$schedule_event['title']
+											);
+											?>
+											<a
+												class="wpfa-calendar-action"
+												href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
+												target="_blank"
+												rel="noopener"
+												aria-label="<?php echo esc_attr( $calendar_label ); ?>"
+											>
+												<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+											</a>
+										<?php endif; ?>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+						</section>
+					<?php endforeach; ?>
+				<?php endif; ?>
+
+				<?php
+				$total           = max( 1, (int) ceil( $total_events / $events_per_page ) );
+				$pagination_args = array();
+				if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $site_timezone_string ) {
+					$pagination_args['schedule_tz'] = $selected_schedule_timezone_str;
+				}
+				if ( $current_language ) {
+					$pagination_args['language'] = $current_language;
+				}
+				if ( 'calendar' === $current_view ) {
+					$pagination_args['view'] = 'calendar';
+				}
+				wpfa_render_pagination( $total, $current_page, __( 'Schedule pagination', 'wpfaevent' ), $pagination_args );
+				?>
+			<?php else : ?>
+				<p><?php esc_html_e( 'No schedule entries yet.', 'wpfaevent' ); ?></p>
 			<?php endif; ?>
 		</div>
-
-		<?php if ( $groups ) : ?>
-			<?php foreach ( $groups as $group ) : ?>
-				<section class="wpfa-schedule-group">
-					<h2 class="wpfa-schedule-date"><?php echo esc_html( $group['date'] ); ?></h2>
-					<ul class="wpfa-schedule-items">
-						<?php foreach ( $group['events'] as $schedule_event ) : ?>
-							<li class="wpfa-schedule-item">
-								<strong>
-									<a href="<?php echo esc_url( $schedule_event['permalink'] ); ?>">
-										<?php echo esc_html( $schedule_event['title'] ); ?>
-									</a>
-								</strong>
-								<?php if ( ! empty( $schedule_event['time_label'] ) ) : ?>
-									<span class="wpfa-schedule-time"><?php echo esc_html( $schedule_event['time_label'] ); ?></span>
-								<?php endif; ?>
-								<?php if ( ! empty( $schedule_event['location'] ) ) : ?>
-									<span class="wpfa-schedule-location"><?php echo esc_html( $schedule_event['location'] ); ?></span>
-								<?php endif; ?>
-								<?php if ( ! empty( $schedule_event['calendar_url'] ) ) : ?>
-									<?php
-									$calendar_label = sprintf(
-										/* translators: %s: event title. */
-										__( 'Add %s to Google Calendar', 'wpfaevent' ),
-										$schedule_event['title']
-									);
-									?>
-									<a
-										class="wpfa-calendar-action"
-										href="<?php echo esc_url( $schedule_event['calendar_url'] ); ?>"
-										target="_blank"
-										rel="noopener"
-										aria-label="<?php echo esc_attr( $calendar_label ); ?>"
-									>
-										<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-									</a>
-								<?php endif; ?>
-							</li>
-						<?php endforeach; ?>
-					</ul>
-				</section>
-			<?php endforeach; ?>
-
-			<?php
-			$total           = max( 1, (int) ceil( $total_events / $events_per_page ) );
-			$pagination_args = array();
-			if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $site_timezone_string ) {
-				$pagination_args['schedule_tz'] = $selected_schedule_timezone_str;
-			}
-			wpfa_render_pagination( $total, $current_page, __( 'Schedule pagination', 'wpfaevent' ), $pagination_args );
-			?>
-		<?php else : ?>
-			<p><?php esc_html_e( 'No schedule entries yet.', 'wpfaevent' ); ?></p>
-		<?php endif; ?>
-	</div>
 <?php if ( $wpfaevent_is_embed ) : ?>
-</section>
+	</section>
 <?php else : ?>
-</main>
-<?php endif; ?>
-
-<?php if ( ! $wpfaevent_is_embed && ! $wpfaevent_use_theme_layout ) : ?>
-	<?php require WPFAEVENT_PATH . 'public/partials/footer.php'; ?>
+	</main>
 </div>
 
 	<?php wp_footer(); ?>
 </body>
 </html>
-<?php elseif ( $wpfaevent_use_theme_layout ) : ?>
-	<?php get_footer(); ?>
 <?php endif; ?>

--- a/tests/calendar-test.php
+++ b/tests/calendar-test.php
@@ -44,6 +44,40 @@ if ( ! function_exists( 'esc_html__' ) ) {
 	}
 }
 
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Minimal translation fallback for standalone CLI tests.
+	 *
+	 * @param string $text Text.
+	 * @return string
+	 */
+	function __( $text ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'wp_timezone_string' ) ) {
+	/**
+	 * Minimal wp_timezone_string() fallback for standalone CLI tests.
+	 *
+	 * @return string
+	 */
+	function wp_timezone_string() {
+		return 'UTC';
+	}
+}
+
+if ( ! function_exists( 'wp_timezone' ) ) {
+	/**
+	 * Minimal wp_timezone() fallback for standalone CLI tests.
+	 *
+	 * @return DateTimeZone
+	 */
+	function wp_timezone() {
+		return new DateTimeZone( 'UTC' );
+	}
+}
+
 if ( ! function_exists( 'get_post' ) ) {
 	/**
 	 * Simulate a missing post for invalid event ID tests.


### PR DESCRIPTION
Part 3 of the replacement split for #81.\n\nScope:\n- Adds schedule helper/frontend updates.\n- Adds sessions schedule template integration.\n- Keeps schedule/calendar behavior aligned with imported Eventyay data.\n\nStacked after the speakers PR.