### PR TITLE
fix: speaker photos cropping, partner logo aspects, placeholders, and admin metaboxes

### DIFF
--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -915,6 +915,26 @@ class Wpfaevent_Admin {
 			);
 		}
 
+		// Event sponsors meta box.
+		add_meta_box(
+			'wpfa_event_sponsors_box',
+			__( 'Event Sponsors', 'wpfaevent' ),
+			array( $this, 'render_event_sponsors_meta_box' ),
+			'wpfa_event',
+			'normal',
+			'default'
+		);
+
+		// Event exhibitors meta box.
+		add_meta_box(
+			'wpfa_event_exhibitors_box',
+			__( 'Event Exhibitors', 'wpfaevent' ),
+			array( $this, 'render_event_exhibitors_meta_box' ),
+			'wpfa_event',
+			'normal',
+			'default'
+		);
+
 		// Speaker meta boxes.
 		add_meta_box(
 			'wpfa_speaker_details',
@@ -1158,6 +1178,260 @@ class Wpfaevent_Admin {
 	}
 
 	/**
+	 * Render Event Sponsors meta box.
+	 *
+	 * @since 1.0.1
+	 * @param WP_Post $post The post object.
+	 */
+	public function render_event_sponsors_meta_box( $post ) {
+		$sponsors = array();
+		if ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+			$store          = new Wpfaevent_Eventyay_Dashboard_Store();
+			$sponsor_groups = $store->read_dashboard_json_file( 'sponsors-' . $post->ID . '.json', array() );
+			if ( is_array( $sponsor_groups ) ) {
+				foreach ( $sponsor_groups as $group ) {
+					$group_name     = isset( $group['group_name'] ) ? $group['group_name'] : '';
+					$logo_size      = isset( $group['logo_size'] ) ? $group['logo_size'] : 160;
+					$group_sponsors = isset( $group['sponsors'] ) && is_array( $group['sponsors'] ) ? $group['sponsors'] : array();
+					foreach ( $group_sponsors as $sp ) {
+						$sponsors[] = array(
+							'group_name'  => $group_name,
+							'logo_size'   => $logo_size,
+							'name'        => isset( $sp['name'] ) ? $sp['name'] : '',
+							'image'       => isset( $sp['image'] ) ? $sp['image'] : '',
+							'link'        => isset( $sp['link'] ) ? $sp['link'] : '',
+							'description' => isset( $sp['description'] ) ? $sp['description'] : '',
+							'level'       => isset( $sp['level'] ) ? $sp['level'] : 0,
+						);
+					}
+				}
+			}
+		}
+
+		?>
+		<div class="wpfaevent-meta-cards-container" id="wpfaevent-sponsors-container">
+			<?php
+			if ( ! empty( $sponsors ) ) :
+				foreach ( $sponsors as $index => $sp ) :
+					?>
+					<div class="wpfaevent-meta-card">
+						<a href="#" class="wpfaevent-remove-sponsor wpfaevent-remove-card-btn"><?php esc_html_e( 'Remove', 'wpfaevent' ); ?></a>
+						<div class="wpfaevent-meta-card-grid">
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Tier/Group Name', 'wpfaevent' ); ?></label>
+								<input type="text" name="wpfa_sponsors[<?php echo absint( $index ); ?>][group_name]" value="<?php echo esc_attr( $sp['group_name'] ); ?>" required placeholder="e.g. Gold Sponsors">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Logo Size', 'wpfaevent' ); ?></label>
+								<input type="number" name="wpfa_sponsors[<?php echo absint( $index ); ?>][logo_size]" value="<?php echo esc_attr( $sp['logo_size'] ); ?>" required min="50" max="500">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Sponsor Name', 'wpfaevent' ); ?></label>
+								<input type="text" name="wpfa_sponsors[<?php echo absint( $index ); ?>][name]" value="<?php echo esc_attr( $sp['name'] ); ?>" required>
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Logo URL', 'wpfaevent' ); ?></label>
+								<input type="url" name="wpfa_sponsors[<?php echo absint( $index ); ?>][image]" value="<?php echo esc_attr( $sp['image'] ); ?>" required placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Website URL', 'wpfaevent' ); ?></label>
+								<input type="url" name="wpfa_sponsors[<?php echo absint( $index ); ?>][link]" value="<?php echo esc_attr( $sp['link'] ); ?>" placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Sort Level', 'wpfaevent' ); ?></label>
+								<input type="number" name="wpfa_sponsors[<?php echo absint( $index ); ?>][level]" value="<?php echo esc_attr( $sp['level'] ); ?>" min="0">
+							</div>
+							<div class="wpfaevent-meta-card-field span-2">
+								<label><?php esc_html_e( 'Description', 'wpfaevent' ); ?></label>
+								<input type="text" name="wpfa_sponsors[<?php echo absint( $index ); ?>][description]" value="<?php echo esc_attr( $sp['description'] ); ?>">
+							</div>
+						</div>
+					</div>
+					<?php
+				endforeach;
+			endif;
+			?>
+		</div>
+
+		<button type="button" class="button button-primary" id="wpfaevent-add-sponsor-row">
+			<?php esc_html_e( 'Add Sponsor', 'wpfaevent' ); ?>
+		</button>
+
+		<script>
+			jQuery(document).ready(function($) {
+				let sponsorIndex = $('#wpfaevent-sponsors-container .wpfaevent-meta-card').length;
+
+				$('#wpfaevent-add-sponsor-row').on('click', function(e) {
+					e.preventDefault();
+					const html = `<div class="wpfaevent-meta-card">
+						<a href="#" class="wpfaevent-remove-sponsor wpfaevent-remove-card-btn">Remove</a>
+						<div class="wpfaevent-meta-card-grid">
+							<div class="wpfaevent-meta-card-field">
+								<label>Tier/Group Name</label>
+								<input type="text" name="wpfa_sponsors[\${sponsorIndex}][group_name]" required placeholder="e.g. Gold Sponsors">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Logo Size</label>
+								<input type="number" name="wpfa_sponsors[\${sponsorIndex}][logo_size]" value="160" required min="50" max="500">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Sponsor Name</label>
+								<input type="text" name="wpfa_sponsors[\${sponsorIndex}][name]" required>
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Logo URL</label>
+								<input type="url" name="wpfa_sponsors[\${sponsorIndex}][image]" required placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Website URL</label>
+								<input type="url" name="wpfa_sponsors[\${sponsorIndex}][link]" placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Sort Level</label>
+								<input type="number" name="wpfa_sponsors[\${sponsorIndex}][level]" value="0" min="0">
+							</div>
+							<div class="wpfaevent-meta-card-field span-2">
+								<label>Description</label>
+								<input type="text" name="wpfa_sponsors[\${sponsorIndex}][description]">
+							</div>
+						</div>
+					</div>`;
+					$('#wpfaevent-sponsors-container').append(html);
+					sponsorIndex++;
+				});
+
+				$('#wpfaevent-sponsors-container').on('click', '.wpfaevent-remove-sponsor', function(e) {
+					e.preventDefault();
+					$(this).closest('.wpfaevent-meta-card').remove();
+				});
+			});
+		</script>
+		<?php
+	}
+
+	/**
+	 * Render Event Exhibitors meta box.
+	 *
+	 * @since 1.0.1
+	 * @param WP_Post $post The post object.
+	 */
+	public function render_event_exhibitors_meta_box( $post ) {
+		$exhibitors = array();
+		if ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+			$store      = new Wpfaevent_Eventyay_Dashboard_Store();
+			$exhibitors = $store->read_dashboard_json_file( 'exhibitors-' . $post->ID . '.json', array() );
+		}
+
+		?>
+		<div class="wpfaevent-meta-cards-container" id="wpfaevent-exhibitors-container">
+			<?php
+			if ( ! empty( $exhibitors ) && is_array( $exhibitors ) ) :
+				foreach ( $exhibitors as $index => $ex ) :
+					?>
+					<div class="wpfaevent-meta-card">
+						<a href="#" class="wpfaevent-remove-exhibitor wpfaevent-remove-card-btn"><?php esc_html_e( 'Remove', 'wpfaevent' ); ?></a>
+						<div class="wpfaevent-meta-card-grid">
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Exhibitor Name', 'wpfaevent' ); ?></label>
+								<input type="text" name="wpfa_exhibitors[<?php echo absint( $index ); ?>][name]" value="<?php echo esc_attr( $ex['name'] ); ?>" required>
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Logo URL', 'wpfaevent' ); ?></label>
+								<input type="url" name="wpfa_exhibitors[<?php echo absint( $index ); ?>][logo]" value="<?php echo esc_attr( isset( $ex['logo'] ) ? $ex['logo'] : '' ); ?>" required placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Banner URL', 'wpfaevent' ); ?></label>
+								<input type="url" name="wpfa_exhibitors[<?php echo absint( $index ); ?>][banner]" value="<?php echo esc_attr( isset( $ex['banner'] ) ? $ex['banner'] : '' ); ?>" placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Website URL', 'wpfaevent' ); ?></label>
+								<input type="url" name="wpfa_exhibitors[<?php echo absint( $index ); ?>][link]" value="<?php echo esc_attr( isset( $ex['link'] ) ? $ex['link'] : '' ); ?>" placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Email', 'wpfaevent' ); ?></label>
+								<input type="email" name="wpfa_exhibitors[<?php echo absint( $index ); ?>][contact_email]" value="<?php echo esc_attr( isset( $ex['contact_email'] ) ? $ex['contact_email'] : '' ); ?>">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Contact Link', 'wpfaevent' ); ?></label>
+								<input type="url" name="wpfa_exhibitors[<?php echo absint( $index ); ?>][contact_link]" value="<?php echo esc_attr( isset( $ex['contact_link'] ) ? $ex['contact_link'] : '' ); ?>" placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label><?php esc_html_e( 'Sort Order', 'wpfaevent' ); ?></label>
+								<input type="number" name="wpfa_exhibitors[<?php echo absint( $index ); ?>][position]" value="<?php echo esc_attr( isset( $ex['position'] ) ? $ex['position'] : 0 ); ?>" min="0">
+							</div>
+							<div class="wpfaevent-meta-card-field span-2">
+								<label><?php esc_html_e( 'Description', 'wpfaevent' ); ?></label>
+								<input type="text" name="wpfa_exhibitors[<?php echo absint( $index ); ?>][description]" value="<?php echo esc_attr( isset( $ex['description'] ) ? $ex['description'] : '' ); ?>">
+							</div>
+						</div>
+					</div>
+					<?php
+				endforeach;
+			endif;
+			?>
+		</div>
+
+		<button type="button" class="button button-primary" id="wpfaevent-add-exhibitor-row">
+			<?php esc_html_e( 'Add Exhibitor', 'wpfaevent' ); ?>
+		</button>
+
+		<script>
+			jQuery(document).ready(function($) {
+				let exhibitorIndex = $('#wpfaevent-exhibitors-container .wpfaevent-meta-card').length;
+
+				$('#wpfaevent-add-exhibitor-row').on('click', function(e) {
+					e.preventDefault();
+					const html = `<div class="wpfaevent-meta-card">
+						<a href="#" class="wpfaevent-remove-exhibitor wpfaevent-remove-card-btn">Remove</a>
+						<div class="wpfaevent-meta-card-grid">
+							<div class="wpfaevent-meta-card-field">
+								<label>Exhibitor Name</label>
+								<input type="text" name="wpfa_exhibitors[\${exhibitorIndex}][name]" required>
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Logo URL</label>
+								<input type="url" name="wpfa_exhibitors[\${exhibitorIndex}][logo]" required placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Banner URL</label>
+								<input type="url" name="wpfa_exhibitors[\${exhibitorIndex}][banner]" placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Website URL</label>
+								<input type="url" name="wpfa_exhibitors[\${exhibitorIndex}][link]" placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Email</label>
+								<input type="email" name="wpfa_exhibitors[\${exhibitorIndex}][contact_email]">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Contact Link</label>
+								<input type="url" name="wpfa_exhibitors[\${exhibitorIndex}][contact_link]" placeholder="https://">
+							</div>
+							<div class="wpfaevent-meta-card-field">
+								<label>Sort Order</label>
+								<input type="number" name="wpfa_exhibitors[\${exhibitorIndex}][position]" value="0" min="0">
+							</div>
+							<div class="wpfaevent-meta-card-field span-2">
+								<label>Description</label>
+								<input type="text" name="wpfa_exhibitors[\${exhibitorIndex}][description]">
+							</div>
+						</div>
+					</div>`;
+					$('#wpfaevent-exhibitors-container').append(html);
+					exhibitorIndex++;
+				});
+
+				$('#wpfaevent-exhibitors-container').on('click', '.wpfaevent-remove-exhibitor', function(e) {
+					e.preventDefault();
+					$(this).closest('.wpfaevent-meta-card').remove();
+				});
+			});
+		</script>
+		<?php
+	}
+
+	/**
 	 * Render Speaker meta box.
 	 *
 	 * @since 1.0.0
@@ -1373,6 +1647,135 @@ class Wpfaevent_Admin {
 		$this->update_post_id_list_meta( $post_id, 'wpfa_event_speakers', $speakers );
 
 		Wpfaevent_Meta_Event::sync_event_speaker_relationships( $post_id, $previous_speakers, $speakers );
+
+		// Handle sponsors saving.
+		if ( isset( $_POST['wpfa_sponsors'] ) && is_array( $_POST['wpfa_sponsors'] ) ) {
+			$raw_sponsors = wp_unslash( $_POST['wpfa_sponsors'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized in loop below.
+			$groups       = array();
+
+			foreach ( $raw_sponsors as $sp ) {
+				$group_name  = isset( $sp['group_name'] ) ? sanitize_text_field( $sp['group_name'] ) : '';
+				$logo_size   = isset( $sp['logo_size'] ) ? absint( $sp['logo_size'] ) : 160;
+				$name        = isset( $sp['name'] ) ? sanitize_text_field( $sp['name'] ) : '';
+				$image       = isset( $sp['image'] ) ? esc_url_raw( $sp['image'] ) : '';
+				$link        = isset( $sp['link'] ) ? esc_url_raw( $sp['link'] ) : '';
+				$level       = isset( $sp['level'] ) ? absint( $sp['level'] ) : 0;
+				$description = isset( $sp['description'] ) ? sanitize_text_field( $sp['description'] ) : '';
+
+				if ( ! $group_name || ! $name || ! $image ) {
+					continue;
+				}
+
+				if ( ! isset( $groups[ $group_name ] ) ) {
+					$groups[ $group_name ] = array(
+						'group_name' => $group_name,
+						'logo_size'  => $logo_size,
+						'sponsors'   => array(),
+					);
+				}
+
+				$groups[ $group_name ]['sponsors'][] = array(
+					'id'          => 'sponsor-' . sanitize_title( $name ),
+					'source'      => 'manual',
+					'name'        => $name,
+					'image'       => $image,
+					'link'        => $link,
+					'level'       => $level,
+					'description' => $description,
+					'type'        => $group_name,
+				);
+			}
+
+			// Sort sponsors inside each group by level ASC, name ASC.
+			foreach ( $groups as &$g ) {
+				usort(
+					$g['sponsors'],
+					static function ( $a, $b ) {
+						if ( $a['level'] !== $b['level'] ) {
+							return $a['level'] <=> $b['level'];
+						}
+						return strcasecmp( $a['name'], $b['name'] );
+					}
+				);
+			}
+			unset( $g );
+
+			// Reindex groups.
+			$formatted_sponsors = array_values( $groups );
+
+			if ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+				$store = new Wpfaevent_Eventyay_Dashboard_Store();
+				$store->write_dashboard_json_file(
+					'sponsors-' . $post_id . '.json',
+					$formatted_sponsors
+				);
+			}
+		} elseif ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+			$store = new Wpfaevent_Eventyay_Dashboard_Store();
+			$store->write_dashboard_json_file(
+				'sponsors-' . $post_id . '.json',
+				array()
+			);
+		}
+
+		// Handle exhibitors saving.
+		if ( isset( $_POST['wpfa_exhibitors'] ) && is_array( $_POST['wpfa_exhibitors'] ) ) {
+			$raw_exhibitors       = wp_unslash( $_POST['wpfa_exhibitors'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized in loop below.
+			$formatted_exhibitors = array();
+
+			foreach ( $raw_exhibitors as $ex ) {
+				$name          = isset( $ex['name'] ) ? sanitize_text_field( $ex['name'] ) : '';
+				$logo          = isset( $ex['logo'] ) ? esc_url_raw( $ex['logo'] ) : '';
+				$banner        = isset( $ex['banner'] ) ? esc_url_raw( $ex['banner'] ) : '';
+				$link          = isset( $ex['link'] ) ? esc_url_raw( $ex['link'] ) : '';
+				$contact_email = isset( $ex['contact_email'] ) ? sanitize_email( $ex['contact_email'] ) : '';
+				$contact_link  = isset( $ex['contact_link'] ) ? esc_url_raw( $ex['contact_link'] ) : '';
+				$position      = isset( $ex['position'] ) ? absint( $ex['position'] ) : 0;
+				$description   = isset( $ex['description'] ) ? sanitize_text_field( $ex['description'] ) : '';
+
+				if ( ! $name || ! $logo ) {
+					continue;
+				}
+
+				$formatted_exhibitors[] = array(
+					'id'            => 'exhibitor-' . sanitize_title( $name ),
+					'source'        => 'manual',
+					'name'          => $name,
+					'logo'          => $logo,
+					'banner'        => $banner,
+					'link'          => $link,
+					'contact_email' => $contact_email,
+					'contact_link'  => $contact_link,
+					'position'      => $position,
+					'description'   => $description,
+				);
+			}
+
+			// Sort exhibitors by position ASC, name ASC.
+			usort(
+				$formatted_exhibitors,
+				static function ( $a, $b ) {
+					if ( $a['position'] !== $b['position'] ) {
+						return $a['position'] <=> $b['position'];
+					}
+					return strcasecmp( $a['name'], $b['name'] );
+				}
+			);
+
+			if ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+				$store = new Wpfaevent_Eventyay_Dashboard_Store();
+				$store->write_dashboard_json_file(
+					'exhibitors-' . $post_id . '.json',
+					$formatted_exhibitors
+				);
+			}
+		} elseif ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+			$store = new Wpfaevent_Eventyay_Dashboard_Store();
+			$store->write_dashboard_json_file(
+				'exhibitors-' . $post_id . '.json',
+				array()
+			);
+		}
 	}
 
 	/**

--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -1854,14 +1854,25 @@ class Wpfaevent_Eventyay_Importer {
 		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'type', 'level_name', 'level-name', 'tier', 'category' ) );
 		$level            = $this->eventyay_first_present_raw( $sponsor_resource, array( 'level', 'position', 'order', 'sort_order', 'sort-order' ) );
 
+		$desc  = $this->eventyay_first_present_rich_text( $sponsor_resource, array( 'description', 'subtitle', 'summary' ) );
+		$image = $this->eventyay_url_value( $this->eventyay_first_present_raw( $sponsor_resource, array( 'logo-url', 'logo_url', 'logo', 'image', 'image-url', 'image_url' ) ), $settings['base_url'] );
+
+		if ( empty( $image ) ) {
+			$image = WPFAEVENT_URL . 'assets/images/logo.png';
+		}
+		if ( empty( $desc ) ) {
+			/* translators: %s: sponsor name */
+			$desc = sprintf( __( 'Event sponsor and partner %s.', 'wpfaevent' ), $name );
+		}
+
 		return array(
 			'id'          => $source_id ? 'eventyay-sponsor-' . sanitize_key( $source_id ) : 'eventyay-sponsor-' . sanitize_title( $name ),
 			'source'      => 'eventyay',
 			'eventyay_id' => sanitize_text_field( $source_id ),
 			'name'        => sanitize_text_field( $name ),
-			'description' => $this->eventyay_first_present_rich_text( $sponsor_resource, array( 'description', 'subtitle', 'summary' ) ),
+			'description' => $desc,
 			'link'        => $this->eventyay_url_value( $this->eventyay_first_present_raw( $sponsor_resource, array( 'url', 'link', 'website', 'website-url', 'website_url' ) ), $settings['base_url'] ),
-			'image'       => $this->eventyay_url_value( $this->eventyay_first_present_raw( $sponsor_resource, array( 'logo-url', 'logo_url', 'logo', 'image', 'image-url', 'image_url' ) ), $settings['base_url'] ),
+			'image'       => $image,
 			'type'        => sanitize_text_field( $type ),
 			'level'       => is_numeric( $level ) ? absint( $level ) : 0,
 		);
