### PR TITLE
fix: legacy past-events redirection, dynamic navigation highlighting, and filter preselection

### DIFF
--- a/includes/class-wpfaevent-templates.php
+++ b/includes/class-wpfaevent-templates.php
@@ -110,82 +110,10 @@ class Wpfaevent_Templates {
 		add_filter( 'single_template', array( __CLASS__, 'load' ), 99 );
 		add_filter( 'template_include', array( __CLASS__, 'load' ), 99 );
 		add_filter( 'redirect_canonical', array( __CLASS__, 'prevent_canonical_redirect_for_virtual_routes' ), 10, 2 );
-		add_action( 'template_redirect', array( __CLASS__, 'maybe_redirect_old_routes' ) );
+		add_action( 'template_redirect', array( __CLASS__, 'maybe_redirect_old_routes' ), 9 );
 		add_action( 'init', array( __CLASS__, 'register_shortcodes' ) );
 		add_action( 'init', array( __CLASS__, 'register_blocks' ) );
 		add_action( 'init', array( __CLASS__, 'register_patterns' ) );
-		add_action( 'init', array( __CLASS__, 'ensure_all_plugin_pages' ) );
-	}
-
-	/**
-	 * Auto-ensures essential plugin WordPress pages exist in wp_posts.
-	 *
-	 * @since 1.0.0
-	 * @return void
-	 */
-	public static function ensure_all_plugin_pages() {
-		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
-		if ( ! function_exists( 'wp_insert_post' ) ) {
-			return;
-		}
-
-		$plugin_pages = array(
-			'full-schedule'   => array(
-				'title'    => __( 'Full Schedule', 'wpfaevent' ),
-				'template' => 'page-schedule.php',
-				'option'   => 'wpfaevent_schedule_page_id',
-			),
-			'past-events'     => array(
-				'title'    => __( 'Past Events', 'wpfaevent' ),
-				'template' => 'page-past-events.php',
-				'option'   => 'wpfaevent_past_events_page_id',
-			),
-			'speakers'        => array(
-				'title'    => __( 'Speakers', 'wpfaevent' ),
-				'template' => 'page-speakers.php',
-				'option'   => 'wpfaevent_speakers_page_id',
-			),
-			'code-of-conduct' => array(
-				'title'    => __( 'Code of Conduct', 'wpfaevent' ),
-				'template' => 'page-code-of-conduct.php',
-				'option'   => 'wpfaevent_coc_page_id',
-			),
-		);
-
-		foreach ( $plugin_pages as $slug => $data ) {
-			$page_id = (int) get_option( $data['option'], 0 );
-			if ( $page_id && 'page' === get_post_type( $page_id ) && 'trash' !== get_post_status( $page_id ) ) {
-				update_post_meta( $page_id, '_wp_page_template', $data['template'] );
-				continue;
-			}
-
-			$page = get_page_by_path( $slug );
-			if ( $page instanceof WP_Post ) {
-				update_post_meta( $page->ID, '_wp_page_template', $data['template'] );
-				update_option( $data['option'], $page->ID, false );
-				continue;
-			}
-
-			$new_id = wp_insert_post(
-				array(
-					'post_title'     => $data['title'],
-					'post_name'      => $slug,
-					'post_type'      => 'page',
-					'post_status'    => 'publish',
-					'post_content'   => '',
-					'comment_status' => 'closed',
-					'ping_status'    => 'closed',
-				)
-			);
-
-			if ( $new_id && ! is_wp_error( $new_id ) ) {
-				update_post_meta( $new_id, '_wp_page_template', $data['template'] );
-				update_option( $data['option'], $new_id, false );
-			}
-		}
 	}
 
 	/**
@@ -199,22 +127,21 @@ class Wpfaevent_Templates {
 	 */
 	public static function prevent_canonical_redirect_for_virtual_routes( $redirect_url, $_requested_url ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
+			$req_path    = '';
+			$parsed_path = wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH );
+			if ( is_string( $parsed_path ) ) {
+				$req_path = trim( $parsed_path, '/' );
+			}
 			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
