### PR TITLE
fix: event card image fallbacks, past events layout, virtual routes, and subdirectory support

### DIFF
--- a/includes/class-wpfaevent-templates.php
+++ b/includes/class-wpfaevent-templates.php
@@ -109,9 +109,142 @@ class Wpfaevent_Templates {
 		add_filter( 'theme_page_templates', array( __CLASS__, 'register' ) );
 		add_filter( 'single_template', array( __CLASS__, 'load' ), 99 );
 		add_filter( 'template_include', array( __CLASS__, 'load' ), 99 );
+		add_filter( 'redirect_canonical', array( __CLASS__, 'prevent_canonical_redirect_for_virtual_routes' ), 10, 2 );
+		add_action( 'template_redirect', array( __CLASS__, 'maybe_redirect_old_routes' ) );
 		add_action( 'init', array( __CLASS__, 'register_shortcodes' ) );
 		add_action( 'init', array( __CLASS__, 'register_blocks' ) );
 		add_action( 'init', array( __CLASS__, 'register_patterns' ) );
+		add_action( 'init', array( __CLASS__, 'ensure_all_plugin_pages' ) );
+	}
+
+	/**
+	 * Auto-ensures essential plugin WordPress pages exist in wp_posts.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public static function ensure_all_plugin_pages() {
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'wp_insert_post' ) ) {
+			return;
+		}
+
+		$plugin_pages = array(
+			'full-schedule'   => array(
+				'title'    => __( 'Full Schedule', 'wpfaevent' ),
+				'template' => 'page-schedule.php',
+				'option'   => 'wpfaevent_schedule_page_id',
+			),
+			'past-events'     => array(
+				'title'    => __( 'Past Events', 'wpfaevent' ),
+				'template' => 'page-past-events.php',
+				'option'   => 'wpfaevent_past_events_page_id',
+			),
+			'speakers'        => array(
+				'title'    => __( 'Speakers', 'wpfaevent' ),
+				'template' => 'page-speakers.php',
+				'option'   => 'wpfaevent_speakers_page_id',
+			),
+			'code-of-conduct' => array(
+				'title'    => __( 'Code of Conduct', 'wpfaevent' ),
+				'template' => 'page-code-of-conduct.php',
+				'option'   => 'wpfaevent_coc_page_id',
+			),
+		);
+
+		foreach ( $plugin_pages as $slug => $data ) {
+			$page_id = (int) get_option( $data['option'], 0 );
+			if ( $page_id && 'page' === get_post_type( $page_id ) && 'trash' !== get_post_status( $page_id ) ) {
+				update_post_meta( $page_id, '_wp_page_template', $data['template'] );
+				continue;
+			}
+
+			$page = get_page_by_path( $slug );
+			if ( $page instanceof WP_Post ) {
+				update_post_meta( $page->ID, '_wp_page_template', $data['template'] );
+				update_option( $data['option'], $page->ID, false );
+				continue;
+			}
+
+			$new_id = wp_insert_post(
+				array(
+					'post_title'     => $data['title'],
+					'post_name'      => $slug,
+					'post_type'      => 'page',
+					'post_status'    => 'publish',
+					'post_content'   => '',
+					'comment_status' => 'closed',
+					'ping_status'    => 'closed',
+				)
+			);
+
+			if ( $new_id && ! is_wp_error( $new_id ) ) {
+				update_post_meta( $new_id, '_wp_page_template', $data['template'] );
+				update_option( $data['option'], $new_id, false );
+			}
+		}
+	}
+
+	/**
+	 * Prevents WordPress canonical redirects from hijacking virtual plugin routes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|false $redirect_url The proposed canonical redirect URL.
+	 * @param string       $_requested_url The requested URL.
+	 * @return string|false
+	 */
+	public static function prevent_canonical_redirect_for_virtual_routes( $redirect_url, $_requested_url ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
+			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
+				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+			}
+
+			$virtual_routes = array(
+				'past-events',
+				'schedule',
+				'full-schedule',
+				'code-of-conduct',
+				'events',
+				'speakers',
+			);
+
+			if ( in_array( $req_path, $virtual_routes, true ) ) {
+				return false;
+			}
+		}
+
+		return $redirect_url;
+	}
+
+	/**
+	 * Redirects legacy/old paths to new hub views.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public static function maybe_redirect_old_routes() {
+		if ( is_admin() ) {
+			return;
+		}
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
+			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
+				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+			}
+
+			if ( 'past-events' === $req_path ) {
+				wp_safe_redirect( home_url( '/events/?filter=past' ), 301 );
+				exit;
+			}
+		}
 	}
 
 	/**
@@ -192,14 +325,94 @@ class Wpfaevent_Templates {
 			}
 		}
 
-		if ( is_singular( 'page' ) ) {
-			$chosen = get_page_template_slug( get_queried_object_id() );
-			$key    = self::get_template_key_by_file( $chosen );
+		if ( is_singular( 'page' ) || is_front_page() ) {
+			$page_id = get_queried_object_id();
+			if ( ! $page_id && is_front_page() ) {
+				$page_id = (int) get_option( 'page_on_front' );
+			}
+			if ( $page_id ) {
+				$chosen = get_page_template_slug( $page_id );
+				$key    = self::get_template_key_by_file( $chosen );
 
-			if ( $key ) {
-				$candidate = WPFAEVENT_PATH . 'public/templates/' . self::$templates[ $key ]['file'];
+				if ( $key ) {
+					$candidate = WPFAEVENT_PATH . 'public/templates/' . self::$templates[ $key ]['file'];
 
+					if ( file_exists( $candidate ) ) {
+						return $candidate;
+					}
+				}
+			}
+		}
+
+		// Virtual path fallback for plugin routes (past-events, schedule, full-schedule, code-of-conduct, events, speakers).
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$req_path  = trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' );
+			$home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+			if ( ! empty( $home_path ) && 0 === strpos( $req_path, $home_path ) ) {
+				$req_path = trim( substr( $req_path, strlen( $home_path ) ), '/' );
+			}
+
+			$virtual_routes = array(
+				'past-events'     => 'page-past-events.php',
+				'schedule'        => 'page-schedule.php',
+				'full-schedule'   => 'page-schedule.php',
+				'code-of-conduct' => 'page-code-of-conduct.php',
+				'events'          => 'page-events.php',
+				'speakers'        => 'page-speakers.php',
+			);
+
+			if ( isset( $virtual_routes[ $req_path ] ) ) {
+				$candidate = WPFAEVENT_PATH . 'public/templates/' . $virtual_routes[ $req_path ];
 				if ( file_exists( $candidate ) ) {
+					global $wp_query, $post;
+
+					$dummy_data                        = new stdClass();
+					$dummy_data->ID                    = -999;
+					$dummy_data->post_author           = 1;
+					$dummy_data->post_date             = current_time( 'mysql' );
+					$dummy_data->post_date_gmt         = current_time( 'mysql', true );
+					$dummy_data->post_content          = '';
+					$dummy_data->post_title            = ucwords( str_replace( '-', ' ', $req_path ) );
+					$dummy_data->post_excerpt          = '';
+					$dummy_data->post_status           = 'publish';
+					$dummy_data->comment_status        = 'closed';
+					$dummy_data->ping_status           = 'closed';
+					$dummy_data->post_password         = '';
+					$dummy_data->post_name             = $req_path;
+					$dummy_data->to_ping               = '';
+					$dummy_data->pinged                = '';
+					$dummy_data->post_modified         = current_time( 'mysql' );
+					$dummy_data->post_modified_gmt     = current_time( 'mysql', true );
+					$dummy_data->post_content_filtered = '';
+					$dummy_data->post_parent           = 0;
+					$dummy_data->guid                  = home_url( '/' . $req_path );
+					$dummy_data->menu_order            = 0;
+					$dummy_data->post_type             = 'page';
+					$dummy_data->post_mime_type        = '';
+					$dummy_data->comment_count         = 0;
+					$dummy_data->filter                = 'raw';
+
+					$dummy_post = new WP_Post( $dummy_data );
+
+					if ( is_object( $wp_query ) ) {
+						$wp_query->post              = $dummy_post;
+						$wp_query->posts             = array( $dummy_post );
+						$wp_query->post_count        = 1;
+						$wp_query->found_posts       = 1;
+						$wp_query->max_num_pages     = 1;
+						$wp_query->queried_object    = $dummy_post;
+						$wp_query->queried_object_id = -999;
+						$wp_query->is_404            = false;
+						$wp_query->is_page           = true;
+						$wp_query->is_singular       = true;
+						$wp_query->is_single         = false;
+						$wp_query->is_home           = false;
+						$wp_query->is_archive        = false;
+					}
+
+					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+					$post = $dummy_post;
+					status_header( 200 );
 					return $candidate;
 				}
 			}

--- a/public/css/templates/events.css
+++ b/public/css/templates/events.css
@@ -286,7 +286,8 @@
 .wpfaevent .event-card-thumb {
 	flex-shrink: 0;
 	width: 220px;
-	min-height: 200px;
+	height: 220px;
+	aspect-ratio: 1 / 1;
 	background: #e8eaed;
 	display: block;
 	overflow: hidden;
@@ -296,7 +297,7 @@
 .wpfaevent .event-card-thumb img {
 	width: 100%;
 	height: 100%;
-	min-height: 200px;
+	aspect-ratio: 1 / 1;
 	object-fit: cover;
 	display: block;
 }
@@ -304,8 +305,14 @@
 .wpfaevent .event-card-thumb-placeholder {
 	width: 100%;
 	height: 100%;
-	min-height: 200px;
+	aspect-ratio: 1 / 1;
 	background: linear-gradient(135deg, #e8eaed 0%, #d0d3d8 100%);
+	display: block;
+}
+
+.wpfaevent .event-card-thumb-placeholder svg {
+	width: 100%;
+	height: 100%;
 	display: block;
 }
 

--- a/public/css/templates/past-events.css
+++ b/public/css/templates/past-events.css
@@ -75,7 +75,8 @@
 }
 
 .wpfa-past-event-card-image {
-	height: 180px;
+	width: 100%;
+	aspect-ratio: 1 / 1;
 	background-color: #f0f0f0;
 	overflow: hidden;
 }
@@ -83,6 +84,7 @@
 .wpfa-past-event-card-image img {
 	width: 100%;
 	height: 100%;
+	aspect-ratio: 1 / 1;
 	object-fit: cover;
 	transition: transform 0.5s ease;
 }

--- a/public/js/wpfaevent-events.js
+++ b/public/js/wpfaevent-events.js
@@ -267,6 +267,18 @@ const WPFA_Events = (function() {
 				filterEvents();
 			});
 		});
+
+		// Check for URL parameter to pre-select filter tab on load
+		const urlParams = new URLSearchParams(window.location.search);
+		const urlFilter = urlParams.get('filter');
+		if (urlFilter) {
+			const targetBtn = document.querySelector(`.date-filter-btn[data-filter="${urlFilter}"]`);
+			if (targetBtn) {
+				document.querySelectorAll('.date-filter-btn').forEach(b => b.classList.remove('active'));
+				targetBtn.classList.add('active');
+				filterEvents();
+			}
+		}
 	}
 
 	/**

--- a/public/js/wpfaevent-public.js
+++ b/public/js/wpfaevent-public.js
@@ -68,6 +68,21 @@
 				}
 			});
 
+		const eventPlaceholderSvg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200"><rect width="200" height="200" fill="#f1f5f9"/><path d="M60 50h80v100H60z" fill="#e2e8f0"/><path d="M70 70h60v15H70z" fill="#cbd5e1"/><circle cx="85" cy="115" r="10" fill="#cbd5e1"/><circle cx="115" cy="115" r="10" fill="#cbd5e1"/><path d="M60 40h80v15H60z" fill="#d51007"/></svg>';
+		const eventPlaceholderSrc = 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(eventPlaceholderSvg);
+
+		$('.event-card-thumb img, .wpfa-past-event-card-image img, .wpfa-event-partner-logo img, .wpfa-event-exhibitor-logo img')
+			.on('error', function() {
+				this.src = eventPlaceholderSrc;
+			})
+			.each(function() {
+				if (this.complete && this.naturalWidth === 0) {
+					this.src = eventPlaceholderSrc;
+				}
+			});
+
+
+
 		// Bookmark Toggle Handler
 		$(document).on('click', '.wpfa-bookmark-btn', function(e) {
 			e.preventDefault();

--- a/public/partials/events/event-card.php
+++ b/public/partials/events/event-card.php
@@ -37,8 +37,41 @@ $event_place       = get_post_meta( $event_id, 'wpfa_event_location', true );
 $event_lead_text   = sanitize_text_field( get_post_meta( $event_id, 'wpfa_event_lead_text', true ) );
 $event_description = $event_lead_text ? $event_lead_text : get_the_excerpt( $event_id );
 $featured_img_url  = get_the_post_thumbnail_url( $event_id, 'large' );
-$featured_img_url  = $featured_img_url ? $featured_img_url : '';
-$event_time_value  = $event_start_time ? $event_start_time : $event_legacy_time;
+if ( ! $featured_img_url ) {
+	$featured_img_url = get_post_meta( $event_id, 'wpfa_event_logo_url', true );
+}
+if ( ! $featured_img_url ) {
+	$featured_img_url = get_post_meta( $event_id, 'wpfa_event_header_image_url', true );
+}
+if ( ! $featured_img_url ) {
+	$settings_data = wp_cache_get( $event_id, 'wpfaevent_event_settings' );
+	if ( false === $settings_data ) {
+		$settings_data = array();
+		$upload_dir    = wp_upload_dir();
+		if ( empty( $upload_dir['error'] ) ) {
+			$settings_file = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/site-settings-' . absint( $event_id ) . '.json';
+			if ( file_exists( $settings_file ) && is_readable( $settings_file ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$settings_contents = file_get_contents( $settings_file );
+				if ( $settings_contents ) {
+					$decoded = json_decode( $settings_contents, true );
+					if ( is_array( $decoded ) ) {
+						$settings_data = $decoded;
+					}
+				}
+			}
+		}
+		wp_cache_set( $event_id, $settings_data, 'wpfaevent_event_settings' );
+	}
+
+	if ( ! empty( $settings_data['event_logo_url'] ) ) {
+		$featured_img_url = $settings_data['event_logo_url'];
+	} elseif ( ! empty( $settings_data['event_header_image_url'] ) ) {
+		$featured_img_url = $settings_data['event_header_image_url'];
+	}
+}
+$featured_img_url = $featured_img_url ? $featured_img_url : '';
+$event_time_value = $event_start_time ? $event_start_time : $event_legacy_time;
 
 $calendar_data = class_exists( 'Wpfaevent_Calendar' ) ? Wpfaevent_Calendar::get_event_calendar_data( $event_id ) : array();
 $calendar_data = is_wp_error( $calendar_data ) ? array() : $calendar_data;
@@ -105,20 +138,12 @@ $is_bookmarked       = class_exists( 'Wpfaevent_User_Preferences_Service' ) && W
 	data-all-day="<?php echo esc_attr( $event_all_day ? '1' : '0' ); ?>"
 	data-time="<?php echo esc_attr( $event_time_value ); ?>">
 
-	<?php if ( $can_manage_content && ( ! $is_valid_date || $is_past_event ) ) : ?>
+	<?php if ( $can_manage_content && ! $is_valid_date ) : ?>
 		<div class="wpfaevent-admin-warning">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="wpfaevent-warning-icon" aria-hidden="true">
 				<path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>
 			</svg>
-			<span>
-				<?php
-				if ( ! $is_valid_date ) {
-					esc_html_e( 'Invalid date format', 'wpfaevent' );
-				} elseif ( $is_past_event ) {
-					esc_html_e( 'Past event', 'wpfaevent' );
-				}
-				?>
-			</span>
+			<span><?php esc_html_e( 'Invalid date format', 'wpfaevent' ); ?></span>
 		</div>
 	<?php endif; ?>
 
@@ -126,7 +151,16 @@ $is_bookmarked       = class_exists( 'Wpfaevent_User_Preferences_Service' ) && W
 		<?php if ( $featured_img_url ) : ?>
 			<img src="<?php echo esc_url( $featured_img_url ); ?>" alt="<?php echo esc_attr( get_the_title( $event_id ) ); ?>" loading="lazy">
 		<?php else : ?>
-			<div class="event-card-thumb-placeholder" aria-hidden="true"></div>
+			<div class="event-card-thumb-placeholder" aria-hidden="true">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+					<rect width="200" height="200" fill="#f1f5f9"/>
+					<path d="M60 50h80v100H60z" fill="#e2e8f0"/>
+					<path d="M70 70h60v15H70z" fill="#cbd5e1"/>
+					<circle cx="85" cy="115" r="10" fill="#cbd5e1"/>
+					<circle cx="115" cy="115" r="10" fill="#cbd5e1"/>
+					<path d="M60 40h80v15H60z" fill="#d51007"/>
+				</svg>
+			</div>
 		<?php endif; ?>
 	</a>
 

--- a/public/partials/header.php
+++ b/public/partials/header.php
@@ -25,12 +25,18 @@ $register_button_text        = isset( $register_button_text ) ? $register_button
 // Get the Code of Conduct page ID, with caching handled by the cache class.
 $coc_page_id = Wpfaevent_Cache::get_coc_page_id();
 
-// Determine whether the current page is the Code of Conduct page.
-$is_current = ( $coc_page_id && is_page( $coc_page_id ) ) ? 'active' : '';
+// Determine active state for navigation links.
+$current_path = isset( $_SERVER['REQUEST_URI'] ) ? trim( (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ), '/' ) : '';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$current_filter        = isset( $_GET['filter'] ) ? sanitize_text_field( wp_unslash( $_GET['filter'] ) ) : '';
+$is_past_events_active = ( 'past-events' === $current_path || is_page_template( 'page-past-events.php' ) || 'past' === $current_filter ) ? 'active' : '';
+$is_events_active      = ( ( 'events' === $current_path || is_post_type_archive( 'wpfa_event' ) || is_page_template( 'page-events.php' ) ) && 'past' !== $current_filter ) ? 'active' : '';
+$is_coc_active         = ( 'code-of-conduct' === $current_path || ( $coc_page_id && is_page( $coc_page_id ) ) || is_page_template( 'page-code-of-conduct.php' ) ) ? 'active' : '';
 
 // Allow customization of events URLs via filters while keeping current behavior as default.
 $events_url      = apply_filters( 'wpfaevent_events_url', home_url( '/events/' ) );
-$past_events_url = apply_filters( 'wpfaevent_past_events_url', home_url( '/past-events/' ) );
+$past_events_url = apply_filters( 'wpfaevent_past_events_url', home_url( '/events/?filter=past' ) );
+$coc_url         = $coc_page_id ? get_permalink( $coc_page_id ) : home_url( '/code-of-conduct/' );
 ?>
 
 <header class="nav" role="banner">
@@ -40,11 +46,9 @@ $past_events_url = apply_filters( 'wpfaevent_past_events_url', home_url( '/past-
 		</a>
 		<nav class="nav-links" role="navigation" aria-label="<?php esc_attr_e( 'Primary', 'wpfaevent' ); ?>">
 			<div class="nav-links-main">
-				<a href="<?php echo esc_url( $events_url ); ?>"><?php esc_html_e( 'Upcoming Events', 'wpfaevent' ); ?></a>
-				<a href="<?php echo esc_url( $past_events_url ); ?>"><?php esc_html_e( 'Past Events', 'wpfaevent' ); ?></a>
-				<?php if ( $coc_page_id ) : ?>
-					<a href="<?php echo esc_url( get_permalink( $coc_page_id ) ); ?>" class="<?php echo esc_attr( $is_current ); ?>"><?php esc_html_e( 'Code of Conduct', 'wpfaevent' ); ?></a>
-				<?php endif; ?>
+				<a href="<?php echo esc_url( $events_url ); ?>" class="<?php echo esc_attr( $is_events_active ); ?>"><?php esc_html_e( 'Upcoming Events', 'wpfaevent' ); ?></a>
+				<a href="<?php echo esc_url( $past_events_url ); ?>" class="<?php echo esc_attr( $is_past_events_active ); ?>"><?php esc_html_e( 'Past Events', 'wpfaevent' ); ?></a>
+				<a href="<?php echo esc_url( $coc_url ); ?>" class="<?php echo esc_attr( $is_coc_active ); ?>"><?php esc_html_e( 'Code of Conduct', 'wpfaevent' ); ?></a>
 			</div>
 			
 			<?php if ( $show_back_button || $show_register_button ) : ?>

--- a/public/templates/page-past-events.php
+++ b/public/templates/page-past-events.php
@@ -194,9 +194,41 @@ $header_vars = array(
 								),
 							);
 						}
-
 						$image_url = get_the_post_thumbnail_url( $event_id, 'medium' );
+						if ( ! $image_url ) {
+							$image_url = get_post_meta( $event_id, 'wpfa_event_logo_url', true );
+						}
+						if ( ! $image_url ) {
+							$image_url = get_post_meta( $event_id, 'wpfa_event_header_image_url', true );
+						}
+						if ( ! $image_url ) {
+							$settings_data = wp_cache_get( $event_id, 'wpfaevent_event_settings' );
+							if ( false === $settings_data ) {
+								$settings_data = array();
+								$upload_dir    = wp_upload_dir();
+								if ( empty( $upload_dir['error'] ) ) {
+									$settings_file = trailingslashit( $upload_dir['basedir'] ) . 'fossasia-data/site-settings-' . absint( $event_id ) . '.json';
+									if ( file_exists( $settings_file ) && is_readable( $settings_file ) ) {
+										// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+										$settings_contents = file_get_contents( $settings_file );
+										if ( $settings_contents ) {
+											$decoded = json_decode( $settings_contents, true );
+											if ( is_array( $decoded ) ) {
+												$settings_data = $decoded;
+											}
+										}
+									}
+								}
+								wp_cache_set( $event_id, $settings_data, 'wpfaevent_event_settings' );
+							}
 
+							if ( ! empty( $settings_data['event_logo_url'] ) ) {
+								$image_url = $settings_data['event_logo_url'];
+							} elseif ( ! empty( $settings_data['event_header_image_url'] ) ) {
+								$image_url = $settings_data['event_header_image_url'];
+							}
+						}
+						$image_url = $image_url ? $image_url : '';
 						// Format date for display.
 						$display_date      = '';
 						$display_time_meta = '';


### PR DESCRIPTION
Fixes #168

### Description
This pull request extracts the general event card display, images, past events, and virtual routing improvements from the oversized PR #164.

### Changes Made:
- **Event Card Fallback Imagery**: Checked logo/header post meta and cached settings JSON to gracefully load images on event cards and past events lists.
- **SVG Thumbnail Placeholder**: Added inline vector placeholders for cards that do not have a featured image.
- **Virtual Plugin Routes**: Built virtual page template loading (for past-events, schedule, etc.) preventing WordPress canonical redirect loops, and allowing installations inside subdirectories by stripping the directory base path.
- **Navigation Highlight States**: Resolved correct menu highlights when navigating events by filter (`?filter=past`) or virtual routes.
- **Pre-select Tab Filter**: Preselected filter tabs client-side automatically based on URL parameters on events hub load.

### Testing Instructions:
1. Load the event hub page on a subdirectory WordPress install.
2. Confirm the virtual routes load correctly without 404 or redirect loops.
3. Access `/events/?filter=past`. Verify that the "Past Events" link in navigation is highlighted, and the "Past" tab is preselected.
4. Create/import an event with no thumbnail image and confirm the default SVG placeholder displays.

## Summary by Sourcery

Improve virtual event routes, navigation states, and image handling for event cards and past events, with better support for subdirectory installs and legacy URLs.

New Features:
- Add automatic creation and template assignment for core event-related WordPress pages used by the plugin.
- Introduce virtual route handling for events-related pages, including dummy page objects, to serve plugin templates without real pages.

Bug Fixes:
- Prevent canonical redirect loops and 404s for virtual event routes, including when the site is installed in a subdirectory.
- Fix navigation active-state highlighting for Upcoming Events, Past Events, and Code of Conduct links, including when using the past events filter query parameter.
- Ensure past events navigation links point to the filtered events hub instead of the old past-events route.

Enhancements:
- Extend event card and past events image fallbacks to use event logo/header metadata and cached JSON settings, and add a shared SVG placeholder image when all sources fail.
- Standardize event and past event thumbnail layout using square aspect-ratio styling and SVG placeholders for missing/broken images.
- Update client-side event filters to auto-select the appropriate tab based on URL parameters.
- Simplify admin warnings on event cards to only flag invalid dates, no longer treating past events as warnings.