@@ -2023,14 +2034,25 @@ class Wpfaevent_Eventyay_Importer {
 		$name               = $this->eventyay_first_present_text( $exhibitor_resource, array( 'name', 'title', 'label' ) );
 		$position           = $this->eventyay_first_present_raw( $exhibitor_resource, array( 'position', 'order', 'sort_order', 'sort-order' ) );
 
+		$desc = $this->eventyay_first_present_rich_text( $exhibitor_resource, array( 'description', 'subtitle', 'summary' ) );
+		$logo = $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'logo-url', 'logo_url', 'logo', 'image', 'image-url', 'image_url' ) ), $settings['base_url'] );
+
+		if ( empty( $logo ) ) {
+			$logo = WPFAEVENT_URL . 'assets/images/logo.png';
+		}
+		if ( empty( $desc ) ) {
+			/* translators: %s: exhibitor name */
+			$desc = sprintf( __( 'Exhibitor booth for %s.', 'wpfaevent' ), $name );
+		}
+
 		return array(
 			'id'            => $source_id ? 'eventyay-exhibitor-' . sanitize_key( $source_id ) : 'eventyay-exhibitor-' . sanitize_title( $name ),
 			'source'        => 'eventyay',
 			'eventyay_id'   => sanitize_text_field( $source_id ),
 			'name'          => sanitize_text_field( $name ),
-			'description'   => $this->eventyay_first_present_rich_text( $exhibitor_resource, array( 'description', 'subtitle', 'summary' ) ),
+			'description'   => $desc,
 			'link'          => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'url', 'link', 'website', 'website-url', 'website_url' ) ), $settings['base_url'] ),
