### PR TITLE
feat(ci): add PR title lint workflow with Conventional Commits validation

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -45,7 +45,7 @@ jobs:
       # Post or update the warning comment if linting fails
       - name: Comment on PR if title is invalid
         if: steps.lint_pr_title.outcome == 'failure'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: pr-title-lint-error
           message: |
@@ -67,7 +67,7 @@ jobs:
       # Automatically clean up and delete the comment if the user fixed the title
       - name: Delete warning comment if title is valid
         if: steps.lint_pr_title.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -2,11 +2,16 @@ name: Lint PR Title
 
 on:
   pull_request:
+    branches: [ main ]
     types:
       - opened
       - edited
       - reopened
       - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write
@@ -18,7 +23,7 @@ jobs:
     steps:
       - id: lint_pr_title
         name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,42 +42,32 @@ jobs:
             revert
           requireScope: false
 
+      # Post or update the warning comment if linting fails
       - name: Comment on PR if title is invalid
         if: steps.lint_pr_title.outcome == 'failure'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
+          header: pr-title-lint-error
+          message: |
             Hi @${{ github.event.pull_request.user.login }}, 👋
 
-            It looks like your PR title doesn't quite match our project's **Conventional Commits** specification. To keep our codebase clean, maintainable, and ready for automated changelogs, please update your PR title.
+            It looks like your PR title doesn't quite match our project's **Conventional Commits** specification.
+
+            ### ❌ Error Details
+            ```text
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
 
             ### How to Structure Your PR Title
             `type(optional-scope): short description in lowercase`
             * **Example:** `feat(auth): add google OAuth2 login provider`
-            * **Example:** `fix: resolve memory leak on dashboard unmount`
 
-            ---
+            Simply click **Edit** next to your PR title at the top of this page, update the text to match the rules, and save. This comment will disappear automatically once fixed!
 
-            ### Allowed Types
-            | Type | Purpose |
-            | :--- | :--- |
-            | **feat** | A new feature |
-            | **fix** | A bug fix |
-            | **docs** | Documentation changes only |
-            | **style** | Formatting, missing semi-colons, etc. |
-            | **refactor** | Code changes that neither fix a bug nor add a feature |
-            | **perf** | A code change that improves performance |
-            | **test** | Adding or correcting tests |
-            | **build** | Changes affecting the build system or external dependencies |
-            | **ci** | Changes to CI configuration files and scripts |
-            | **chore** | Other changes that don't modify src or test files |
-            | **revert** | Reverts a previous commit |
-
-            ---
-
-            ### Quick Tips for Success
-            * **Use lowercase:** The prefix (`feat`, `fix`, etc.) must always be lowercase.
-            * **Be concise:** Keep the description short and use the imperative mood (e.g., "add variable" instead of "added" or "adds").
-            * **How to fix:** Simply click **Edit** next to your PR title at the top of this page, update the text to match the rules, and save. The check will re-run automatically.
+      # Automatically clean up and delete the comment if the user fixed the title
+      - name: Delete warning comment if title is valid
+        if: steps.lint_pr_title.outcome == 'success'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,78 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - id: lint_pr_title
+        name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+
+      - name: Comment on PR if title is invalid
+        if: steps.lint_pr_title.outcome == 'failure'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Hi @${{ github.event.pull_request.user.login }}, 👋
+
+            It looks like your PR title doesn't quite match our project's **Conventional Commits** specification. To keep our codebase clean, maintainable, and ready for automated changelogs, please update your PR title.
+
+            ### How to Structure Your PR Title
+            `type(optional-scope): short description in lowercase`
+            * **Example:** `feat(auth): add google OAuth2 login provider`
+            * **Example:** `fix: resolve memory leak on dashboard unmount`
+
+            ---
+
+            ### Allowed Types
+            | Type | Purpose |
+            | :--- | :--- |
+            | **feat** | A new feature |
+            | **fix** | A bug fix |
+            | **docs** | Documentation changes only |
+            | **style** | Formatting, missing semi-colons, etc. |
+            | **refactor** | Code changes that neither fix a bug nor add a feature |
+            | **perf** | A code change that improves performance |
+            | **test** | Adding or correcting tests |
+            | **build** | Changes affecting the build system or external dependencies |
+            | **ci** | Changes to CI configuration files and scripts |
+            | **chore** | Other changes that don't modify src or test files |
+            | **revert** | Reverts a previous commit |
+
+            ---
+
+            ### Quick Tips for Success
+            * **Use lowercase:** The prefix (`feat`, `fix`, etc.) must always be lowercase.
+            * **Be concise:** Keep the description short and use the imperative mood (e.g., "add variable" instead of "added" or "adds").
+            * **How to fix:** Simply click **Edit** next to your PR title at the top of this page, update the text to match the rules, and save. The check will re-run automatically.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that validates PR titles against the Conventional Commits specification on every `pull_request` event (open, edit, reopen, synchronize).

## Changes

- **`.github/workflows/lint-pr-title.yml`** — New workflow:
  - Uses [amannn/action-semantic-pull-request@v6](https://github.com/amannn/action-semantic-pull-request) to validate titles
  - Uses [marocchino/sticky-pull-request-comment@v3](https://github.com/marocchino/sticky-pull-request-comment) to post/delete PR comments
  - Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
  - Posts an actionable comment to the PR when the title is invalid
  - Automatically deletes the comment once the title is fixed
  - Non-blocking (uses `continue-on-error: true`) so it doesn't interfere with automated PRs
  - `branches: [ main ]` filter for consistency with other repo workflows
  - `concurrency` group to cancel in-progress duplicate runs

## Testing

Validated locally with `act` and on GitHub Actions (see branch history for test runs).

## References

- [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) — Validates PR titles against Conventional Commits
- [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) — Manages sticky PR comments
- [Conventional Commits spec](https://www.conventionalcommits.org/) — Title format reference

---

Fixes #138