### PR TITLE
feat: repeatable admin schedule metabox and client-side schedule view & timezone conversion

### DIFF
--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -58,6 +58,14 @@ class Wpfaevent_Admin {
 	private $eventyay_ajax_sync;
 
 	/**
+	 * Temporary event schedule sessions storage.
+	 *
+	 * @since 1.0.0
+	 * @var array<array<string>> $schedule_sessions
+	 */
+	private $schedule_sessions = array();
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
@@ -915,6 +923,16 @@ class Wpfaevent_Admin {
 			);
 		}
 
+		// Event schedule meta box.
+		add_meta_box(
+			'wpfa_event_schedule_box',
+			__( 'Event Schedule Sessions', 'wpfaevent' ),
+			array( $this, 'render_event_schedule_meta_box' ),
+			'wpfa_event',
+			'normal',
+			'default'
+		);
+
 		// Speaker meta boxes.
 		add_meta_box(
 			'wpfa_speaker_details',
@@ -1158,6 +1176,144 @@ class Wpfaevent_Admin {
 	}
 
 	/**
+	 * Render Event schedule sessions meta box.
+	 *
+	 * @since 1.0.0
+	 * @param WP_Post $post The post object.
+	 */
+	public function render_event_schedule_meta_box( $post ) {
+		$sessions = array();
+		if ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+			$store          = new Wpfaevent_Eventyay_Dashboard_Store();
+			$schedule_table = $store->read_dashboard_json_file( 'schedule-' . $post->ID . '.json', array() );
+			$schedule_rows  = isset( $schedule_table['data'] ) && is_array( $schedule_table['data'] ) ? $schedule_table['data'] : array();
+			$schedule_meta  = isset( $schedule_table['sessions'] ) && is_array( $schedule_table['sessions'] ) ? $schedule_table['sessions'] : array();
+			$schedule_body  = ! empty( $schedule_rows ) && is_array( $schedule_rows[0] ) ? array_slice( $schedule_rows, 1 ) : array();
+
+			foreach ( $schedule_body as $row_index => $row ) {
+				$row_meta = isset( $schedule_meta[ $row_index + 1 ] ) && is_array( $schedule_meta[ $row_index + 1 ] ) ? $schedule_meta[ $row_index + 1 ] : array();
+
+				$starts_at = isset( $row_meta['starts_at'] ) ? $row_meta['starts_at'] : '';
+				$ends_at   = isset( $row_meta['ends_at'] ) ? $row_meta['ends_at'] : '';
+
+				$date_val       = '';
+				$start_time_val = '';
+				$end_time_val   = '';
+
+				if ( $starts_at ) {
+					$tz = get_post_meta( $post->ID, 'wpfa_event_timezone', true );
+					if ( ! $tz ) {
+						$tz = wp_timezone_string();
+					}
+					try {
+						$dt             = new DateTimeImmutable( $starts_at );
+						$dt             = $dt->setTimezone( new DateTimeZone( $tz ) );
+						$date_val       = $dt->format( 'Y-m-d' );
+						$start_time_val = $dt->format( 'H:i' );
+					} catch ( Exception $e ) {
+						unset( $e );
+					}
+				}
+
+				if ( $ends_at ) {
+					$tz = get_post_meta( $post->ID, 'wpfa_event_timezone', true );
+					if ( ! $tz ) {
+						$tz = wp_timezone_string();
+					}
+					try {
+						$dt           = new DateTimeImmutable( $ends_at );
+						$dt           = $dt->setTimezone( new DateTimeZone( $tz ) );
+						$end_time_val = $dt->format( 'H:i' );
+					} catch ( Exception $e ) {
+						unset( $e );
+					}
+				}
+
+				if ( ! $date_val && isset( $row[0] ) ) {
+					$date_val = sanitize_text_field( $row[0] );
+				}
+
+				$sessions[] = array(
+					'date'       => $date_val,
+					'start_time' => $start_time_val,
+					'end_time'   => $end_time_val,
+					'title'      => isset( $row[2] ) ? sanitize_text_field( $row[2] ) : '',
+					'speakers'   => isset( $row[3] ) ? sanitize_text_field( $row[3] ) : '',
+					'track'      => isset( $row[4] ) ? sanitize_text_field( $row[4] ) : '',
+					'room'       => isset( $row[5] ) ? sanitize_text_field( $row[5] ) : '',
+				);
+			}
+		}
+
+		$this->schedule_sessions = $sessions;
+		?>
+		<table class="wp-list-table widefat fixed striped" id="wpfaevent-schedule-sessions-table">
+			<thead>
+				<tr>
+					<th class="wpfa-col-date"><?php esc_html_e( 'Date', 'wpfaevent' ); ?></th>
+					<th class="wpfa-col-start-time"><?php esc_html_e( 'Start Time', 'wpfaevent' ); ?></th>
+					<th class="wpfa-col-end-time"><?php esc_html_e( 'End Time', 'wpfaevent' ); ?></th>
+					<th><?php esc_html_e( 'Session Title', 'wpfaevent' ); ?></th>
+					<th><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></th>
+					<th class="wpfa-col-track"><?php esc_html_e( 'Track', 'wpfaevent' ); ?></th>
+					<th class="wpfa-col-room"><?php esc_html_e( 'Room', 'wpfaevent' ); ?></th>
+					<th class="wpfa-col-action"><?php esc_html_e( 'Action', 'wpfaevent' ); ?></th>
+				</tr>
+			</thead>
+			<tbody id="wpfaevent-schedule-sessions-body">
+				<?php
+				$sessions = $this->schedule_sessions;
+				if ( ! empty( $sessions ) ) :
+					foreach ( $sessions as $index => $sess ) :
+						?>
+						<tr>
+							<td><input type="date" name="wpfa_schedule_sessions[<?php echo absint( $index ); ?>][date]" value="<?php echo esc_attr( $sess['date'] ); ?>" required></td>
+							<td><input type="time" name="wpfa_schedule_sessions[<?php echo absint( $index ); ?>][start_time]" value="<?php echo esc_attr( $sess['start_time'] ); ?>" required></td>
+							<td><input type="time" name="wpfa_schedule_sessions[<?php echo absint( $index ); ?>][end_time]" value="<?php echo esc_attr( $sess['end_time'] ); ?>"></td>
+							<td><input type="text" name="wpfa_schedule_sessions[<?php echo absint( $index ); ?>][title]" value="<?php echo esc_attr( $sess['title'] ); ?>" required></td>
+							<td><input type="text" name="wpfa_schedule_sessions[<?php echo absint( $index ); ?>][speakers]" value="<?php echo esc_attr( $sess['speakers'] ); ?>"></td>
+							<td><input type="text" name="wpfa_schedule_sessions[<?php echo absint( $index ); ?>][track]" value="<?php echo esc_attr( $sess['track'] ); ?>"></td>
+							<td><input type="text" name="wpfa_schedule_sessions[<?php echo absint( $index ); ?>][room]" value="<?php echo esc_attr( $sess['room'] ); ?>"></td>
+							<td class="wpfa-col-action"><a href="#" class="wpfaevent-remove-session"><?php esc_html_e( 'Remove', 'wpfaevent' ); ?></a></td>
+						</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
+			</tbody>
+		</table>
+		<button type="button" class="button button-primary" id="wpfaevent-add-session-row">
+			<?php esc_html_e( 'Add Session', 'wpfaevent' ); ?>
+		</button>
+
+		<script>
+			jQuery(document).ready(function($) {
+				let sessionIndex = $('#wpfaevent-schedule-sessions-body tr').length;
+
+				$('#wpfaevent-add-session-row').on('click', function(e) {
+					e.preventDefault();
+					const html = `<tr>
+						<td><input type="date" name="wpfa_schedule_sessions[\${sessionIndex}][date]" required></td>
+						<td><input type="time" name="wpfa_schedule_sessions[\${sessionIndex}][start_time]" required></td>
+						<td><input type="time" name="wpfa_schedule_sessions[\${sessionIndex}][end_time]"></td>
+						<td><input type="text" name="wpfa_schedule_sessions[\${sessionIndex}][title]" required></td>
+						<td><input type="text" name="wpfa_schedule_sessions[\${sessionIndex}][speakers]"></td>
+						<td><input type="text" name="wpfa_schedule_sessions[\${sessionIndex}][track]"></td>
+						<td><input type="text" name="wpfa_schedule_sessions[\${sessionIndex}][room]"></td>
+						<td class="wpfa-col-action"><a href="#" class="wpfaevent-remove-session">Remove</a></td>
+					</tr>`;
+					$('#wpfaevent-schedule-sessions-body').append(html);
+					sessionIndex++;
+				});
+
+				$('#wpfaevent-schedule-sessions-body').on('click', '.wpfaevent-remove-session', function(e) {
+					e.preventDefault();
+					$(this).closest('tr').remove();
+				});
+			});
+		</script>
+		<?php
+	}
+
+	/**
 	 * Render Speaker meta box.
 	 *
 	 * @since 1.0.0
@@ -1373,6 +1529,102 @@ class Wpfaevent_Admin {
 		$this->update_post_id_list_meta( $post_id, 'wpfa_event_speakers', $speakers );
 
 		Wpfaevent_Meta_Event::sync_event_speaker_relationships( $post_id, $previous_speakers, $speakers );
+
+		// Handle schedule sessions saving.
+		if ( isset( $_POST['wpfa_schedule_sessions'] ) && is_array( $_POST['wpfa_schedule_sessions'] ) ) {
+			$raw_sessions       = wp_unslash( $_POST['wpfa_schedule_sessions'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized in loop below.
+			$formatted_data     = array();
+			$formatted_sessions = array();
+
+			// Add headers to data array.
+			$formatted_data[]     = array( 'Date', 'Time', 'Session', 'Speakers', 'Track', 'Room' );
+			$formatted_sessions[] = array(); // Header row meta is empty.
+
+			$event_tz = get_post_meta( $post_id, 'wpfa_event_timezone', true );
+			if ( ! $event_tz ) {
+				$event_tz = wp_timezone_string();
+			}
+			$timezone_obj = new DateTimeZone( $event_tz );
+
+			foreach ( $raw_sessions as $sess ) {
+				$date       = isset( $sess['date'] ) ? sanitize_text_field( $sess['date'] ) : '';
+				$time_start = isset( $sess['start_time'] ) ? sanitize_text_field( $sess['start_time'] ) : '';
+				$time_end   = isset( $sess['end_time'] ) ? sanitize_text_field( $sess['end_time'] ) : '';
+				$title      = isset( $sess['title'] ) ? sanitize_text_field( $sess['title'] ) : '';
+				$speakers   = isset( $sess['speakers'] ) ? sanitize_text_field( $sess['speakers'] ) : '';
+				$track      = isset( $sess['track'] ) ? sanitize_text_field( $sess['track'] ) : '';
+				$room       = isset( $sess['room'] ) ? sanitize_text_field( $sess['room'] ) : '';
+
+				if ( ! $date || ! $time_start || ! $title ) {
+					continue;
+				}
+
+				// Build ISO 8601 UTC date-time.
+				$starts_at_iso = '';
+				$ends_at_iso   = '';
+				$start_dt      = null;
+				$end_dt        = null;
+
+				try {
+					$start_dt = DateTimeImmutable::createFromFormat( 'Y-m-d H:i', $date . ' ' . $time_start, $timezone_obj );
+					if ( $start_dt ) {
+						$starts_at_iso = $start_dt->setTimezone( new DateTimeZone( 'UTC' ) )->format( 'Y-m-d\TH:i:s\Z' );
+					}
+				} catch ( Exception $e ) {
+					unset( $e );
+				}
+
+				try {
+					if ( $time_end ) {
+						$end_dt = DateTimeImmutable::createFromFormat( 'Y-m-d H:i', $date . ' ' . $time_end, $timezone_obj );
+						if ( $end_dt ) {
+							$ends_at_iso = $end_dt->setTimezone( new DateTimeZone( 'UTC' ) )->format( 'Y-m-d\TH:i:s\Z' );
+						}
+					}
+				} catch ( Exception $e ) {
+					unset( $e );
+				}
+
+				// Build time range string (12-hour format).
+				$start_time_12 = $start_dt ? $start_dt->format( 'g:i A' ) : '';
+				$end_time_12   = ( isset( $end_dt ) && $end_dt ) ? $end_dt->format( 'g:i A' ) : '';
+				$time_label    = $start_time_12 . ( $end_time_12 ? ' - ' . $end_time_12 : '' );
+
+				$formatted_data[] = array(
+					$date,
+					$time_label,
+					$title,
+					$speakers,
+					$track,
+					$room,
+				);
+
+				$formatted_sessions[] = array(
+					'starts_at' => $starts_at_iso,
+					'ends_at'   => $ends_at_iso,
+				);
+			}
+
+			if ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+				$store = new Wpfaevent_Eventyay_Dashboard_Store();
+				$store->write_dashboard_json_file(
+					'schedule-' . $post_id . '.json',
+					array(
+						'data'     => $formatted_data,
+						'sessions' => $formatted_sessions,
+					)
+				);
+			}
+		} elseif ( class_exists( 'Wpfaevent_Eventyay_Dashboard_Store' ) ) {
+			$store = new Wpfaevent_Eventyay_Dashboard_Store();
+			$store->write_dashboard_json_file(
+				'schedule-' . $post_id . '.json',
+				array(
+					'data'     => array( array( 'Date', 'Time', 'Session', 'Speakers', 'Track', 'Room' ) ),
+					'sessions' => array( array() ),
+				)
+			);
+		}
 	}
 
 	/**

--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -273,3 +273,72 @@
 	box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15) !important;
 	outline: none !important;
 }
+
+/**
+ * Schedule Sessions Metabox Styling
+ */
+#wpfaevent-schedule-sessions-table {
+	margin-top: 10px;
+}
+
+#wpfaevent-schedule-sessions-table th {
+	font-weight: bold;
+	text-align: left;
+	padding: 10px;
+}
+
+#wpfaevent-schedule-sessions-table td {
+	padding: 10px;
+	vertical-align: middle;
+}
+
+#wpfaevent-schedule-sessions-table input {
+	width: 100%;
+	box-sizing: border-box;
+}
+
+#wpfaevent-schedule-sessions-table th.wpfa-col-date,
+#wpfaevent-schedule-sessions-table td.wpfa-col-date {
+	width: 15%;
+}
+
+#wpfaevent-schedule-sessions-table th.wpfa-col-start-time,
+#wpfaevent-schedule-sessions-table td.wpfa-col-start-time {
+	width: 12%;
+}
+
+#wpfaevent-schedule-sessions-table th.wpfa-col-end-time,
+#wpfaevent-schedule-sessions-table td.wpfa-col-end-time {
+	width: 12%;
+}
+
+#wpfaevent-schedule-sessions-table th.wpfa-col-track,
+#wpfaevent-schedule-sessions-table td.wpfa-col-track {
+	width: 15%;
+}
+
+#wpfaevent-schedule-sessions-table th.wpfa-col-room,
+#wpfaevent-schedule-sessions-table td.wpfa-col-room {
+	width: 12%;
+}
+
+#wpfaevent-schedule-sessions-table th.wpfa-col-action,
+#wpfaevent-schedule-sessions-table td.wpfa-col-action {
+	width: 80px;
+	text-align: center;
+}
+
+.wpfaevent-remove-session {
+	color: #a00;
+	cursor: pointer;
+	font-weight: bold;
+	text-decoration: none;
+}
+
+.wpfaevent-remove-session:hover {
+	color: #f00;
+}
+
+#wpfaevent-add-session-row {
+	margin-top: 15px;
+}