-			'logo'          => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'logo-url', 'logo_url', 'logo', 'image', 'image-url', 'image_url' ) ), $settings['base_url'] ),
+			'logo'          => $logo,
 			'banner'        => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'banner-url', 'banner_url', 'banner' ) ), $settings['base_url'] ),
 			'video'         => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'video-url', 'video_url', 'video' ) ), $settings['base_url'] ),
 			'slides'        => $this->eventyay_url_value( $this->eventyay_first_present_raw( $exhibitor_resource, array( 'slides-url', 'slides_url', 'slides' ) ), $settings['base_url'] ),

--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -273,3 +273,80 @@
 	box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15) !important;
 	outline: none !important;
 }
+
+/**
+ * Sponsors and Exhibitors Metabox Styling
+ */
+.wpfaevent-meta-cards-container {
+	margin-top: 10px;
+}
+
+.wpfaevent-meta-card {
+	background: #fff;
+	border: 1px solid #ccd0d4;
+	border-radius: 4px;
+	padding: 15px;
+	margin-bottom: 15px;
+	position: relative;
+	box-shadow: 0 1px 1px rgba(0,0,0,.04);
+}
+
+.wpfaevent-meta-card-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	gap: 15px;
+}
+
+.wpfaevent-meta-card-field {
+	display: flex;
+	flex-direction: column;
+}
+
+.wpfaevent-meta-card-field label {
+	font-weight: 600;
+	margin-bottom: 5px;
+	font-size: 12px;
+	color: #23282d;
+}
+
+.wpfaevent-meta-card-field input {
+	padding: 6px 10px;
+	font-size: 14px;
+	line-height: 1.4;
+	color: #32373c;
+	background-color: #fff;
+	border: 1px solid #7e8993;
+	border-radius: 4px;
+	box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.wpfaevent-meta-card-field input:focus {
+	border-color: #007cba;
+	box-shadow: 0 0 0 1px #007cba;
+	outline: 2px solid transparent;
+}
+
+.wpfaevent-remove-card-btn {
+	position: absolute;
+	top: 10px;
+	right: 15px;
+	color: #b32d2e;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 13px;
+}
+
+.wpfaevent-remove-card-btn:hover {
+	color: #dc3232;
+}
+
+#wpfaevent-add-sponsor-row,
+#wpfaevent-add-exhibitor-row {
+	margin-top: 15px;
+}
+
+.wpfaevent-meta-card-field.span-2 {
+	grid-column: span 2;
+}

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -568,6 +568,15 @@ class Wpfaevent_Event_Template_Controller {
 					continue;
 				}
 
