### PR TITLE
fix: speaker photos cropping issue and standardise partners aspect ratios

### DIFF
--- a/public/css/templates/event.css
+++ b/public/css/templates/event.css
@@ -1333,14 +1333,6 @@
 	aspect-ratio: 1 / 1;
 }
 
-.wpfaevent .wpfa-event-detail .wpfa-speaker-photo img {
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
-	object-position: center top;
-	display: block;
-}
-
 .wpfaevent .wpfa-event-detail .wpfa-speaker-meta {
 	padding: 18px 18px 14px;
 }

--- a/public/css/templates/event.css
+++ b/public/css/templates/event.css
@@ -1330,7 +1330,15 @@
 
 .wpfaevent .wpfa-event-detail .wpfa-speaker-photo {
 	background: #eaf1f8;
-	height: 190px;
+	aspect-ratio: 1 / 1;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-photo img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: center top;
+	display: block;
 }
 
 .wpfaevent .wpfa-event-detail .wpfa-speaker-meta {
@@ -1708,7 +1716,7 @@
 	display: flex;
 	justify-content: center;
 	min-height: 148px;
-	padding: 28px 24px 22px;
+	padding: 20px 24px;
 }
 
 .wpfaevent .wpfa-event-partner-logo img {
@@ -2271,7 +2279,7 @@
 	display: flex;
 	height: 70px;
 	justify-content: center;
-	padding: 12px;
+	padding: 10px;
 	width: 88px;
 }
 

--- a/public/css/templates/events.css
+++ b/public/css/templates/events.css
@@ -286,7 +286,8 @@
 .wpfaevent .event-card-thumb {
 	flex-shrink: 0;
 	width: 220px;
-	min-height: 200px;
+	height: 220px;
+	aspect-ratio: 1 / 1;
 	background: #e8eaed;
 	display: block;
 	overflow: hidden;
@@ -296,7 +297,7 @@
 .wpfaevent .event-card-thumb img {
 	width: 100%;
 	height: 100%;
-	min-height: 200px;
+	aspect-ratio: 1 / 1;
 	object-fit: cover;
 	display: block;
 }
@@ -304,8 +305,14 @@
 .wpfaevent .event-card-thumb-placeholder {
 	width: 100%;
 	height: 100%;
-	min-height: 200px;
+	aspect-ratio: 1 / 1;
 	background: linear-gradient(135deg, #e8eaed 0%, #d0d3d8 100%);
+	display: block;
+}
+
+.wpfaevent .event-card-thumb-placeholder svg {
+	width: 100%;
+	height: 100%;
 	display: block;
 }
 

--- a/public/css/templates/partners.css
+++ b/public/css/templates/partners.css
@@ -85,7 +85,7 @@
 	display: flex;
 	justify-content: center;
 	min-height: 148px;
-	padding: 28px 24px 22px;
+	padding: 20px 24px;
 }
 
 .wpfaevent .wpfa-event-partner-logo img {

--- a/public/css/templates/past-events.css
+++ b/public/css/templates/past-events.css
@@ -75,7 +75,8 @@
 }
 
 .wpfa-past-event-card-image {
-	height: 180px;
+	width: 100%;
+	aspect-ratio: 1 / 1;
 	background-color: #f0f0f0;
 	overflow: hidden;
 }
@@ -83,6 +84,7 @@
 .wpfa-past-event-card-image img {
 	width: 100%;
 	height: 100%;
+	aspect-ratio: 1 / 1;
 	object-fit: cover;
 	transition: transform 0.5s ease;
 }

--- a/public/css/templates/single-event.css
+++ b/public/css/templates/single-event.css
@@ -707,14 +707,6 @@
 	aspect-ratio: 1 / 1;
 }
 
-.wpfaevent .wpfa-event-detail .wpfa-speaker-photo img {
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
-	object-position: center top;
-	display: block;
-}
-
 .wpfaevent .wpfa-event-detail .wpfa-speaker-meta {
 	padding: 18px 18px 14px;
 }
@@ -2400,5 +2392,3 @@
 		padding: 20px;
 	}
 }
-
-

--- a/public/css/templates/single-event.css
+++ b/public/css/templates/single-event.css
@@ -704,6 +704,15 @@
 
 .wpfaevent .wpfa-event-detail .wpfa-speaker-photo {
 	background: #eaf1f8;
+	aspect-ratio: 1 / 1;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-photo img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: center top;
+	display: block;
 }
 
 .wpfaevent .wpfa-event-detail .wpfa-speaker-meta {
@@ -807,7 +816,7 @@
 	display: flex;
 	justify-content: center;
 	min-height: 148px;
-	padding: 28px 24px 22px;
+	padding: 20px 24px;
 }
 
 .wpfaevent .wpfa-event-partner-logo img {
@@ -1370,7 +1379,7 @@
 	display: flex;
 	height: 70px;
 	justify-content: center;
-	padding: 12px;
+	padding: 10px;
 	width: 88px;
 }
 
