### PR TITLE
style: scope ticket widget overlay alert suppression to plugin container

### DIFF
--- a/public/css/templates/event.css
+++ b/public/css/templates/event.css
@@ -442,6 +442,11 @@
 	display: none;
 }
 
+/* Suppress Eventyay/Pretix ticket widget error alert overlay icon */
+.wpfaevent .pretix-widget-alert-holder {
+	display: none !important;
+}
+
 .wpfaevent .wpfa-event-ticket-widget-loaded .wpfa-event-ticket-backup {
 	display: none;
 }

--- a/public/css/templates/single-event.css
+++ b/public/css/templates/single-event.css
@@ -2391,3 +2391,8 @@
 		padding: 20px;
 	}
 }
+
+/* Suppress Eventyay/Pretix ticket widget error alert overlay icon */
+.wpfaevent .pretix-widget-alert-holder {
+	display: none !important;
+}

--- a/public/css/wpfaevent-public.css
+++ b/public/css/wpfaevent-public.css
@@ -317,3 +317,8 @@
     color: var(--brand);
     font-weight: bold;
 }
+
+/* Suppress Eventyay/Pretix ticket widget error alert overlay icon */
+.wpfaevent .pretix-widget-alert-holder {
+	display: none !important;
+}


### PR DESCRIPTION
Closes #172

### Problem and Solution
The CSS rule to suppress the ticket widget alert icon was written with a global `.pretix-widget-alert-holder` selector, which suppresses alert warning icons on any Pretix widgets site-wide.
This PR scopes the suppression to `.wpfaevent` container wrapper, limiting the suppression to only the plugin's ticket widgets.

### Main Changes
* Scope ticket widget alert styling selectors to `.wpfaevent .pretix-widget-alert-holder` in `wpfaevent-public.css`, `event.css`, and `single-event.css`.

### Testing Steps
1. Navigate to single event page with a ticket widget.
2. Confirm the ticket widget alert overlay icon is suppressed.
3. Test a mock Pretix widget without `.wpfaevent` wrapper and verify that `.pretix-widget-alert-holder` alert is NOT suppressed.

## Summary by Sourcery

Enhancements:
- Limit the CSS rule that hides Pretix ticket widget alert overlays to widgets inside the .wpfaevent container across public and template stylesheets.


## Screenshot 

<img width="1440" height="612" alt="Screenshot 2026-08-12 at 12 59 04 PM" src="https://github.com/user-attachments/assets/458f99b6-64cd-4166-91b9-a6de2252a246" />