+				if ( empty( $sponsor['image'] ) ) {
+					$sponsor['image'] = WPFAEVENT_URL . 'assets/images/logo.png';
+				}
+
+				if ( empty( $sponsor['description'] ) ) {
+					/* translators: %s: event title */
+					$sponsor['description'] = sprintf( __( 'Event partner and supporter of %s.', 'wpfaevent' ), $event_title );
+				}
+
 				// Pre-compute detail URL to satisfy Dependency Inversion (Class Coupling Smell).
 				$sponsor['detail_url'] = self::get_partner_detail_url( $event_id, 'sponsor', $sponsor );
 
@@ -586,6 +595,15 @@ class Wpfaevent_Event_Template_Controller {
 		foreach ( $exhibitors as $exhibitor ) {
 			if ( ! is_array( $exhibitor ) || empty( $exhibitor['name'] ) ) {
 				continue;
+			}
+
+			if ( empty( $exhibitor['logo'] ) ) {
+				$exhibitor['logo'] = WPFAEVENT_URL . 'assets/images/logo.png';
+			}
+
+			if ( empty( $exhibitor['description'] ) ) {
+				/* translators: %s: event title */
+				$exhibitor['description'] = sprintf( __( 'Exhibitor booth at %s.', 'wpfaevent' ), $event_title );
 			}
 
 			// Pre-compute detail URL to satisfy Dependency Inversion (Class Coupling Smell).
@@ -879,6 +897,8 @@ class Wpfaevent_Event_Template_Controller {
 			'build_event_schedule_view_url'            => $build_event_schedule_view_url,
 			'selected_schedule_timezone'               => $selected_schedule_timezone,
 			'main_regular_speaker_ids'                 => $main_regular_speaker_ids,
+			'speaker_ids'                              => $speaker_ids,
+			'regular_speaker_ids'                      => $regular_speaker_ids,
 			'main_dashboard_regular_speakers'          => $main_dashboard_regular_speakers,
 			'main_dashboard_speakers'                  => $main_dashboard_speakers,
 			'dashboard_speaker_overflow_count'         => $dashboard_speaker_overflow_count,
@@ -964,6 +984,8 @@ class Wpfaevent_Event_Template_Controller {
 			},
 			'selected_schedule_timezone'               => wp_timezone(),
 			'main_regular_speaker_ids'                 => array(),
+			'speaker_ids'                              => array(),
+			'regular_speaker_ids'                      => array(),
 			'main_dashboard_regular_speakers'          => array(),
 			'main_dashboard_speakers'                  => array(),
 			'dashboard_speaker_overflow_count'         => 0,

--- a/public/css/templates/event.css
+++ b/public/css/templates/event.css
@@ -442,6 +442,7 @@
 	display: none;
 }
 
+
 .wpfaevent .wpfa-event-ticket-widget-loaded .wpfa-event-ticket-backup {
 	display: none;
 }
@@ -1330,7 +1331,15 @@
 
 .wpfaevent .wpfa-event-detail .wpfa-speaker-photo {
 	background: #eaf1f8;
-	height: 190px;
+	aspect-ratio: 1 / 1;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-photo img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: center top;
+	display: block;
 }
 
 .wpfaevent .wpfa-event-detail .wpfa-speaker-meta {
@@ -1708,7 +1717,7 @@
 	display: flex;
 	justify-content: center;
 	min-height: 148px;
-	padding: 28px 24px 22px;
+	padding: 20px 24px;
 }
 
 .wpfaevent .wpfa-event-partner-logo img {
@@ -2271,7 +2280,7 @@
 	display: flex;
 	height: 70px;
 	justify-content: center;
-	padding: 12px;
+	padding: 10px;
 	width: 88px;
 }
 

--- a/public/css/templates/partners.css
+++ b/public/css/templates/partners.css
@@ -85,7 +85,7 @@
 	display: flex;
 	justify-content: center;
 	min-height: 148px;
-	padding: 28px 24px 22px;
+	padding: 20px 24px;
 }
 
 .wpfaevent .wpfa-event-partner-logo img {

--- a/public/css/templates/single-event.css
+++ b/public/css/templates/single-event.css
@@ -704,6 +704,15 @@
 
 .wpfaevent .wpfa-event-detail .wpfa-speaker-photo {
 	background: #eaf1f8;
+	aspect-ratio: 1 / 1;
+}
+
+.wpfaevent .wpfa-event-detail .wpfa-speaker-photo img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: center top;
+	display: block;
 }
 
 .wpfaevent .wpfa-event-detail .wpfa-speaker-meta {
@@ -807,7 +816,7 @@
 	display: flex;
 	justify-content: center;
 	min-height: 148px;
-	padding: 28px 24px 22px;
+	padding: 20px 24px;
 }
 
 .wpfaevent .wpfa-event-partner-logo img {
@@ -1370,7 +1379,7 @@
 	display: flex;
 	height: 70px;
 	justify-content: center;
-	padding: 12px;
+	padding: 10px;
 	width: 88px;
 }
 
@@ -2391,3 +2400,4 @@
 		padding: 20px;
 	}
 }