-			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
-				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+			if ( '' !== $home_path ) {
+				if ( $req_path === $home_path ) {
+					$req_path = '';
+				} elseif ( 0 === strpos( $req_path, $home_path . '/' ) ) {
+					$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+				}
 			}
 
-			$virtual_routes = array(
-				'past-events',
-				'schedule',
-				'full-schedule',
-				'code-of-conduct',
-				'events',
-				'speakers',
-			);
-
-			if ( in_array( $req_path, $virtual_routes, true ) ) {
+			if ( 'past-events' === $req_path ) {
 				return false;
 			}
 		}
@@ -234,10 +161,18 @@ class Wpfaevent_Templates {
 		}
 
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
+			$req_path    = '';
+			$parsed_path = wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH );
+			if ( is_string( $parsed_path ) ) {
+				$req_path = trim( $parsed_path, '/' );
+			}
 			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
-			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
-				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+			if ( '' !== $home_path ) {
+				if ( $req_path === $home_path ) {
+					$req_path = '';
+				} elseif ( 0 === strpos( $req_path, $home_path . '/' ) ) {
+					$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+				}
 			}
 
 			if ( 'past-events' === $req_path ) {
@@ -325,94 +260,14 @@ class Wpfaevent_Templates {
 			}
 		}
 
-		if ( is_singular( 'page' ) || is_front_page() ) {
-			$page_id = get_queried_object_id();
-			if ( ! $page_id && is_front_page() ) {
-				$page_id = (int) get_option( 'page_on_front' );
-			}
-			if ( $page_id ) {
-				$chosen = get_page_template_slug( $page_id );
-				$key    = self::get_template_key_by_file( $chosen );
+		if ( is_singular( 'page' ) ) {
+			$chosen = get_page_template_slug( get_queried_object_id() );
+			$key    = self::get_template_key_by_file( $chosen );
 
-				if ( $key ) {
-					$candidate = WPFAEVENT_PATH . 'public/templates/' . self::$templates[ $key ]['file'];
+			if ( $key ) {
+				$candidate = WPFAEVENT_PATH . 'public/templates/' . self::$templates[ $key ]['file'];
 
-					if ( file_exists( $candidate ) ) {
-						return $candidate;
-					}
-				}
-			}
-		}
-
-		// Virtual path fallback for plugin routes (past-events, schedule, full-schedule, code-of-conduct, events, speakers).
-		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
-			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
-			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
-				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
-			}
-
-			$virtual_routes = array(
-				'past-events'     => 'page-past-events.php',
-				'schedule'        => 'page-schedule.php',
-				'full-schedule'   => 'page-schedule.php',
-				'code-of-conduct' => 'page-code-of-conduct.php',
-				'events'          => 'page-events.php',
-				'speakers'        => 'page-speakers.php',
-			);
-
-			if ( isset( $virtual_routes[ $req_path ] ) ) {
-				$candidate = WPFAEVENT_PATH . 'public/templates/' . $virtual_routes[ $req_path ];
 				if ( file_exists( $candidate ) ) {
-					global $wp_query, $post;
-
-					$dummy_data                        = new stdClass();
-					$dummy_data->ID                    = -999;
-					$dummy_data->post_author           = 1;
-					$dummy_data->post_date             = current_time( 'mysql' );
-					$dummy_data->post_date_gmt         = current_time( 'mysql', true );
-					$dummy_data->post_content          = '';
-					$dummy_data->post_title            = ucwords( str_replace( '-', ' ', $req_path ) );
-					$dummy_data->post_excerpt          = '';
-					$dummy_data->post_status           = 'publish';
-					$dummy_data->comment_status        = 'closed';
-					$dummy_data->ping_status           = 'closed';
-					$dummy_data->post_password         = '';
-					$dummy_data->post_name             = $req_path;
-					$dummy_data->to_ping               = '';
-					$dummy_data->pinged                = '';
-					$dummy_data->post_modified         = current_time( 'mysql' );
-					$dummy_data->post_modified_gmt     = current_time( 'mysql', true );
-					$dummy_data->post_content_filtered = '';
-					$dummy_data->post_parent           = 0;
-					$dummy_data->guid                  = home_url( '/' . $req_path );
-					$dummy_data->menu_order            = 0;
-					$dummy_data->post_type             = 'page';
-					$dummy_data->post_mime_type        = '';
-					$dummy_data->comment_count         = 0;
-					$dummy_data->filter                = 'raw';
-
-					$dummy_post = new WP_Post( $dummy_data );
-
-					if ( is_object( $wp_query ) ) {
-						$wp_query->post              = $dummy_post;
-						$wp_query->posts             = array( $dummy_post );
-						$wp_query->post_count        = 1;
-						$wp_query->found_posts       = 1;
-						$wp_query->max_num_pages     = 1;
-						$wp_query->queried_object    = $dummy_post;
-						$wp_query->queried_object_id = -999;
-						$wp_query->is_404            = false;
-						$wp_query->is_page           = true;
-						$wp_query->is_singular       = true;
-						$wp_query->is_single         = false;
-						$wp_query->is_home           = false;
-						$wp_query->is_archive        = false;
-					}
-
-					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-					$post = $dummy_post;
-					status_header( 200 );
 					return $candidate;
 				}
 			}

--- a/includes/class-wpfaevent-templates.php
+++ b/includes/class-wpfaevent-templates.php
@@ -109,9 +109,142 @@ class Wpfaevent_Templates {
 		add_filter( 'theme_page_templates', array( __CLASS__, 'register' ) );
 		add_filter( 'single_template', array( __CLASS__, 'load' ), 99 );
 		add_filter( 'template_include', array( __CLASS__, 'load' ), 99 );
+		add_filter( 'redirect_canonical', array( __CLASS__, 'prevent_canonical_redirect_for_virtual_routes' ), 10, 2 );
+		add_action( 'template_redirect', array( __CLASS__, 'maybe_redirect_old_routes' ) );
 		add_action( 'init', array( __CLASS__, 'register_shortcodes' ) );
 		add_action( 'init', array( __CLASS__, 'register_blocks' ) );
 		add_action( 'init', array( __CLASS__, 'register_patterns' ) );
+		add_action( 'init', array( __CLASS__, 'ensure_all_plugin_pages' ) );
+	}
+
+	/**
+	 * Auto-ensures essential plugin WordPress pages exist in wp_posts.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public static function ensure_all_plugin_pages() {
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'wp_insert_post' ) ) {
+			return;
+		}
+
+		$plugin_pages = array(
+			'full-schedule'   => array(
+				'title'    => __( 'Full Schedule', 'wpfaevent' ),
+				'template' => 'page-schedule.php',
+				'option'   => 'wpfaevent_schedule_page_id',
+			),
+			'past-events'     => array(
+				'title'    => __( 'Past Events', 'wpfaevent' ),
+				'template' => 'page-past-events.php',
+				'option'   => 'wpfaevent_past_events_page_id',
+			),
+			'speakers'        => array(
+				'title'    => __( 'Speakers', 'wpfaevent' ),
+				'template' => 'page-speakers.php',
+				'option'   => 'wpfaevent_speakers_page_id',
+			),
+			'code-of-conduct' => array(
+				'title'    => __( 'Code of Conduct', 'wpfaevent' ),
+				'template' => 'page-code-of-conduct.php',
+				'option'   => 'wpfaevent_coc_page_id',
+			),
+		);
+
+		foreach ( $plugin_pages as $slug => $data ) {
+			$page_id = (int) get_option( $data['option'], 0 );
+			if ( $page_id && 'page' === get_post_type( $page_id ) && 'trash' !== get_post_status( $page_id ) ) {
+				update_post_meta( $page_id, '_wp_page_template', $data['template'] );
+				continue;
+			}
+
+			$page = get_page_by_path( $slug );
+			if ( $page instanceof WP_Post ) {
+				update_post_meta( $page->ID, '_wp_page_template', $data['template'] );
+				update_option( $data['option'], $page->ID, false );
+				continue;
+			}
+
+			$new_id = wp_insert_post(
+				array(
+					'post_title'     => $data['title'],
+					'post_name'      => $slug,
+					'post_type'      => 'page',
+					'post_status'    => 'publish',
+					'post_content'   => '',
+					'comment_status' => 'closed',
+					'ping_status'    => 'closed',
+				)
+			);
+
+			if ( $new_id && ! is_wp_error( $new_id ) ) {
+				update_post_meta( $new_id, '_wp_page_template', $data['template'] );
+				update_option( $data['option'], $new_id, false );
+			}
+		}
+	}
+
+	/**
+	 * Prevents WordPress canonical redirects from hijacking virtual plugin routes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|false $redirect_url The proposed canonical redirect URL.
+	 * @param string       $_requested_url The requested URL.
+	 * @return string|false
+	 */
+	public static function prevent_canonical_redirect_for_virtual_routes( $redirect_url, $_requested_url ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
+			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
+				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+			}
+
+			$virtual_routes = array(
+				'past-events',
+				'schedule',
+				'full-schedule',
+				'code-of-conduct',
+				'events',
+				'speakers',
+			);
+
+			if ( in_array( $req_path, $virtual_routes, true ) ) {
+				return false;
+			}
+		}
+
+		return $redirect_url;
+	}
+
+	/**
+	 * Redirects legacy/old paths to new hub views.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public static function maybe_redirect_old_routes() {
+		if ( is_admin() ) {
+			return;
+		}
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
+			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
+				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+			}
+
+			if ( 'past-events' === $req_path ) {
+				wp_safe_redirect( home_url( '/events/?filter=past' ), 301 );
+				exit;
+			}
+		}
 	}
 
 	/**
@@ -192,14 +325,94 @@ class Wpfaevent_Templates {
 			}
 		}
 
-		if ( is_singular( 'page' ) ) {
-			$chosen = get_page_template_slug( get_queried_object_id() );
-			$key    = self::get_template_key_by_file( $chosen );
+		if ( is_singular( 'page' ) || is_front_page() ) {
+			$page_id = get_queried_object_id();
+			if ( ! $page_id && is_front_page() ) {
+				$page_id = (int) get_option( 'page_on_front' );
+			}
+			if ( $page_id ) {
+				$chosen = get_page_template_slug( $page_id );
+				$key    = self::get_template_key_by_file( $chosen );
 
-			if ( $key ) {
-				$candidate = WPFAEVENT_PATH . 'public/templates/' . self::$templates[ $key ]['file'];
+				if ( $key ) {
+					$candidate = WPFAEVENT_PATH . 'public/templates/' . self::$templates[ $key ]['file'];
 
+					if ( file_exists( $candidate ) ) {
+						return $candidate;
+					}
+				}
+			}
+		}
+
+		// Virtual path fallback for plugin routes (past-events, schedule, full-schedule, code-of-conduct, events, speakers).
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
+			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
+				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+			}
+
+			$virtual_routes = array(
+				'past-events'     => 'page-past-events.php',
+				'schedule'        => 'page-schedule.php',
+				'full-schedule'   => 'page-schedule.php',
+				'code-of-conduct' => 'page-code-of-conduct.php',
+				'events'          => 'page-events.php',
+				'speakers'        => 'page-speakers.php',
+			);
+
+			if ( isset( $virtual_routes[ $req_path ] ) ) {
+				$candidate = WPFAEVENT_PATH . 'public/templates/' . $virtual_routes[ $req_path ];
 				if ( file_exists( $candidate ) ) {
+					global $wp_query, $post;
+
+					$dummy_data                        = new stdClass();
+					$dummy_data->ID                    = -999;
+					$dummy_data->post_author           = 1;
+					$dummy_data->post_date             = current_time( 'mysql' );
+					$dummy_data->post_date_gmt         = current_time( 'mysql', true );
+					$dummy_data->post_content          = '';
+					$dummy_data->post_title            = ucwords( str_replace( '-', ' ', $req_path ) );
+					$dummy_data->post_excerpt          = '';
+					$dummy_data->post_status           = 'publish';
+					$dummy_data->comment_status        = 'closed';
+					$dummy_data->ping_status           = 'closed';
+					$dummy_data->post_password         = '';
+					$dummy_data->post_name             = $req_path;
+					$dummy_data->to_ping               = '';
+					$dummy_data->pinged                = '';
+					$dummy_data->post_modified         = current_time( 'mysql' );
+					$dummy_data->post_modified_gmt     = current_time( 'mysql', true );
+					$dummy_data->post_content_filtered = '';
+					$dummy_data->post_parent           = 0;
+					$dummy_data->guid                  = home_url( '/' . $req_path );
+					$dummy_data->menu_order            = 0;
+					$dummy_data->post_type             = 'page';
+					$dummy_data->post_mime_type        = '';
+					$dummy_data->comment_count         = 0;
+					$dummy_data->filter                = 'raw';
+
+					$dummy_post = new WP_Post( $dummy_data );
+
+					if ( is_object( $wp_query ) ) {
+						$wp_query->post              = $dummy_post;
+						$wp_query->posts             = array( $dummy_post );
+						$wp_query->post_count        = 1;
+						$wp_query->found_posts       = 1;
+						$wp_query->max_num_pages     = 1;
+						$wp_query->queried_object    = $dummy_post;
+						$wp_query->queried_object_id = -999;
+						$wp_query->is_404            = false;
+						$wp_query->is_page           = true;
+						$wp_query->is_singular       = true;
+						$wp_query->is_single         = false;
+						$wp_query->is_home           = false;
+						$wp_query->is_archive        = false;
+					}
+
+					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+					$post = $dummy_post;
+					status_header( 200 );
 					return $candidate;
 				}
 			}

--- a/public/js/wpfaevent-events.js
+++ b/public/js/wpfaevent-events.js
@@ -267,6 +267,18 @@ const WPFA_Events = (function() {
 				filterEvents();
 			});
 		});
+
+		// Check for URL parameter to pre-select filter tab on load
+		const urlParams = new URLSearchParams(window.location.search);
+		const urlFilter = urlParams.get('filter');
+		if (urlFilter) {
+			const targetBtn = document.querySelector(`.date-filter-btn[data-filter="${urlFilter}"]`);
+			if (targetBtn) {
+				document.querySelectorAll('.date-filter-btn').forEach(b => b.classList.remove('active'));
+				targetBtn.classList.add('active');
+				filterEvents();
+			}
+		}
 	}
 
 	/**

--- a/public/js/wpfaevent-events.js
+++ b/public/js/wpfaevent-events.js
@@ -271,8 +271,10 @@ const WPFA_Events = (function() {
 		// Check for URL parameter to pre-select filter tab on load
 		const urlParams = new URLSearchParams(window.location.search);
 		const urlFilter = urlParams.get('filter');
-		if (urlFilter) {
-			const targetBtn = document.querySelector(`.date-filter-btn[data-filter="${urlFilter}"]`);
+		const allowedFilters = ['all', 'upcoming', 'past', 'bookmarked'];
+		if (urlFilter && allowedFilters.includes(urlFilter)) {
+			const targetBtn = Array.from(document.querySelectorAll('.date-filter-btn'))
+				.find(btn => btn.dataset.filter === urlFilter);
 			if (targetBtn) {
 				document.querySelectorAll('.date-filter-btn').forEach(b => b.classList.remove('active'));
 				targetBtn.classList.add('active');

--- a/public/partials/header.php
+++ b/public/partials/header.php
@@ -25,12 +25,18 @@ $register_button_text        = isset( $register_button_text ) ? $register_button
 // Get the Code of Conduct page ID, with caching handled by the cache class.
 $coc_page_id = Wpfaevent_Cache::get_coc_page_id();
 
-// Determine whether the current page is the Code of Conduct page.
-$is_current = ( $coc_page_id && is_page( $coc_page_id ) ) ? 'active' : '';
+// Determine active state for navigation links.
+$current_path = isset( $_SERVER['REQUEST_URI'] ) ? trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' ) : '';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$current_filter        = isset( $_GET['filter'] ) ? sanitize_text_field( wp_unslash( $_GET['filter'] ) ) : '';
+$is_past_events_active = ( 'past-events' === $current_path || is_page_template( 'page-past-events.php' ) || 'past' === $current_filter ) ? 'active' : '';
+$is_events_active      = ( ( 'events' === $current_path || is_post_type_archive( 'wpfa_event' ) || is_page_template( 'page-events.php' ) ) && 'past' !== $current_filter ) ? 'active' : '';
+$is_coc_active         = ( 'code-of-conduct' === $current_path || ( $coc_page_id && is_page( $coc_page_id ) ) || is_page_template( 'page-code-of-conduct.php' ) ) ? 'active' : '';
 
 // Allow customization of events URLs via filters while keeping current behavior as default.
 $events_url      = apply_filters( 'wpfaevent_events_url', home_url( '/events/' ) );
-$past_events_url = apply_filters( 'wpfaevent_past_events_url', home_url( '/past-events/' ) );
+$past_events_url = apply_filters( 'wpfaevent_past_events_url', home_url( '/events/?filter=past' ) );
+$coc_url         = $coc_page_id ? get_permalink( $coc_page_id ) : home_url( '/code-of-conduct/' );
 ?>
 
 <header class="nav" role="banner">
@@ -40,11 +46,9 @@ $past_events_url = apply_filters( 'wpfaevent_past_events_url', home_url( '/past-
 		</a>
 		<nav class="nav-links" role="navigation" aria-label="<?php esc_attr_e( 'Primary', 'wpfaevent' ); ?>">
 			<div class="nav-links-main">
-				<a href="<?php echo esc_url( $events_url ); ?>"><?php esc_html_e( 'Upcoming Events', 'wpfaevent' ); ?></a>
-				<a href="<?php echo esc_url( $past_events_url ); ?>"><?php esc_html_e( 'Past Events', 'wpfaevent' ); ?></a>
-				<?php if ( $coc_page_id ) : ?>
-					<a href="<?php echo esc_url( get_permalink( $coc_page_id ) ); ?>" class="<?php echo esc_attr( $is_current ); ?>"><?php esc_html_e( 'Code of Conduct', 'wpfaevent' ); ?></a>
-				<?php endif; ?>
+				<a href="<?php echo esc_url( $events_url ); ?>" class="<?php echo esc_attr( $is_events_active ); ?>"><?php esc_html_e( 'Upcoming Events', 'wpfaevent' ); ?></a>
+				<a href="<?php echo esc_url( $past_events_url ); ?>" class="<?php echo esc_attr( $is_past_events_active ); ?>"><?php esc_html_e( 'Past Events', 'wpfaevent' ); ?></a>
+				<a href="<?php echo esc_url( $coc_url ); ?>" class="<?php echo esc_attr( $is_coc_active ); ?>"><?php esc_html_e( 'Code of Conduct', 'wpfaevent' ); ?></a>
 			</div>
 			
 			<?php if ( $show_back_button || $show_register_button ) : ?>

--- a/public/partials/header.php
+++ b/public/partials/header.php
@@ -26,9 +26,30 @@ $register_button_text        = isset( $register_button_text ) ? $register_button
 $coc_page_id = Wpfaevent_Cache::get_coc_page_id();
 
 // Determine active state for navigation links.
-$current_path = isset( $_SERVER['REQUEST_URI'] ) ? trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' ) : '';
+$current_path = '';
+if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+	$parsed_path = wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH );
+	if ( is_string( $parsed_path ) ) {
+		$current_path = trim( $parsed_path, '/' );
+	}
+}
+
+$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+if ( '' !== $home_path ) {
+	if ( $current_path === $home_path ) {
+		$current_path = '';
+	} elseif ( 0 === strpos( $current_path, $home_path . '/' ) ) {
+		$current_path = trim( substr( $current_path, strlen( $home_path ) ), '/' );
+	}
+}
+
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$current_filter        = isset( $_GET['filter'] ) ? sanitize_text_field( wp_unslash( $_GET['filter'] ) ) : '';
+$raw_filter     = isset( $_GET['filter'] ) ? sanitize_text_field( wp_unslash( $_GET['filter'] ) ) : '';
+$current_filter = '';
+if ( 'past' === $raw_filter ) {
+	$current_filter = 'past';
+}
+
 $is_past_events_active = ( 'past-events' === $current_path || is_page_template( 'page-past-events.php' ) || 'past' === $current_filter ) ? 'active' : '';
 $is_events_active      = ( ( 'events' === $current_path || is_post_type_archive( 'wpfa_event' ) || is_page_template( 'page-events.php' ) ) && 'past' !== $current_filter ) ? 'active' : '';
 $is_coc_active         = ( 'code-of-conduct' === $current_path || ( $coc_page_id && is_page( $coc_page_id ) ) || is_page_template( 'page-code-of-conduct.php' ) ) ? 'active' : '';


### PR DESCRIPTION
Closes #168

### Problem and Solution
This PR resolves the broken/404 legacy `/past-events/` URL by introducing 301 redirection to `/events/?filter=past`. It also fixes navigation menu highlighting and client-side pre-filtering when the Events page is loaded with `?filter=past` query param.

### Main Changes
* **Redirection & Virtual Routes:** Intercept `/past-events/` request path and trigger a 301 redirect in `includes/class-wpfaevent-templates.php`. Suppress canonical redirection loop checks.
* **Menu Active Checking:** Check for active query parameter in `public/partials/header.php` and dynamically highlight the "Past Events" link.
* **Client-side Filter tab selection:** Parse query URL parameters in `public/js/wpfaevent-events.js` and pre-click the tab corresponding to the filter value.

### Testing Steps
1. Navigate to `/past-events/` in browser and verify redirection to `/events/?filter=past`.
2. Verify that the "Past Events" item in header menu has `.is-active` / active style.
3. Verify that the "Past" filter tab is selected on the page load automatically.

## Summary by Sourcery

Handle legacy events URLs and virtual plugin routes, ensuring they resolve to the correct templates and navigation state.

New Features:
- Automatically create and maintain required plugin pages (schedule, past events, speakers, code of conduct) with the appropriate templates for admins.
- Introduce virtual routes for key plugin paths so they render the correct event-related templates even without backing WordPress pages.
- Add client-side preselection of the events filter tab based on the `filter` query parameter on page load.

Bug Fixes:
- Redirect the legacy `/past-events/` URL to `/events/?filter=past` and prevent canonical redirects from breaking plugin routes.
- Fix navigation highlighting so Upcoming Events, Past Events, and Code of Conduct links reflect the current route or filter state consistently.

Enhancements:
- Extend template resolution to support the front page and virtual plugin routes while returning proper 200 responses instead of 404s.


## Screencast

https://github.com/user-attachments/assets/6ea6a549-58d8-49f6-b371-db8c45486725