@@ -2391,3 +2400,5 @@
 		padding: 20px;
 	}
 }
+
+

--- a/public/css/templates/speakers.css
+++ b/public/css/templates/speakers.css
@@ -186,16 +186,40 @@
 	overflow: hidden;
 }
 
-.wpfaevent .wpfa-speaker-photo img {
+.wpfaevent .wpfa-speaker-photo-container {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+}
+
+.wpfaevent .wpfa-speaker-photo-blur {
+	position: absolute;
+	top: 0;
+	left: 0;
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
 	object-position: center top;
+	filter: blur(10px);
+	transform: scale(1.1);
+	opacity: 0.5;
 	display: block;
-	transition: transform 0.3s ease;
+	z-index: 1;
 }
 
-.wpfaevent .wpfa-speaker-card:hover .wpfa-speaker-photo img {
+.wpfaevent .wpfa-speaker-photo-img {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	object-position: center;
+	display: block;
+	transition: transform 0.3s ease;
+	z-index: 2;
+}
+
+.wpfaevent .wpfa-speaker-card:hover .wpfa-speaker-photo-img {
 	transform: scale(1.05);
 }
 

--- a/public/css/templates/speakers.css
+++ b/public/css/templates/speakers.css
@@ -212,8 +212,8 @@
 	position: relative;
 	width: 100%;
 	height: 100%;
-	object-fit: contain;
-	object-position: center;
+	object-fit: cover;
+	object-position: center top;
 	display: block;
 	transition: transform 0.3s ease;
 	z-index: 2;

--- a/public/css/templates/speakers.css
+++ b/public/css/templates/speakers.css
@@ -180,16 +180,18 @@
 /* Speaker Photo */
 .wpfaevent .wpfa-speaker-photo {
 	display: block;
-	height: 220px;
-	background: linear-gradient(135deg, #e9e9e9, #f6f6f6);
+	width: 100%;
+	aspect-ratio: 1 / 1;
+	background: #000;
 	overflow: hidden;
 }
 
 .wpfaevent .wpfa-speaker-photo img {
 	width: 100%;
 	height: 100%;
-	object-fit: contain;
-	object-position: center;
+	object-fit: cover;
+	object-position: center top;
+	display: block;
 	transition: transform 0.3s ease;
 }
 
@@ -227,6 +229,13 @@
 	-webkit-mask-size: contain;
 	-webkit-mask-repeat: no-repeat;
 	-webkit-mask-position: center;
+}
+
+.wpfaevent .wpfa-speaker-placeholder-img {
+	width: 100%;
+	height: 100% !important;
+	object-fit: contain;
+	background: linear-gradient(135deg, #e0e4ea, #eef0f3);
 }
 
 /* Speaker Meta (Name, Role, Category) */

--- a/public/partials/speakers/dashboard-speaker-card.php
+++ b/public/partials/speakers/dashboard-speaker-card.php
@@ -26,8 +26,12 @@ $is_featured_speaker = ! empty( $wpfa_dashboard_speaker_is_featured ) || ! empty
 <article class="wpfa-speaker-card visible <?php echo esc_attr( $is_featured_speaker ? 'is-featured' : '' ); ?>">
 	<div class="wpfa-speaker-photo">
 		<?php if ( ! empty( $speaker['image'] ) ) : ?>
-			<?php /* translators: %s: Speaker name. */ ?>
-			<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy">
+			<div class="wpfa-speaker-photo-container">
+				<img class="wpfa-speaker-photo-blur" src="<?php echo esc_url( $speaker['image'] ); ?>" alt="" aria-hidden="true" loading="lazy">
+				<?php /* translators: %s: Speaker name. */ ?>
+				<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy" onerror="this.style.display='none'; if(this.previousElementSibling) this.previousElementSibling.style.display='none'; this.nextElementSibling.style.display='block';">
+				<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img" style="display:none;">
+			</div>
 		<?php else : ?>
 			<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img">
 		<?php endif; ?>

--- a/public/partials/speakers/dashboard-speaker-card.php
+++ b/public/partials/speakers/dashboard-speaker-card.php
@@ -27,7 +27,7 @@ $is_featured_speaker = ! empty( $wpfa_dashboard_speaker_is_featured ) || ! empty
 	<div class="wpfa-speaker-photo">
 		<?php if ( ! empty( $speaker['image'] ) ) : ?>
 			<?php /* translators: %s: Speaker name. */ ?>
-			<img src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy">
+			<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy">
 		<?php else : ?>
 			<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img">
 		<?php endif; ?>

--- a/public/partials/speakers/dashboard-speaker-card.php
+++ b/public/partials/speakers/dashboard-speaker-card.php
@@ -29,8 +29,8 @@ $is_featured_speaker = ! empty( $wpfa_dashboard_speaker_is_featured ) || ! empty
 			<div class="wpfa-speaker-photo-container">
 				<img class="wpfa-speaker-photo-blur" src="<?php echo esc_url( $speaker['image'] ); ?>" alt="" aria-hidden="true" loading="lazy">
 				<?php /* translators: %s: Speaker name. */ ?>
-				<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy" onerror="this.style.display='none'; if(this.previousElementSibling) this.previousElementSibling.style.display='none'; this.nextElementSibling.style.display='block';">
-				<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img" style="display:none;">
+				<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy" onerror="this.style.display='none'; if(this.previousElementSibling) this.previousElementSibling.style.display='none'; if(this.nextElementSibling) this.nextElementSibling.style.display='flex';">
+				<span class="wpfa-speaker-placeholder" style="display:none;" aria-hidden="true"></span>
 			</div>
 		<?php else : ?>
 			<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img">

--- a/public/partials/speakers/speaker-card.php
+++ b/public/partials/speakers/speaker-card.php
@@ -68,7 +68,7 @@ $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
 <article class="wpfa-speaker-card" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( sprintf( '%d', absint( $sid ) ) ); ?>">
 	<a class="wpfa-speaker-photo" href="<?php echo esc_url( $speaker_link ); ?>">
 		<?php if ( $photo_url ) : ?>
-			<img src="<?php echo esc_url( $photo_url ); ?>"
+			<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $photo_url ); ?>"
 				alt="<?php echo esc_attr( $photo_alt ); ?>"
 				loading="lazy"
 				itemprop="image"

--- a/public/partials/speakers/speaker-card.php
+++ b/public/partials/speakers/speaker-card.php
@@ -68,12 +68,15 @@ $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
 <article class="wpfa-speaker-card" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( sprintf( '%d', absint( $sid ) ) ); ?>">
 	<a class="wpfa-speaker-photo" href="<?php echo esc_url( $speaker_link ); ?>">
 		<?php if ( $photo_url ) : ?>
-			<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $photo_url ); ?>"
-				alt="<?php echo esc_attr( $photo_alt ); ?>"
-				loading="lazy"
-				itemprop="image"
-				onerror="this.style.display='none';this.nextElementSibling.style.display='flex';" />
-			<span class="wpfa-speaker-placeholder" style="display:none;" aria-hidden="true"></span>
+			<div class="wpfa-speaker-photo-container">
+				<img class="wpfa-speaker-photo-blur" src="<?php echo esc_url( $photo_url ); ?>" alt="" aria-hidden="true" loading="lazy" />
+				<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $photo_url ); ?>"
+					alt="<?php echo esc_attr( $photo_alt ); ?>"
+					loading="lazy"
+					itemprop="image"
+					onerror="this.style.display='none'; if(this.previousElementSibling) this.previousElementSibling.style.display='none'; this.nextElementSibling.style.display='flex';" />
+				<span class="wpfa-speaker-placeholder" style="display:none;" aria-hidden="true"></span>
+			</div>
 		<?php else : ?>
 			<span class="wpfa-speaker-placeholder" aria-hidden="true"></span>
 		<?php endif; ?>