+

--- a/public/css/templates/speakers.css
+++ b/public/css/templates/speakers.css
@@ -180,16 +180,18 @@
 /* Speaker Photo */
 .wpfaevent .wpfa-speaker-photo {
 	display: block;
-	height: 220px;
-	background: linear-gradient(135deg, #e9e9e9, #f6f6f6);
+	width: 100%;
+	aspect-ratio: 1 / 1;
+	background: #000;
 	overflow: hidden;
 }
 
 .wpfaevent .wpfa-speaker-photo img {
 	width: 100%;
 	height: 100%;
-	object-fit: contain;
-	object-position: center;
+	object-fit: cover;
+	object-position: center top;
+	display: block;
 	transition: transform 0.3s ease;
 }
 
@@ -227,6 +229,13 @@
 	-webkit-mask-size: contain;
 	-webkit-mask-repeat: no-repeat;
 	-webkit-mask-position: center;
+}
+
+.wpfaevent .wpfa-speaker-placeholder-img {
+	width: 100%;
+	height: 100% !important;
+	object-fit: contain;
+	background: linear-gradient(135deg, #e0e4ea, #eef0f3);
 }
 
 /* Speaker Meta (Name, Role, Category) */

--- a/public/partials/speakers/dashboard-speaker-card.php
+++ b/public/partials/speakers/dashboard-speaker-card.php
@@ -27,7 +27,7 @@ $is_featured_speaker = ! empty( $wpfa_dashboard_speaker_is_featured ) || ! empty
 	<div class="wpfa-speaker-photo">
 		<?php if ( ! empty( $speaker['image'] ) ) : ?>
 			<?php /* translators: %s: Speaker name. */ ?>
-			<img src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy">
+			<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Photo of %s', 'wpfaevent' ), $speaker_name ) ); ?>" loading="lazy">
 		<?php else : ?>
 			<img src="<?php echo esc_url( $placeholder_url ); ?>" alt="<?php esc_attr_e( 'Speaker photo placeholder', 'wpfaevent' ); ?>" loading="lazy" class="wpfa-speaker-placeholder-img">
 		<?php endif; ?>

--- a/public/partials/speakers/speaker-card.php
+++ b/public/partials/speakers/speaker-card.php
@@ -68,7 +68,7 @@ $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
 <article class="wpfa-speaker-card" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( sprintf( '%d', absint( $sid ) ) ); ?>">
 	<a class="wpfa-speaker-photo" href="<?php echo esc_url( $speaker_link ); ?>">
 		<?php if ( $photo_url ) : ?>
-			<img src="<?php echo esc_url( $photo_url ); ?>"
+			<img class="wpfa-speaker-photo-img" src="<?php echo esc_url( $photo_url ); ?>"
 				alt="<?php echo esc_attr( $photo_alt ); ?>"
 				loading="lazy"
 				itemprop="image"


### PR DESCRIPTION
Fixes #176
Fixes #180

### Description
This pull request extracts the speaker, exhibitor, and sponsor-related improvements from the oversized PR #164.

### Changes Made:
- **Speaker Headshot Cropping**: Configured speaker photo containers to display headshots fully without cropping faces using a clean `object-fit: cover` and center-top alignment.
- **Partner & Exhibitor Logos**: Implemented standard aspect ratios and object-fit layout constraints so logos fill card headers consistently without distortion.
- **Fallback Content**: Integrated default SVG placeholders and localized description text for sponsors and exhibitors lacking files or text.
- **Admin Repeatable Metaboxes**: Added responsive card-based repeatable metabox rows in the WordPress event edit area to manually add, edit, and sort sponsors and exhibitors.
- **Speaker Visibility**: Restored `speaker_ids` and `regular_speaker_ids` in manual template controllers to ensure speakers display correctly.

### Testing Instructions:
1. Navigate to the Event Edit screen in WP Admin.
2. Verify that you can add new Sponsors and Exhibitors cards in the repeatable metaboxes, fill their details, and save the post.
3. Check the frontend single event page and check that the manual sponsors and exhibitors render correctly with consistent logo sizes and fallback image/copy if blank.
4. Verify that the speaker headshots render cleanly without cropping.

## Summary by Sourcery

Add admin metaboxes and frontend handling improvements for sponsors, exhibitors, and speakers in event templates.

New Features:
- Introduce repeatable, card-based Event Sponsors and Event Exhibitors metaboxes in the WP Admin event edit screen for manually managing partner data.

Enhancements:
- Persist manually entered sponsors and exhibitors to dashboard JSON files with normalized structure, sorting, and IDs for consistent frontend rendering.
- Apply default placeholder logos and localized fallback descriptions for sponsors and exhibitors when source data is incomplete.
- Adjust speaker photo containers to square aspect ratios with cover-fit images to prevent face cropping across event views.
- Refine partner logo container spacing to standardize visual presentation in single event and partners layouts.
- Expose speaker and regular speaker ID arrays in manual event template data to restore speaker visibility in templates.