--- a/public/js/wpfaevent-public.js
+++ b/public/js/wpfaevent-public.js
@@ -30,9 +30,75 @@
 	 */
 
 	$(function() {
-		$('.wpfa-event-timezone-select').on('change', function() {
-			if (this.form) {
-				this.form.submit();
+		// Client-side Schedule View Switch (List vs Calendar)
+		$(document).on('click', '.wpfa-schedule-view-switch a', function(e) {
+			e.preventDefault();
+			const $btn = $(this);
+			const href = $btn.attr('href') || '';
+			const isCalendar = href.indexOf('view=calendar') !== -1 || href.indexOf('schedule_view=calendar') !== -1;
+
+			const $switch = $btn.closest('.wpfa-schedule-view-switch');
+			$switch.find('a').removeClass('is-active').removeAttr('aria-current');
+			$btn.addClass('is-active').attr('aria-current', 'page');
+
+			if (isCalendar) {
+				$('.wpfa-schedule-calendar').show();
+				$('.wpfa-schedule-program').hide();
+			} else {
+				$('.wpfa-schedule-program').show();
+				$('.wpfa-schedule-calendar').hide();
+			}
+
+			if (window.history && window.history.replaceState) {
+				window.history.replaceState(null, '', href);
+			}
+		});
+
+		// Client-side Timezone Converter
+		$(document).on('change', '.wpfa-event-timezone-select, #wpfa-schedule-timezone', function(e) {
+			e.preventDefault();
+			const selectedTz = $(this).val();
+			if (!selectedTz) return;
+
+			let formatter;
+			try {
+				formatter = new Intl.DateTimeFormat([], {
+					timeZone: selectedTz,
+					hour: 'numeric',
+					minute: '2-digit',
+					hour12: true
+				});
+			} catch (err) {
+				return;
+			}
+
+			$('time[data-utc-start]').each(function() {
+				const rawStart = $(this).attr('data-utc-start');
+				const rawEnd = $(this).attr('data-utc-end');
+
+				try {
+					const startObj = rawStart ? new Date(rawStart) : null;
+					if (!startObj || isNaN(startObj.getTime())) return;
+
+					const startLabel = formatter.format(startObj);
+
+					if (rawEnd) {
+						const endObj = new Date(rawEnd);
+						const endLabel = !isNaN(endObj.getTime()) ? formatter.format(endObj) : '';
+						$(this).text(endLabel && endLabel !== startLabel ? `${startLabel} - ${endLabel}` : startLabel);
+						return;
+					}
+
+					$(this).text(startLabel);
+				} catch (err) {
+					// Timezone fallback if unsupported string
+				}
+			});
+
+			if (window.history && window.history.replaceState) {
+				const currentUrl = new URL(window.location.href);
+				currentUrl.searchParams.set('schedule_tz', selectedTz);
+				window.history.replaceState(null, '', currentUrl.toString());
 			}
 		});
 

--- a/public/templates/page-schedule.php
+++ b/public/templates/page-schedule.php
@@ -435,13 +435,73 @@ if ( ! empty( $languages ) ) {
 
 			<?php if ( $is_event_schedule ) : ?>
 				<?php if ( ! empty( $event_session_schedule['groups'] ) ) : ?>
-					<?php if ( 'calendar' === $current_view ) : ?>
-						<div class="wpfa-schedule-calendar" role="list">
-							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
-								<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading">
-									<header class="wpfa-schedule-calendar-day-head">
-										<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading"><?php echo esc_html( $day_label ); ?></h2>
-										<span>
+					<div class="wpfa-schedule-calendar" role="list" style="<?php echo 'calendar' === $current_view ? '' : 'display:none;'; ?>">
+						<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+							<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading">
+								<header class="wpfa-schedule-calendar-day-head">
+									<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading"><?php echo esc_html( $day_label ); ?></h2>
+									<span>
+										<?php
+										printf(
+											/* translators: %d: number of sessions on this day. */
+											esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+											absint( count( $day_sessions ) )
+										);
+										?>
+									</span>
+								</header>
+								<div class="wpfa-schedule-calendar-slots">
+									<?php foreach ( $day_sessions as $item ) : ?>
+										<article class="wpfa-schedule-calendar-slot">
+											<?php if ( ! empty( $item['time_label'] ) ) : ?>
+												<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-end="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+											<?php endif; ?>
+											<h3><?php echo esc_html( $item['title'] ); ?></h3>
+											<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+												<ul class="wpfa-schedule-calendar-meta">
+													<?php if ( ! empty( $item['speakers'] ) ) : ?>
+														<li><?php echo esc_html( $item['speakers'] ); ?></li>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['room'] ) ) : ?>
+														<li><?php echo esc_html( $item['room'] ); ?></li>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['track'] ) ) : ?>
+														<li><?php echo esc_html( $item['track'] ); ?></li>
+													<?php endif; ?>
+												</ul>
+											<?php endif; ?>
+											<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+												<?php
+												$session_calendar_label = sprintf(
+													/* translators: %s: session title. */
+													__( 'Add %s to Google Calendar', 'wpfaevent' ),
+													$item['title']
+												);
+												?>
+												<a
+													class="wpfa-schedule-session-calendar"
+													href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+													target="_blank"
+													rel="noopener"
+													aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+												>
+													<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+												</a>
+											<?php endif; ?>
+										</article>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endforeach; ?>
+					</div>
+
+					<div class="wpfa-schedule-program" style="<?php echo 'list' === $current_view ? '' : 'display:none;'; ?>">
+						<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
+							<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+								<header class="wpfa-schedule-day-head">
+									<div>
+										<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h2>
+										<p>
 											<?php
 											printf(
 												/* translators: %d: number of sessions on this day. */
@@ -449,82 +509,21 @@ if ( ! empty( $languages ) ) {
 												absint( count( $day_sessions ) )
 											);
 											?>
-										</span>
-									</header>
-									<div class="wpfa-schedule-calendar-slots">
-										<?php foreach ( $day_sessions as $item ) : ?>
-											<article class="wpfa-schedule-calendar-slot">
-												<?php if ( ! empty( $item['time_label'] ) ) : ?>
-													<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
-												<?php endif; ?>
-												<h3><?php echo esc_html( $item['title'] ); ?></h3>
-												<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
-													<ul class="wpfa-schedule-calendar-meta">
-														<?php if ( ! empty( $item['speakers'] ) ) : ?>
-															<li><?php echo esc_html( $item['speakers'] ); ?></li>
-														<?php endif; ?>
-														<?php if ( ! empty( $item['room'] ) ) : ?>
-															<li><?php echo esc_html( $item['room'] ); ?></li>
-														<?php endif; ?>
-														<?php if ( ! empty( $item['track'] ) ) : ?>
-															<li><?php echo esc_html( $item['track'] ); ?></li>
-														<?php endif; ?>
-													</ul>
-												<?php endif; ?>
-												<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
-													<?php
-													$session_calendar_label = sprintf(
-														/* translators: %s: session title. */
-														__( 'Add %s to Google Calendar', 'wpfaevent' ),
-														$item['title']
-													);
-													?>
-													<a
-														class="wpfa-schedule-session-calendar"
-														href="<?php echo esc_url( $item['calendar_url'] ); ?>"
-														target="_blank"
-														rel="noopener"
-														aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
-													>
-														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-													</a>
-												<?php endif; ?>
-											</article>
-										<?php endforeach; ?>
+										</p>
 									</div>
-								</section>
-							<?php endforeach; ?>
-						</div>
-					<?php else : ?>
-						<div class="wpfa-schedule-program">
-							<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
-								<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
-									<header class="wpfa-schedule-day-head">
-										<div>
-											<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h2>
-											<p>
-												<?php
-												printf(
-													/* translators: %d: number of sessions on this day. */
-													esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
-													absint( count( $day_sessions ) )
-												);
-												?>
-											</p>
-										</div>
-									</header>
+								</header>
 
-									<div class="wpfa-schedule-day-sessions" role="list">
-										<?php foreach ( $day_sessions as $item ) : ?>
-											<article class="wpfa-schedule-session" role="listitem">
-												<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
-													<?php if ( ! empty( $item['time_start'] ) ) : ?>
-														<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
-															<?php echo esc_html( $item['time_start'] ); ?>
-														</time>
-													<?php endif; ?>
+								<div class="wpfa-schedule-day-sessions" role="list">
+									<?php foreach ( $day_sessions as $item ) : ?>
+										<article class="wpfa-schedule-session" role="listitem">
+											<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+												<?php if ( ! empty( $item['time_start'] ) ) : ?>
+													<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+														<?php echo esc_html( $item['time_start'] ); ?>
+													</time>
+												<?php endif; ?>
 													<?php if ( ! empty( $item['time_end'] ) ) : ?>
-														<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
+														<time class="wpfa-schedule-session-end" datetime="<?php echo esc_attr( $item['end_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_end'] ); ?></time>
 													<?php endif; ?>
 												</div>
 
@@ -579,7 +578,6 @@ if ( ! empty( $languages ) ) {
 								</section>
 							<?php endforeach; ?>
 						</div>
-					<?php endif; ?>
 				<?php else : ?>
 					<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
 				<?php endif; ?>

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -66,6 +66,8 @@ $format_timezone_label                    = $event_data['format_timezone_label']
 $build_event_schedule_view_url            = $event_data['build_event_schedule_view_url'];
 $selected_schedule_timezone               = $event_data['selected_schedule_timezone'];
 $main_regular_speaker_ids                 = $event_data['main_regular_speaker_ids'];
+$speaker_ids                              = $event_data['speaker_ids'];
+$regular_speaker_ids                      = $event_data['regular_speaker_ids'];
 $main_dashboard_regular_speakers          = $event_data['main_dashboard_regular_speakers'];
 $main_dashboard_speakers                  = $event_data['main_dashboard_speakers'];
 $dashboard_speaker_overflow_count         = $event_data['dashboard_speaker_overflow_count'];
@@ -237,7 +239,7 @@ if ( $show_ticket_widget ) {
 						</a>
 					<?php endif; ?>
 					<button class="wpfa-event-bookmark-btn wpfa-bookmark-btn<?php echo $is_bookmarked ? ' is-bookmarked' : ''; ?>" data-event-id="<?php echo esc_attr( (string) $event_id ); ?>">
-						<svg class="wpfa-bookmark-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" style="width: 16px; height: 16px; margin-right: 8px; vertical-align: middle;">
+						<svg class="wpfa-bookmark-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
 							<path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
 						</svg>
 						<span class="wpfa-bookmark-text"><?php echo $is_bookmarked ? esc_html__( 'Remove Bookmark', 'wpfaevent' ) : esc_html__( 'Bookmark Event', 'wpfaevent' ); ?></span>
@@ -552,13 +554,73 @@ if ( $show_ticket_widget ) {
 						<?php endif; ?>
 					</div>
 					<?php if ( ! empty( $schedule_preview_items ) ) : ?>
-						<?php if ( 'calendar' === $current_schedule_view ) : ?>
-							<div class="wpfa-schedule-calendar" role="list">
-								<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
-									<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading">
-										<header class="wpfa-schedule-calendar-day-head">
-											<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading"><?php echo esc_html( $day_label ); ?></h3>
-											<span>
+						<div class="wpfa-schedule-calendar" role="list" style="<?php echo 'calendar' === $current_schedule_view ? '' : 'display:none;'; ?>">
+							<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading">
+									<header class="wpfa-schedule-calendar-day-head">
+										<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-preview-calendar-heading"><?php echo esc_html( $day_label ); ?></h3>
+										<span>
+											<?php
+											printf(
+												/* translators: %d: number of sessions on this day. */
+												esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
+												absint( count( $day_sessions ) )
+											);
+											?>
+										</span>
+									</header>
+									<div class="wpfa-schedule-calendar-slots">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-calendar-slot">
+												<?php if ( ! empty( $item['time_label'] ) ) : ?>
+													<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-end="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+												<?php endif; ?>
+												<h4><?php echo esc_html( $item['title'] ); ?></h4>
+												<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+													<ul class="wpfa-schedule-calendar-meta">
+														<?php if ( ! empty( $item['speakers'] ) ) : ?>
+															<li><?php echo esc_html( $item['speakers'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['room'] ) ) : ?>
+															<li><?php echo esc_html( $item['room'] ); ?></li>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['track'] ) ) : ?>
+															<li><?php echo esc_html( $item['track'] ); ?></li>
+														<?php endif; ?>
+													</ul>
+												<?php endif; ?>
+												<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+													<?php
+													$session_calendar_label = sprintf(
+														/* translators: %s: session title. */
+														__( 'Add %s to Google Calendar', 'wpfaevent' ),
+														$item['title']
+													);
+													?>
+													<a
+														class="wpfa-schedule-session-calendar"
+														href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+														target="_blank"
+														rel="noopener"
+														aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+													>
+														<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+													</a>
+												<?php endif; ?>
+											</article>
+										<?php endforeach; ?>
+									</div>
+								</section>
+							<?php endforeach; ?>
+						</div>
+
+						<div class="wpfa-schedule-program" style="<?php echo 'list' === $current_schedule_view ? '' : 'display:none;'; ?>">
+							<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+									<header class="wpfa-schedule-day-head">
+										<div>
+											<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h3>
+											<p>
 												<?php
 												printf(
 													/* translators: %d: number of sessions on this day. */
@@ -566,87 +628,26 @@ if ( $show_ticket_widget ) {
 													absint( count( $day_sessions ) )
 												);
 												?>
-											</span>
-										</header>
-										<div class="wpfa-schedule-calendar-slots">
-											<?php foreach ( $day_sessions as $item ) : ?>
-												<article class="wpfa-schedule-calendar-slot">
-													<?php if ( ! empty( $item['time_label'] ) ) : ?>
-														<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
-													<?php endif; ?>
-													<h4><?php echo esc_html( $item['title'] ); ?></h4>
-													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
-														<ul class="wpfa-schedule-calendar-meta">
-															<?php if ( ! empty( $item['speakers'] ) ) : ?>
-																<li><?php echo esc_html( $item['speakers'] ); ?></li>
-															<?php endif; ?>
-															<?php if ( ! empty( $item['room'] ) ) : ?>
-																<li><?php echo esc_html( $item['room'] ); ?></li>
-															<?php endif; ?>
-															<?php if ( ! empty( $item['track'] ) ) : ?>
-																<li><?php echo esc_html( $item['track'] ); ?></li>
-															<?php endif; ?>
-														</ul>
-													<?php endif; ?>
-													<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
-														<?php
-														$session_calendar_label = sprintf(
-															/* translators: %s: session title. */
-															__( 'Add %s to Google Calendar', 'wpfaevent' ),
-															$item['title']
-														);
-														?>
-														<a
-															class="wpfa-schedule-session-calendar"
-															href="<?php echo esc_url( $item['calendar_url'] ); ?>"
-															target="_blank"
-															rel="noopener"
-															aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
-														>
-															<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-														</a>
-													<?php endif; ?>
-												</article>
-											<?php endforeach; ?>
+											</p>
 										</div>
-									</section>
-								<?php endforeach; ?>
-							</div>
-						<?php else : ?>
-							<div class="wpfa-schedule-program">
-								<?php foreach ( $schedule_preview_day_groups as $day_label => $day_sessions ) : ?>
-									<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
-										<header class="wpfa-schedule-day-head">
-											<div>
-												<h3 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h3>
-												<p>
-													<?php
-													printf(
-														/* translators: %d: number of sessions on this day. */
-														esc_html( _n( '%d session', '%d sessions', count( $day_sessions ), 'wpfaevent' ) ),
-														absint( count( $day_sessions ) )
-													);
-													?>
-												</p>
-											</div>
-										</header>
+									</header>
 
-										<div class="wpfa-schedule-day-sessions" role="list">
-											<?php foreach ( $day_sessions as $item ) : ?>
-												<article class="wpfa-schedule-session" role="listitem">
-													<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
-														<?php if ( ! empty( $item['time_start'] ) ) : ?>
-															<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>">
-																<?php echo esc_html( $item['time_start'] ); ?>
-															</time>
-														<?php endif; ?>
-														<?php if ( ! empty( $item['time_end'] ) ) : ?>
-															<span class="wpfa-schedule-session-end"><?php echo esc_html( $item['time_end'] ); ?></span>
-														<?php endif; ?>
-													</div>
+									<div class="wpfa-schedule-day-sessions" role="list">
+										<?php foreach ( $day_sessions as $item ) : ?>
+											<article class="wpfa-schedule-session" role="listitem">
+												<div class="wpfa-schedule-session-timecol" aria-label="<?php esc_attr_e( 'Session time', 'wpfaevent' ); ?>">
+													<?php if ( ! empty( $item['time_start'] ) ) : ?>
+														<time class="wpfa-schedule-session-start" datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>">
+															<?php echo esc_html( $item['time_start'] ); ?>
+														</time>
+													<?php endif; ?>
+													<?php if ( ! empty( $item['time_end'] ) ) : ?>
+														<time class="wpfa-schedule-session-end" datetime="<?php echo esc_attr( $item['end_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_end'] ); ?></time>
+													<?php endif; ?>
+												</div>
 
-													<div class="wpfa-schedule-session-main">
-														<h4 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h4>
+												<div class="wpfa-schedule-session-main">
+													<h4 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h4>
 
 														<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
 															<dl class="wpfa-schedule-session-details">
@@ -696,7 +697,6 @@ if ( $show_ticket_widget ) {
 									</section>
 								<?php endforeach; ?>
 							</div>
-						<?php endif; ?>
 						<?php if ( $schedule_hidden_count ) : ?>
 							<p class="wpfa-event-schedule-preview-note">
 								<?php


### PR DESCRIPTION
Fixes #170

### Description
This pull request extracts the admin and public schedule-related improvements from the oversized PR #164.

### Changes Made:
- **Repeatable Schedule Metabox**: Added an administrative table metabox to easily add, sort, edit, and delete event sessions, saving them directly to the `schedule-<post_id>.json` file.
- **Admin UI White Screen Fix**: Patched incorrect boundaries and tag mismatches in metabox rendering code.
- **Client-side View Switch**: Enabled instant toggling between List and Calendar layouts on frontend schedule templates without full-page reloads.
- **Dynamic Timezone Conversion**: Handled timezone conversions entirely on the client side using the Intl API, converting and formatting full "start - end" ranges dynamically using machine-readable `<time>` elements.

### Testing Instructions:
1. Open Event Edit page in WP Admin.
2. Add several schedule sessions using the dynamic sessions table (date, times, track, room, speakers) and save the event.
3. Load the event frontend schedule page.
4. Toggle view from List to Calendar and back. Check that the UI switches instantly.
5. Select different timezones in the dropdown. Check that start and end times adapt correctly on the client side.

## Summary by Sourcery

Introduce an admin schedule sessions metabox and client-side schedule view/timezone handling for event schedules.

New Features:
- Add a repeatable schedule sessions metabox in the event admin to create and manage sessions stored in schedule JSON files.
- Enable client-side switching between calendar and list schedule views on single event and schedule pages without page reloads.
- Implement client-side timezone conversion for schedule times using machine-readable time elements and the Intl API.

Bug Fixes:
- Ensure schedule JSON files are initialized with header rows when no sessions are present, avoiding empty state issues.

Enhancements:
- Refine schedule calendar and list templates to share markup, support dynamic visibility toggling, and expose UTC start/end metadata.
- Adjust bookmark button SVG styling in the single event template for more flexible sizing/alignment.