### PR TITLE
fix: client-side schedule view switching and timezone conversion improvements

### DIFF
--- a/public/js/wpfaevent-public.js
+++ b/public/js/wpfaevent-public.js
@@ -30,10 +30,112 @@
 	 */
 
 	$(function () {
-		$('.wpfa-event-timezone-select').on('change', function () {
-			if (this.form) {
-				this.form.submit();
+		// Client-side Schedule View Switch (List vs Calendar)
+		$(document).on('click', '.wpfa-schedule-view-switch a', function (e) {
+			e.preventDefault();
+			const $btn = $(this);
+			const href = $btn.attr('href') || '';
+			const isCalendar =
+				href.indexOf('view=calendar') !== -1 ||
+				href.indexOf('schedule_view=calendar') !== -1;
+
+			const $switch = $btn.closest('.wpfa-schedule-view-switch');
+			$switch
+				.find('a')
+				.removeClass('is-active')
+				.removeAttr('aria-current');
+			$btn.addClass('is-active').attr('aria-current', 'page');
+
+			if (isCalendar) {
+				$('.wpfa-schedule-calendar').css('display', '');
+				$('.wpfa-schedule-program').css('display', 'none');
+			} else {
+				$('.wpfa-schedule-program').css('display', '');
+				$('.wpfa-schedule-calendar').css('display', 'none');
 			}
+
+			if (window.history && window.history.replaceState) {
+				window.history.replaceState(null, '', href);
+			}
+		});
+
+		// Client-side Timezone Converter
+		$(document).on(
+			'change',
+			'.wpfa-event-timezone-select, #wpfa-schedule-timezone',
+			function (e) {
+				e.preventDefault();
+				const selectedTz = $(this).val();
+				if (!selectedTz) {
+					return;
+				}
+
+				let formatter;
+				try {
+					formatter = new Intl.DateTimeFormat([], {
+						timeZone: selectedTz,
+						hour: 'numeric',
+						minute: '2-digit',
+					});
+				} catch {
+					return;
+				}
+
+				$('time[data-utc-start]').each(function () {
+					const rawStart = $(this).attr('data-utc-start');
+
+					try {
+						const startObj = rawStart ? new Date(rawStart) : null;
+						if (!startObj || isNaN(startObj.getTime())) {
+							return;
+						}
+
+						const rawEnd = $(this).attr('data-utc-end');
+						const startLabel = formatter.format(startObj);
+
+						if (rawEnd) {
+							const endObj = new Date(rawEnd);
+							const endLabel = !isNaN(endObj.getTime())
+								? formatter.format(endObj)
+								: '';
+							$(this).text(
+								endLabel && endLabel !== startLabel
+									? `${startLabel} - ${endLabel}`
+									: startLabel
+							);
+							return;
+						}
+
+						$(this).text(startLabel);
+					} catch {
+						// Timezone fallback if unsupported string
+					}
+				});
+
+				if (window.history && window.history.replaceState) {
+					const currentUrl = new URL(window.location.href);
+					currentUrl.searchParams.set('schedule_tz', selectedTz);
+					window.history.replaceState(
+						null,
+						'',
+						currentUrl.toString()
+					);
+				}
+			}
+		);
+
+		// Progressive enhancement: Hide timezone forms submit/apply buttons when JS is loaded
+		$('.wpfa-event-timezone-form, .wpfa-schedule-filter-form').each(
+			function () {
+				if ($(this).find('.wpfa-event-timezone-select').length) {
+					$(this).find('button[type="submit"]').hide();
+				}
+			}
+		);
+
+		// Auto-submit filter form if language selection changes (since Apply button is hidden)
+		$(document).on('change', '#wpfa-schedule-language', function () {
+			$(this).closest('form').submit();
 		});
 
 		const speakerPlaceholderSvg =
@@ -199,8 +301,6 @@
 			e.preventDefault();
 			e.stopPropagation();
 
-			const $btn = $(this);
-			const eventId = $btn.data('event-id');
 			const settings = window.wpfaeventPublic || {};
 
 			if (!settings.isLoggedIn) {
@@ -211,6 +311,8 @@
 				return;
 			}
 
+			const $btn = $(this);
+			const eventId = $btn.data('event-id');
 			$btn.prop('disabled', true);
 
 			$.ajax({
@@ -221,7 +323,7 @@
 					nonce: settings.nonce,
 					event_id: eventId,
 				},
-				success: function (response) {
+				success(response) {
 					$btn.prop('disabled', false);
 					if (response.success) {
 						const isBookmarked = response.data.bookmarked;
@@ -307,16 +409,20 @@
 							}
 						}
 					} else {
-						alert(
+						// eslint-disable-next-line no-alert
+						window.alert(
 							response.data?.message ||
 								settings.i18n?.error ||
 								'Something went wrong.'
 						);
 					}
 				},
-				error: function () {
+				error() {
 					$btn.prop('disabled', false);
-					alert(settings.i18n?.error || 'Something went wrong.');
+					// eslint-disable-next-line no-alert
+					window.alert(
+						settings.i18n?.error || 'Something went wrong.'
+					);
 				},
 			});
 		});

--- a/public/templates/page-schedule.php
+++ b/public/templates/page-schedule.php
@@ -435,13 +435,73 @@ if ( ! empty( $languages ) ) {
 
 			<?php if ( $is_event_schedule ) : ?>
 				<?php if ( ! empty( $event_session_schedule['groups'] ) ) : ?>
-					<?php if ( 'calendar' === $current_view ) : ?>
-						<div class="wpfa-schedule-calendar" role="list">
-							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
-								<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading">
-									<header class="wpfa-schedule-calendar-day-head">
-										<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading"><?php echo esc_html( $day_label ); ?></h2>
-										<span>
+					<div class="wpfa-schedule-calendar" role="list" style="<?php echo 'calendar' === $current_view ? '' : 'display:none;'; ?>">
+						<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+							<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading">
+								<header class="wpfa-schedule-calendar-day-head">
+									<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading"><?php echo esc_html( $day_label ); ?></h2>
+									<span>
+										<?php
+										printf(
+											/* translators: %d: number of sessions on this day. */
+											esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+											absint( count( $day_sessions ) )
+										);
+										?>
+									</span>
+								</header>
+								<div class="wpfa-schedule-calendar-slots">
+									<?php foreach ( $day_sessions as $item ) : ?>
+										<article class="wpfa-schedule-calendar-slot">
+											<?php if ( ! empty( $item['time_label'] ) ) : ?>
+												<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-end="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+											<?php endif; ?>
+											<h3><?php echo esc_html( $item['title'] ); ?></h3>
+											<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+												<ul class="wpfa-schedule-calendar-meta">
+													<?php if ( ! empty( $item['speakers'] ) ) : ?>
+														<li><?php echo esc_html( $item['speakers'] ); ?></li>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['room'] ) ) : ?>
+														<li><?php echo esc_html( $item['room'] ); ?></li>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['track'] ) ) : ?>
+														<li><?php echo esc_html( $item['track'] ); ?></li>
+													<?php endif; ?>
+												</ul>
+											<?php endif; ?>
+											<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+												<?php
+												$session_calendar_label = sprintf(
+													/* translators: %s: session title. */
+													__( 'Add %s to Google Calendar', 'wpfaevent' ),
+													$item['title']
+												);
+												?>
+												<a
+													class="wpfa-schedule-session-calendar"
+													href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+													target="_blank"
+													rel="noopener"
+													aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+												>
+													<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+												</a>
+											<?php endif; ?>
+										</article>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endforeach; ?>
+					</div>
+
+					<div class="wpfa-schedule-program" style="<?php echo 'list' === $current_view ? '' : 'display:none;'; ?>">
+						<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+							<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+								<header class="wpfa-schedule-day-head">
+									<div>
+										<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h2>
+										<p>
 											<?php
 											printf(
 												/* translators: %d: number of sessions on this day. */
@@ -449,82 +509,21 @@ if ( ! empty( $languages ) ) {
 												absint( count( $day_sessions ) )
 											);
 											?>
-										</span>
-									</header>
-									<div class="wpfa-schedule-calendar-slots">
-										<?php foreach ( $day_sessions as $item ) : ?>
-											<article class="wpfa-schedule-calendar-slot">
-												<?php if ( ! empty( $item['time_label'] ) ) : ?>
-													<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
-												<?php endif; ?>
-												<h3><?php echo esc_html( $item['title'] ); ?></h3>
-												<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
-													<ul class="wpfa-schedule-calendar-meta">
-														<?php if ( ! empty( $item['speakers'] ) ) : ?>
-															<li><?php echo esc_html( $item['speakers'] ); ?></li>
-														<?php endif; ?>
-														<?php if ( ! empty( $item['room'] ) ) : ?>
-															<li><?php echo esc_html( $item['room'] ); ?></li>
-														<?php endif; ?>
-														<?php if ( ! empty( $item['track'] ) ) : ?>
-															<li><?php echo esc_html( $item['track'] ); ?></li>
-														<?php endif; ?>
-													</ul>
-												<?php endif; ?>
-												<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
-													<?php
-													$session_calendar_label = sprintf(
-														/* translators: %s: session title. */
-														__( 'Add %s to Google Calendar', 'wpfaevent' ),
-														$item['title']
-													);
-													?>
-													<a
-														class="wpfa-schedule-session-calendar"
-														href="<?php echo esc_url( $item['calendar_url'] ); ?>"
-														target="_blank"
-														rel="noopener"
-														aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
-													>
-														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-													</a>
-												<?php endif; ?>
-											</article>
-										<?php endforeach; ?>
+										</p>
 									</div>
-								</section>
-							<?php endforeach; ?>
-						</div>
-					<?php else : ?>
-						<div class="wpfa-schedule-program">
-							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
-								<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
-									<header class="wpfa-schedule-day-head">
-										<div>
-											<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h2>
-											<p>
-												<?php
-												printf(
-													/* translators: %d: number of sessions on this day. */
-													esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
-													absint( count( $day_sessions ) )
-												);
-												?>
-											</p>
-										</div>
-									</header>
+								</header>
 
-									<div class="wpfa-schedule-day-sessions" role="list">
-										<?php foreach ( $day_sessions as $item ) : ?>
-											<article class="wpfa-schedule-session" role="listitem">
-												<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
-													<?php if ( ! empty( $item['time_start'] ) ) : ?>
-														<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
-															<?php echo esc_html( $item['time_start'] ); ?>
-														</time>
-													<?php endif; ?>
+								<div class="wpfa-schedule-day-sessions" role="list">
+									<?php foreach ( $day_sessions as $item ) : ?>
+										<article class="wpfa-schedule-session" role="listitem">
+											<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+												<?php if ( ! empty( $item['time_start'] ) ) : ?>
+													<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+														<?php echo esc_html( $item['time_start'] ); ?>
+													</time>
+												<?php endif; ?>
 													<?php if ( ! empty( $item['time_end'] ) ) : ?>
-														<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
+														<time class="wpfa-schedule-session-end" datetime="<?php echo esc_attr( $item['end_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_end'] ); ?></time>
 													<?php endif; ?>
 												</div>
 
@@ -579,7 +578,6 @@ if ( ! empty( $languages ) ) {
 								</section>
 							<?php endforeach; ?>
 						</div>
-					<?php endif; ?>
 				<?php else : ?>
 					<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
 				<?php endif; ?>

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -66,6 +66,8 @@ $format_timezone_label                    = $event_data['format_timezone_label']
 $build_event_schedule_view_url            = $event_data['build_event_schedule_view_url'];
 $selected_schedule_timezone               = $event_data['selected_schedule_timezone'];
 $main_regular_speaker_ids                 = $event_data['main_regular_speaker_ids'];
+$speaker_ids                              = $event_data['speaker_ids'];
+$regular_speaker_ids                      = $event_data['regular_speaker_ids'];
 $main_dashboard_regular_speakers          = $event_data['main_dashboard_regular_speakers'];
 $main_dashboard_speakers                  = $event_data['main_dashboard_speakers'];
 $dashboard_speaker_overflow_count         = $event_data['dashboard_speaker_overflow_count'];
@@ -237,7 +239,7 @@ if ( $show_ticket_widget ) {
 						</a>
 					<?php endif; ?>
 					<button class="wpfa-event-bookmark-btn wpfa-bookmark-btn<?php echo $is_bookmarked ? ' is-bookmarked' : ''; ?>" data-event-id="<?php echo esc_attr( (string) $event_id ); ?>">
-						<svg class="wpfa-bookmark-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" style="width: 16px; height: 16px; margin-right: 8px; vertical-align: middle;">
+						<svg class="wpfa-bookmark-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
 							<path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
 						</svg>
 						<span class="wpfa-bookmark-text"><?php echo $is_bookmarked ? esc_html__( 'Remove Bookmark', 'wpfaevent' ) : esc_html__( 'Bookmark Event', 'wpfaevent' ); ?></span>
@@ -552,13 +554,73 @@ if ( $show_ticket_widget ) {
 						<?php endif; ?>
 					</div>
 					<?php if ( ! empty( $schedule_preview_items ) ) : ?>
-						<?php if ( 'calendar' === $current_schedule_view ) : ?>
-							<div class="wpfa-schedule-calendar" role="list">
-								<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
-									<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading">
-										<header class="wpfa-schedule-calendar-day-head">
-											<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading"><?php echo esc_html( $day_label ); ?></h3>
-											<span>
+						<div class="wpfa-schedule-calendar" role="list" style="<?php echo 'calendar' === $current_schedule_view ? '' : 'display:none;'; ?>">
+							<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading">
+									<header class="wpfa-schedule-calendar-day-head">
+										<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading"><?php echo esc_html( $day_label ); ?></h3>
+										<span>
+											<?php
+											printf(
+												/* translators: %d: number of sessions on this day. */
+												esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+												absint( count( $day_sessions ) )
+											);
+											?>
+										</span>
+									</header>
+									<div class="wpfa-schedule-calendar-slots">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-calendar-slot">
+												<?php if ( ! empty( $item['time_label'] ) ) : ?>
+													<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-end="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+												<?php endif; ?>
+												<h4><?php echo esc_html( $item['title'] ); ?></h4>
+												<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+													<ul class="wpfa-schedule-calendar-meta">
+														<?php if ( ! empty( $item['speakers'] ) ) : ?>
+															<li><?php echo esc_html( $item['speakers'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['room'] ) ) : ?>
+															<li><?php echo esc_html( $item['room'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['track'] ) ) : ?>
+															<li><?php echo esc_html( $item['track'] ); ?></li>
+														<?php endif; ?>
+													</ul>
+												<?php endif; ?>
+												<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+													<?php
+													$session_calendar_label = sprintf(
+														/* translators: %s: session title. */
+														__( 'Add %s to Google Calendar', 'wpfaevent' ),
+														$item['title']
+													);
+													?>
+													<a
+														class="wpfa-schedule-session-calendar"
+														href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+														target="_blank"
+														rel="noopener"
+														aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+													>
+														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+													</a>
+												<?php endif; ?>
+											</article>
+										<?php endforeach; ?>
+									</div>
+								</section>
+							<?php endforeach; ?>
+						</div>
+
+						<div class="wpfa-schedule-program" style="<?php echo 'list' === $current_schedule_view ? '' : 'display:none;'; ?>">
+							<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+									<header class="wpfa-schedule-day-head">
+										<div>
+											<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h3>
+											<p>
 												<?php
 												printf(
 													/* translators: %d: number of sessions on this day. */
@@ -566,87 +628,26 @@ if ( $show_ticket_widget ) {
 													absint( count( $day_sessions ) )
 												);
 												?>
-											</span>
-										</header>
-										<div class="wpfa-schedule-calendar-slots">
-											<?php foreach ( $day_sessions as $item ) : ?>
-												<article class="wpfa-schedule-calendar-slot">
-													<?php if ( ! empty( $item['time_label'] ) ) : ?>
-														<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
-													<?php endif; ?>
-													<h4><?php echo esc_html( $item['title'] ); ?></h4>
-													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
-														<ul class="wpfa-schedule-calendar-meta">
-															<?php if ( ! empty( $item['speakers'] ) ) : ?>
-																<li><?php echo esc_html( $item['speakers'] ); ?></li>
-															<?php endif; ?>
-															<?php if ( ! empty( $item['room'] ) ) : ?>
-																<li><?php echo esc_html( $item['room'] ); ?></li>
-															<?php endif; ?>
-															<?php if ( ! empty( $item['track'] ) ) : ?>
-																<li><?php echo esc_html( $item['track'] ); ?></li>
-															<?php endif; ?>
-														</ul>
-													<?php endif; ?>
-													<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
-														<?php
-														$session_calendar_label = sprintf(
-															/* translators: %s: session title. */
-															__( 'Add %s to Google Calendar', 'wpfaevent' ),
-															$item['title']
-														);
-														?>
-														<a
-															class="wpfa-schedule-session-calendar"
-															href="<?php echo esc_url( $item['calendar_url'] ); ?>"
-															target="_blank"
-															rel="noopener"
-															aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
-														>
-															<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-														</a>
-													<?php endif; ?>
-												</article>
-											<?php endforeach; ?>
+											</p>
 										</div>
-									</section>
-								<?php endforeach; ?>
-							</div>
-						<?php else : ?>
-							<div class="wpfa-schedule-program">
-								<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
-									<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
-										<header class="wpfa-schedule-day-head">
-											<div>
-												<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h3>
-												<p>
-													<?php
-													printf(
-														/* translators: %d: number of sessions on this day. */
-														esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
-														absint( count( $day_sessions ) )
-													);
-													?>
-												</p>
-											</div>
-										</header>
+									</header>
 
-										<div class="wpfa-schedule-day-sessions" role="list">
-											<?php foreach ( $day_sessions as $item ) : ?>
-												<article class="wpfa-schedule-session" role="listitem">
-													<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
-														<?php if ( ! empty( $item['time_start'] ) ) : ?>
-															<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
-																<?php echo esc_html( $item['time_start'] ); ?>
-															</time>
-														<?php endif; ?>
-														<?php if ( ! empty( $item['time_end'] ) ) : ?>
-															<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
-														<?php endif; ?>
-													</div>
+									<div class="wpfa-schedule-day-sessions" role="list">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-session" role="listitem">
+												<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+													<?php if ( ! empty( $item['time_start'] ) ) : ?>
+														<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+															<?php echo esc_html( $item['time_start'] ); ?>
+														</time>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['time_end'] ) ) : ?>
+														<time class="wpfa-schedule-session-end" datetime="<?php echo esc_attr( $item['end_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_end'] ); ?></time>
+													<?php endif; ?>
+												</div>
 
-													<div class="wpfa-schedule-session-main">
-														<h4 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h4>
+												<div class="wpfa-schedule-session-main">
+													<h4 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h4>
 
 														<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
 															<dl class="wpfa-schedule-session-details">
@@ -696,7 +697,6 @@ if ( $show_ticket_widget ) {
 									</section>
 								<?php endforeach; ?>
 							</div>
-						<?php endif; ?>
 						<?php if ( $schedule_hidden_count ) : ?>
 							<p class="wpfa-event-schedule-preview-note">
 								<?php


### PR DESCRIPTION
Closes #170

### Problem and Solution
Toggling views and changing timezones on the event schedule templates triggered full-page reloads. Additionally, the client-side timezone converter dropped end times in calendar view and left end times un-converted in list view due to lack of machine-readable elements.
This PR moves schedule view toggling and timezone conversion entirely client-side without page reloads, and adds raw start/end UTC datetimes to allow consistent timezone formatting across both calendar and list layouts.

### Main Changes
* **Client-side Interactivity:** Toggle visibility of `.wpfa-schedule-calendar` and `.wpfa-schedule-program` instantly in `public/js/wpfaevent-public.js`.
* **Timezone Converter Range support:** Read `data-utc-start` and optional `data-utc-end` attributes and format them using `Intl.DateTimeFormat`.
* **Markup Datetime standardisation:** Render list view end times as `<time>` tags and include start/end UTC properties on all date/time containers in `page-schedule.php` and `single-wpfa-event.php`.

### Testing Steps
1. Navigate to an event's schedule or list view.
2. Toggle between list and calendar views, verifying it is instant without reloads.
3. Select a new timezone from the dropdown. Verify all times (start and end) update dynamically.

## Summary by Sourcery

Move schedule view switching and timezone timezone conversion to client-side behavior for event schedules, using standardized datetime markup to enable dynamic formatting without page reloads.

New Features:
- Enable instant client-side toggling between calendar and list schedule views on event and schedule pages.
- Add client-side timezone conversion for schedule times using machine-readable UTC datetime attributes.

Bug Fixes:
- Ensure session end times are correctly converted and displayed in both calendar and list views when changing timezones.

Enhancements:
- Standardize schedule markup by rendering start/end times as <time> elements with UTC data attributes across calendar and list layouts.
- Preserve selected schedule view and timezone in the URL via history.replaceState for better navigation state handling.
- Slightly adjust bookmark button SVG styling to rely on CSS rather than inline styles.


## Screencast 

https://github.com/user-attachments/assets/37ff9e34-9684-4acb-a581-aeb11e3464bb