### PR DESCRIPTION
Closes #176

### Problem and Solution
Strict square constraints on speaker photo blocks cropped portraits awkwardly, cutting off faces. Partner/exhibitor logo containers also did not size uniformly.
This PR fixes the speaker photo cropping issue by utilizing an inline styled container helper (acting as a blurred background container) and `object-fit: cover` styling. It also standardizes the grid logo containers with responsive aspect ratios.

### Main Changes
* **Blurred Background Crop Fix:** Update `speaker-card.php` and `dashboard-speaker-card.php` to output a blurred copy of the speaker photo as a background wrapper.
* **Responsive CSS adjustments:** Standardize dimensions, margins, and object-fit bounds across `speakers.css`, `past-events.css`, `events.css`, `partners.css`, `event.css`, and `single-event.css`.

### Testing Steps
1. Navigate to the speaker directory and single speaker profile pages. Verify photos are aligned correctly to center-top and show faces fully.
2. Confirm sponsor/exhibitor logos display with standard sizes and no distortion.

## Summary by Sourcery

Improve visual consistency of speaker photos and partner logos across event templates.

Bug Fixes:
- Prevent speaker portraits from being awkwardly cropped by enforcing square containers with top-centered cover images and dedicated placeholder styling.

Enhancements:
- Standardize square aspect ratios and image fit behavior for speaker, event card, and past event thumbnails to ensure consistent presentation.
- Align partner and exhibitor logo blocks with unified padding and sizing across event-related templates.


## Screenshots
<img width="395" height="238" alt="Screenshot 2026-08-03 at 1 51 34 PM" src="https://github.com/user-attachments/assets/f45dfc3f-d075-4598-8d51-95d6614b344d" />

<img width="324" height="256" alt="Screenshot 2026-08-03 at 1 51 47 PM" src="https://github.com/user-attachments/assets/d101791f-e08e-45d4-919a-87faed885e9f" />

<img width="1238" height="459" alt="Screenshot 2026-08-03 at 1 52 23 PM" src="https://github.com/user-attachments/assets/7d25fc59-3600-41bc-90d1-47fe196b8178" />
