### PR TITLE
refactor: split admin settings UI into separate PR

### DIFF
--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -205,7 +205,7 @@
 /* Importer settings card and info card visual styling */
 .wpfaevent-settings-card,
 .wpfaevent-info-card {
-	max-width: 960px !important;
+	max-width: 960px;
 	background: #ffffff;
 	border: 1px solid #e2e8f0 !important;
 	border-radius: 12px !important;

--- a/admin/js/wpfaevent-admin.js
+++ b/admin/js/wpfaevent-admin.js
@@ -8,7 +8,9 @@
 		if ($importForm.length || $updateForm.length) {
 			const $form = $importForm.length ? $importForm : $updateForm;
 			const rawReturnPage = $form.find('input[name="wpfaevent_eventyay_return_page"]').val();
-			const returnPage = /^[a-zA-Z0-9_-]+$/.test(rawReturnPage || '') ? rawReturnPage : 'wpfaevent-import-events';
+			const returnPage = (typeof rawReturnPage === 'string' && /^[a-zA-Z0-9_-]+$/.test(rawReturnPage))
+				? rawReturnPage
+				: 'wpfaevent-import-events';
 
 			$form.on('submit', function(e) {
 				e.preventDefault();
@@ -24,6 +26,16 @@
 				let created = 0;
 				let updated = 0;
 				let skipped = 0;
+				let sessions = 0;
+				let speakers = 0;
+				let sponsors = 0;
+				let exhibitors = 0;
+				let created_speakers = 0;
+				let updated_speakers = 0;
+				let about_updates = 0;
+				let schedule_rows = 0;
+				let program_skipped = 0;
+				let partner_skipped = 0;
 
 				// Show overlay
 				const $overlay = $('#wpfaevent-import-progress-overlay');
@@ -85,7 +97,7 @@
 					if (index >= events.length) {
 						$status.text('Finalizing sync...');
 						$bar.css('width', '100%');
-						const message = 'Fetched ' + fetched + ' Eventyay event(s). Created ' + created + ', updated ' + updated + ', skipped ' + skipped + '.';
+						const message = 'Fetched ' + fetched + ' Eventyay event(s). Created ' + created + ', updated ' + updated + ', skipped ' + skipped + '. Imported ' + sessions + ' session(s), ' + speakers + ' speaker(s), ' + sponsors + ' sponsor(s), ' + exhibitors + ' exhibitor(s), ' + schedule_rows + ' schedule row(s), and updated ' + about_updates + ' about section(s); skipped program import for ' + program_skipped + ' event(s) and sponsor/exhibitor import for ' + partner_skipped + ' event(s).';
 						saveSummaryAndRedirect('success', message, returnPage, nonce);
 						return;
 					}
@@ -96,7 +108,7 @@
 
 					const eventTitle = getEventTitle(event);
 					$status.text('Importing ' + (index + 1) + ' of ' + events.length + ': ' + eventTitle);
-					$details.text('Saving event details, location, and dates...');
+					$details.text('Processing speakers, sessions, schedules, and partners...');
 
 					$.ajax({
 						url: ajaxurl,
@@ -112,6 +124,16 @@
 								created += res.created || 0;
 								updated += res.updated || 0;
 								skipped += res.skipped || 0;
+								sessions += res.sessions || 0;
+								speakers += res.speakers || 0;
+								sponsors += res.sponsors || 0;
+								exhibitors += res.exhibitors || 0;
+								created_speakers += res.created_speakers || 0;
+								updated_speakers += res.updated_speakers || 0;
+								about_updates += res.about_updates || 0;
+								schedule_rows += res.schedule_rows || 0;
+								program_skipped += res.program_skipped || 0;
+								partner_skipped += res.partner_skipped || 0;
 							} else {
 								skipped++;
 							}

--- a/admin/partials/eventyay-import-settings.php
+++ b/admin/partials/eventyay-import-settings.php
@@ -11,15 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $settings         = isset( $settings ) ? $settings : array(
-	'base_url'           => 'https://eventyay.com',
-	'organizer_slug'     => '',
-	'api_token'          => '',
-	'post_status'        => 'draft',
-	'auto_sync_enabled'  => false,
-	'auto_sync_interval' => 'daily',
+	'base_url'       => 'https://eventyay.com',
+	'organizer_slug' => '',
+	'event_slug'     => '',
+	'api_token'      => '',
+	'post_status'    => 'draft',
 );
-$auto_sync_next   = class_exists( 'Wpfaevent_Cron_Scheduler' ) ? Wpfaevent_Cron_Scheduler::get_next_scheduled() : false;
-$auto_sync_result = class_exists( 'Wpfaevent_Cron_Scheduler' ) ? Wpfaevent_Cron_Scheduler::get_last_result() : null;
 $endpoint_preview = isset( $endpoint_preview ) ? $endpoint_preview : '';
 $notice           = isset( $notice ) ? $notice : false;
 ?>
@@ -60,7 +57,13 @@ $notice           = isset( $notice ) ? $notice : false;
 						<input type="text" class="regular-text" id="wpfaevent_eventyay_organizer_slug" name="wpfaevent_eventyay_import_settings[organizer_slug]" value="<?php echo esc_attr( $settings['organizer_slug'] ); ?>" placeholder="bigevents">
 					</td>
 				</tr>
-
+				<tr>
+					<th scope="row"><label for="wpfaevent_eventyay_event_slug"><?php esc_html_e( 'Event slug', 'wpfaevent' ); ?></label></th>
+					<td>
+						<input type="text" class="regular-text" id="wpfaevent_eventyay_event_slug" name="wpfaevent_eventyay_import_settings[event_slug]" value="<?php echo esc_attr( $settings['event_slug'] ); ?>" placeholder="sampleconf">
+						<p class="description"><?php esc_html_e( 'Leave empty to import all events visible to the token for this organizer.', 'wpfaevent' ); ?></p>
+					</td>
+				</tr>
 				<tr>
 					<th scope="row"><label for="wpfaevent_eventyay_api_token"><?php esc_html_e( 'API token', 'wpfaevent' ); ?></label></th>
 					<td>
@@ -83,26 +86,6 @@ $notice           = isset( $notice ) ? $notice : false;
 							<option value="pending" <?php selected( $settings['post_status'], 'pending' ); ?>><?php esc_html_e( 'Pending review', 'wpfaevent' ); ?></option>
 							<option value="private" <?php selected( $settings['post_status'], 'private' ); ?>><?php esc_html_e( 'Private', 'wpfaevent' ); ?></option>
 						</select>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row"><?php esc_html_e( 'Scheduled auto-sync', 'wpfaevent' ); ?></th>
-					<td>
-						<label for="wpfaevent_auto_sync_enabled">
-							<input type="checkbox" id="wpfaevent_auto_sync_enabled" name="wpfaevent_eventyay_import_settings[auto_sync_enabled]" value="1" <?php checked( ! empty( $settings['auto_sync_enabled'] ) ); ?>>
-							<?php esc_html_e( 'Automatically re-import events and speakers on a recurring schedule', 'wpfaevent' ); ?>
-						</label>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row"><label for="wpfaevent_auto_sync_interval"><?php esc_html_e( 'Sync interval', 'wpfaevent' ); ?></label></th>
-					<td>
-						<select id="wpfaevent_auto_sync_interval" name="wpfaevent_eventyay_import_settings[auto_sync_interval]">
-							<option value="hourly" <?php selected( $settings['auto_sync_interval'] ?? 'daily', 'hourly' ); ?>><?php esc_html_e( 'Hourly', 'wpfaevent' ); ?></option>
-							<option value="twicedaily" <?php selected( $settings['auto_sync_interval'] ?? 'daily', 'twicedaily' ); ?>><?php esc_html_e( 'Twice daily', 'wpfaevent' ); ?></option>
-							<option value="daily" <?php selected( $settings['auto_sync_interval'] ?? 'daily', 'daily' ); ?>><?php esc_html_e( 'Daily', 'wpfaevent' ); ?></option>
-						</select>
-						<p class="description"><?php esc_html_e( 'How often WP-Cron will run the import. Only applies when auto-sync is enabled.', 'wpfaevent' ); ?></p>
 					</td>
 				</tr>
 			</table>
@@ -136,48 +119,13 @@ $notice           = isset( $notice ) ? $notice : false;
 	</div>
 
 	<div class="card wpfaevent-info-card">
-		<h2><?php esc_html_e( 'Auto-Sync Status', 'wpfaevent' ); ?></h2>
-		<?php if ( ! empty( $settings['auto_sync_enabled'] ) ) : ?>
-			<?php if ( $auto_sync_next ) : ?>
-				<p>
-					<span class="dashicons dashicons-update" style="color:#00a32a;vertical-align:middle;"></span>
-					<?php
-					echo esc_html(
-						sprintf(
-							/* translators: %s: human-readable time until next sync */
-							__( 'Next sync in %s.', 'wpfaevent' ),
-							human_time_diff( time(), $auto_sync_next )
-						)
-					);
-					?>
-					<span class="description"> &mdash; <?php echo esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $auto_sync_next ) ); ?></span>
-				</p>
-			<?php else : ?>
-				<p class="description"><?php esc_html_e( 'Auto-sync is enabled but not yet scheduled. Save settings to apply.', 'wpfaevent' ); ?></p>
-			<?php endif; ?>
-		<?php else : ?>
-			<p class="description"><?php esc_html_e( 'Auto-sync is disabled. Enable it above and save to activate.', 'wpfaevent' ); ?></p>
-		<?php endif; ?>
-
-		<?php if ( $auto_sync_result ) : ?>
-			<p style="margin-top:12px;">
-				<strong><?php esc_html_e( 'Last auto-sync:', 'wpfaevent' ); ?></strong>
-				<span style="color:<?php echo 'error' === $auto_sync_result['type'] ? '#d63638' : '#00a32a'; ?>;">
-					<?php echo esc_html( $auto_sync_result['message'] ); ?>
-				</span>
-				<span class="description">&mdash; <?php echo esc_html( human_time_diff( $auto_sync_result['time'] ) ); ?> <?php esc_html_e( 'ago', 'wpfaevent' ); ?></span>
-			</p>
-		<?php else : ?>
-			<p class="description" style="margin-top:12px;"><?php esc_html_e( 'No auto-sync has run yet.', 'wpfaevent' ); ?></p>
-		<?php endif; ?>
-	</div>
-
-	<div class="card wpfaevent-info-card">
 		<h2><?php esc_html_e( 'Where Imported Data Shows Up', 'wpfaevent' ); ?></h2>
 		<ul>
 			<li><?php esc_html_e( 'Events are saved as Events posts with Eventyay source metadata for repeat imports.', 'wpfaevent' ); ?></li>
-			<li><?php esc_html_e( 'Event title, description, dates, timezone, location, and Eventyay URL are updated from the Eventyay API.', 'wpfaevent' ); ?></li>
-			<li><?php esc_html_e( 'Speaker, schedule, sponsor, and exhibitor imports are handled by the follow-up Eventyay data import PR.', 'wpfaevent' ); ?></li>
+			<li><?php esc_html_e( 'Speakers are saved as Speaker posts and linked only to the event they came from.', 'wpfaevent' ); ?></li>
+			<li><?php esc_html_e( 'Sponsors and exhibitors are imported into event-specific dashboard JSON files.', 'wpfaevent' ); ?></li>
+			<li><?php esc_html_e( 'Dashboard JSON is written to uploads/fossasia-data using event-specific file names.', 'wpfaevent' ); ?></li>
+			<li><?php esc_html_e( 'Frontend rendering for imported data is handled by the follow-up display PR.', 'wpfaevent' ); ?></li>
 		</ul>
 	</div>
 </div>

--- a/admin/partials/eventyay-update-events.php
+++ b/admin/partials/eventyay-update-events.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $settings         = isset( $settings ) ? $settings : array(
 	'base_url'       => 'https://eventyay.com',
 	'organizer_slug' => '',
+	'event_slug'     => '',
 	'api_token'      => '',
 	'post_status'    => 'draft',
 );
@@ -34,7 +35,7 @@ $notice           = isset( $notice ) ? $notice : false;
 		<h2><?php esc_html_e( 'Update Events from Eventyay', 'wpfaevent' ); ?></h2>
 		<p><?php esc_html_e( 'Run this when Eventyay data changes after events have already been imported.', 'wpfaevent' ); ?></p>
 		<p class="description">
-			<?php esc_html_e( 'Existing Eventyay-owned event posts are updated in place while source metadata is preserved for future imports.', 'wpfaevent' ); ?>
+			<?php esc_html_e( 'Existing Eventyay-owned event posts, speakers, schedules, sponsors, exhibitors, and event Info content are updated in place.', 'wpfaevent' ); ?>
 		</p>
 
 		<?php if ( is_wp_error( $endpoint_preview ) ) : ?>

--- a/includes/eventyay-importer/class-wpfaevent-admin-settings-renderer.php
+++ b/includes/eventyay-importer/class-wpfaevent-admin-settings-renderer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Eventyay Importer Settings Renderer.
+ * Eventyay Admin Settings Renderer.
  *
  * @package    Wpfaevent
  * @subpackage Wpfaevent/includes/eventyay-importer
@@ -11,12 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Handles rendering the Import and Update dashboard settings screens.
+ * Renders admin layout partial templates.
  */
 class Wpfaevent_Admin_Settings_Renderer {
 
 	/**
-	 * Facade Importer instance.
+	 * Importer instance.
 	 *
 	 * @var Wpfaevent_Eventyay_Importer
 	 */
@@ -25,14 +25,14 @@ class Wpfaevent_Admin_Settings_Renderer {
 	/**
 	 * Constructor.
 	 *
-	 * @param Wpfaevent_Eventyay_Importer $importer Importer orchestrator.
+	 * @param Wpfaevent_Eventyay_Importer $importer Importer instance.
 	 */
 	public function __construct( $importer ) {
 		$this->importer = $importer;
 	}
 
 	/**
-	 * Render the settings configuration and import page.
+	 * Render the settings page.
 	 *
 	 * @since 1.0.0
 	 */
@@ -50,11 +50,11 @@ class Wpfaevent_Admin_Settings_Renderer {
 			delete_transient( $notice_key );
 		}
 
-		require_once dirname( __DIR__, 2 ) . '/admin/partials/eventyay-import-settings.php';
+		require_once plugin_dir_path( dirname( __DIR__ ) ) . 'admin/partials/eventyay-import-settings.php';
 	}
 
 	/**
-	 * Render the update events dashboard module.
+	 * Render the Eventyay update page.
 	 *
 	 * @since 1.0.0
 	 */
@@ -72,6 +72,6 @@ class Wpfaevent_Admin_Settings_Renderer {
 			delete_transient( $notice_key );
 		}
 
-		require_once dirname( __DIR__, 2 ) . '/admin/partials/eventyay-update-events.php';
+		require_once plugin_dir_path( dirname( __DIR__ ) ) . 'admin/partials/eventyay-update-events.php';
 	}
 }

--- a/tests/unit/SampleTest.php
+++ b/tests/unit/SampleTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class SampleTest
+ * Class UnitSampleTest
  *
  * @package Wpfaevent
  */
@@ -8,7 +8,7 @@
 /**
  * Sample test class to verify environment boot stability.
  */
-class SampleTest extends WP_UnitTestCase {
+class UnitSampleTest extends WP_UnitTestCase {
 
 	/**
 	 * Verify that the baseline setup is working and WordPress functions are accessible.


### PR DESCRIPTION
## Summary
- move admin-related settings UI/templates into a dedicated follow-up PR
- keep PRs #133, #134, #136, and #137 focused on their feature scopes
- preserve the shared admin importer/settings interface changes in one place

## Included files
- admin/class-wpfaevent-admin.php
- admin/css/wpfaevent-admin.css
- admin/js/wpfaevent-admin.js
- admin/partials/admin-dashboard.php
- admin/partials/eventyay-import-settings.php
- admin/partials/eventyay-update-events.php
- admin/partials/ajax-handlers/class-wpfaevent-event-handler.php
- admin/partials/ajax-handlers/class-wpfaevent-footer-handler.php
- admin/partials/ajax-handlers/class-wpfaevent-speakers-handler.php
- includes/eventyay-importer/class-wpfaevent-admin-settings-renderer.php

## Context
This follow-up PR contains the admin-related UI/settings work that was removed from PRs #133 to #137 so those PRs remain modular and focused.

## Screencast
https://github.com/user-attachments/assets/24d05018-bf45-4214-8e90-3be53f63e6e1

