### PR TITLE
fix: resolve CORS issues in ticket widget for non-SSL/IP hosts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "doctrine/instantiator": "2.1.0",
+        "doctrine/instantiator": "2.0.0",
         "php-stubs/wp-cli-stubs": "^2.12",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9711ff8e1ddae5db096e0c195fc2f5c3",
+    "content-hash": "aa079bf9310f91ab386f7a848fccce27",
     "packages": [],
     "packages-dev": [
         {
@@ -105,29 +105,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.4"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5.58"
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -154,7 +155,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -170,7 +171,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T06:47:08+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -457,9 +457,24 @@ class Wpfaevent_Event_Template_Controller {
 		};
 
 		$ticket_widget_assets   = $build_eventyay_widget_assets( $ticket_widget_url );
+		$site_host              = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		$site_host              = strtolower( $site_host );
+		$is_ip_host             = '' !== $site_host && false !== filter_var( $site_host, FILTER_VALIDATE_IP );
+		$can_embed_widget       = ! empty( $ticket_widget_assets['event_url'] ) && is_ssl() && ! $is_ip_host;
+		$can_embed_widget       = (bool) apply_filters( 'wpfaevent_enable_embedded_ticket_widget', $can_embed_widget, $event_id, $ticket_widget_assets );
 		$show_ticket_widget     = ! empty( $ticket_widget_assets['event_url'] );
+		$show_ticket_section    = ! empty( $ticket_widget_assets['event_url'] );
 		$ticket_widget_id       = 'wpfa-event-ticket-widget-' . absint( $event_id );
+		$ticket_widget_redirect = $show_ticket_widget && ! $can_embed_widget;
 		$ticket_widget_skip_ssl = ! is_ssl();
+		$ticket_widget_message  = '';
+
+		if ( $ticket_widget_redirect ) {
+			$ticket_widget_message = __(
+				'Ticket selection is shown here, but checkout will open on Eventyay because embedded checkout is unavailable on this site.',
+				'wpfaevent'
+			);
+		}
 
 		$about_content = isset( $site_settings['about_section_content'] ) ? trim( (string) $site_settings['about_section_content'] ) : '';
 		$post_content  = trim( (string) get_post_field( 'post_content', $event_id ) );
@@ -514,7 +529,7 @@ class Wpfaevent_Event_Template_Controller {
 		$register_text = ! empty( $site_settings['reg_button_text'] ) ? sanitize_text_field( $site_settings['reg_button_text'] ) : __( 'Get Tickets', 'wpfaevent' );
 		$register_url  = ! empty( $site_settings['reg_button_link'] ) ? esc_url_raw( $site_settings['reg_button_link'] ) : $event_url;
 
-		if ( ! $register_url && $show_ticket_widget ) {
+		if ( ! $register_url && $show_ticket_section ) {
 			$register_url = $ticket_widget_assets['event_url'];
 		}
 
@@ -818,7 +833,7 @@ class Wpfaevent_Event_Template_Controller {
 			'show_sponsors'   => $show_sponsors,
 			'show_exhibitors' => $show_exhibitors,
 			'has_about'       => $show_about && '' !== trim( $about_content ),
-			'has_tickets'     => $show_ticket_widget,
+			'has_tickets'     => $show_ticket_section,
 			'has_speakers'    => $show_speakers && ( ! empty( $speaker_ids ) || ! empty( $dashboard_speakers ) ),
 			'has_schedule'    => $show_schedule && ! empty( $schedule_items ),
 			'has_sponsors'    => $show_sponsors && ! empty( $visible_sponsor_groups ),
@@ -859,8 +874,11 @@ class Wpfaevent_Event_Template_Controller {
 			'event_header_image_url'                   => $event_header_image_url,
 			'event_logo_url'                           => $event_logo_url,
 			'show_ticket_widget'                       => $show_ticket_widget,
+			'show_ticket_section'                      => $show_ticket_section,
+			'ticket_widget_redirect'                   => $ticket_widget_redirect,
 			'ticket_widget_assets'                     => $ticket_widget_assets,
 			'ticket_widget_id'                         => $ticket_widget_id,
+			'ticket_widget_message'                    => $ticket_widget_message,
 			'ticket_widget_skip_ssl'                   => $ticket_widget_skip_ssl,
 			'location'                                 => $location,
 			'event_language_label'                     => $event_language_label,
@@ -935,8 +953,11 @@ class Wpfaevent_Event_Template_Controller {
 			'event_header_image_url'                   => '',
 			'event_logo_url'                           => '',
 			'show_ticket_widget'                       => false,
+			'show_ticket_section'                      => false,
+			'ticket_widget_redirect'                   => false,
 			'ticket_widget_assets'                     => array(),
 			'ticket_widget_id'                         => '',
+			'ticket_widget_message'                    => '',
 			'ticket_widget_skip_ssl'                   => false,
 			'event_start_content'                      => '',
 			'event_end_content'                        => '',

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -457,13 +457,12 @@ class Wpfaevent_Event_Template_Controller {
 		};
 
 		$ticket_widget_assets   = $build_eventyay_widget_assets( $ticket_widget_url );
+		$show_ticket_section    = ! empty( $ticket_widget_assets['event_url'] );
 		$site_host              = (string) wp_parse_url( home_url(), PHP_URL_HOST );
 		$site_host              = strtolower( $site_host );
 		$is_ip_host             = '' !== $site_host && false !== filter_var( $site_host, FILTER_VALIDATE_IP );
-		$can_embed_widget       = ! empty( $ticket_widget_assets['event_url'] ) && is_ssl() && ! $is_ip_host;
-		$can_embed_widget       = (bool) apply_filters( 'wpfaevent_enable_embedded_ticket_widget', $can_embed_widget, $event_id, $ticket_widget_assets );
-		$show_ticket_widget     = ! empty( $ticket_widget_assets['event_url'] );
-		$show_ticket_section    = ! empty( $ticket_widget_assets['event_url'] );
+		$can_embed_widget       = $show_ticket_section && is_ssl() && ! $is_ip_host;
+		$show_ticket_widget     = (bool) apply_filters( 'wpfaevent_enable_embedded_ticket_widget', $show_ticket_section, $event_id, $ticket_widget_assets );
 		$ticket_widget_id       = 'wpfa-event-ticket-widget-' . absint( $event_id );
 		$ticket_widget_redirect = $show_ticket_widget && ! $can_embed_widget;
 		$ticket_widget_skip_ssl = ! is_ssl();

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -82,8 +82,11 @@ $current_schedule_view                    = $event_data['current_schedule_view']
 $event_header_image_url = $event_data['event_header_image_url'];
 $event_logo_url         = $event_data['event_logo_url'];
 $show_ticket_widget     = $event_data['show_ticket_widget'];
+$show_ticket_section    = $event_data['show_ticket_section'];
+$ticket_widget_redirect = $event_data['ticket_widget_redirect'];
 $ticket_widget_assets   = $event_data['ticket_widget_assets'];
 $ticket_widget_id       = $event_data['ticket_widget_id'];
+$ticket_widget_message  = $event_data['ticket_widget_message'];
 $ticket_widget_skip_ssl = $event_data['ticket_widget_skip_ssl'];
 
 if ( $show_ticket_widget ) {
@@ -116,14 +119,52 @@ if ( $show_ticket_widget ) {
 				'var container=document.getElementById(' . wp_json_encode( $ticket_widget_id ) . ');',
 				'if(!container||typeof MutationObserver==="undefined"){return;}',
 				'var expected=' . wp_json_encode( __( 'The ticket shop could not be loaded.', 'wpfaevent' ) ) . ';',
+				'var redirectCheckout=' . wp_json_encode( $ticket_widget_redirect ) . ';',
+				'var redirectUrl=' . wp_json_encode( $ticket_widget_assets['event_url'] ) . ';',
 				'var markFailed=function(){',
 				'var error=container.querySelector(".pretix-widget-error-message");',
 				'if(!error){return;}',
 				'if(expected&&error.textContent.trim()!==expected){return;}',
 				'container.classList.add("wpfa-event-ticket-widget-failed");',
 				'};',
+				'var sendToEventyay=function(event){',
+				'if(!redirectCheckout||!redirectUrl){return;}',
+				'var trigger=null;',
+				'if(event.composedPath){',
+				'var path=event.composedPath();',
+				'for(var i=0;i<path.length;i++){',
+				'var el=path[i];',
+				'if(el.tagName){',
+				'var tag=el.tagName.toLowerCase();',
+				'if(tag==="button"||tag==="a"||(tag==="input"&&el.type==="submit")||(el.classList&&el.classList.contains("btn"))){',
+				'trigger=el;',
+				'break;',
+				'}',
+				'}',
+				'}',
+				'}',
+				'if(!trigger&&event.target&&event.target.closest){',
+				'trigger=event.target.closest("button,input[type=submit],a,.btn,.pretix-widget button,.pretix-widget input[type=submit]");',
+				'}',
+				'if(!trigger){return;}',
+				'var label=((trigger.textContent||trigger.value||"")+"").toLowerCase();',
+				'if(label.indexOf("register")===-1&&label.indexOf("checkout")===-1&&label.indexOf("buy")===-1&&label.indexOf("ticket")===-1){return;}',
+				'event.preventDefault();',
+				'event.stopPropagation();',
+				'window.location.href=redirectUrl;',
+				'};',
+				'var interceptSubmit=function(event){',
+				'if(!redirectCheckout||!redirectUrl){return;}',
+				'event.preventDefault();',
+				'event.stopPropagation();',
+				'window.location.href=redirectUrl;',
+				'};',
 				'var observer=new MutationObserver(markFailed);',
 				'observer.observe(container,{childList:true,subtree:true});',
+				'if(redirectCheckout){',
+				'container.addEventListener("click",sendToEventyay,true);',
+				'container.addEventListener("submit",interceptSubmit,true);',
+				'}',
 				'markFailed();',
 				'})();',
 			)
@@ -229,7 +270,7 @@ if ( $show_ticket_widget ) {
 						<p><?php esc_html_e( 'Registration', 'wpfaevent' ); ?></p>
 						<strong><?php esc_html_e( 'Open', 'wpfaevent' ); ?></strong>
 					</div>
-					<?php if ( $show_ticket_widget ) : ?>
+					<?php if ( $show_ticket_section && $show_ticket_widget ) : ?>
 						<a class="wpfa-event-register" href="#tickets">
 							<?php echo esc_html( $register_text ); ?>
 						</a>
@@ -316,42 +357,63 @@ if ( $show_ticket_widget ) {
 			<?php include WPFAEVENT_PATH . 'public/partials/event-section-nav.php'; ?>
 		<?php endif; ?>
 
-		<?php if ( $show_ticket_widget ) : ?>
+		<?php if ( $show_ticket_section ) : ?>
 			<section id="tickets" class="wpfa-event-section wpfa-event-tickets" aria-labelledby="wpfa-event-tickets-title">
 				<div class="container">
 					<div class="wpfa-event-section-head">
 						<div>
 							<h2 id="wpfa-event-tickets-title"><?php esc_html_e( 'Tickets', 'wpfaevent' ); ?></h2>
-							<p><?php esc_html_e( 'Select ticket options and continue checkout through Eventyay.', 'wpfaevent' ); ?></p>
+							<?php if ( $show_ticket_widget ) : ?>
+								<p><?php esc_html_e( 'Select ticket options and continue checkout through Eventyay.', 'wpfaevent' ); ?></p>
+							<?php else : ?>
+								<p><?php echo esc_html( $ticket_widget_message ); ?></p>
+							<?php endif; ?>
 						</div>
 						<a href="<?php echo esc_url( $ticket_widget_assets['event_url'] ); ?>" target="_blank" rel="noopener">
 							<?php esc_html_e( 'Open on Eventyay', 'wpfaevent' ); ?>
 						</a>
 					</div>
-					<div id="<?php echo esc_attr( $ticket_widget_id ); ?>" class="wpfa-event-ticket-widget">
+					<div
+						<?php if ( $show_ticket_widget ) : ?>
+							id="<?php echo esc_attr( $ticket_widget_id ); ?>"
+						<?php endif; ?>
+						class="wpfa-event-ticket-widget<?php echo $show_ticket_widget ? '' : ' wpfa-event-ticket-widget-failed'; ?>"
+					>
 						<div class="wpfa-event-ticket-backup" role="note">
 							<strong><?php esc_html_e( 'Tickets are handled by Eventyay.', 'wpfaevent' ); ?></strong>
-							<p><?php esc_html_e( 'If ticket options do not appear here, open the Eventyay ticket shop directly.', 'wpfaevent' ); ?></p>
+							<?php if ( $show_ticket_widget ) : ?>
+								<p><?php esc_html_e( 'If ticket options do not appear here, open the Eventyay ticket shop directly.', 'wpfaevent' ); ?></p>
+							<?php else : ?>
+								<p><?php echo esc_html( $ticket_widget_message ); ?></p>
+							<?php endif; ?>
 							<a class="wpfa-event-ticket-backup-button" href="<?php echo esc_url( $ticket_widget_assets['event_url'] ); ?>" target="_blank" rel="noopener">
 								<?php esc_html_e( 'Buy tickets on Eventyay', 'wpfaevent' ); ?>
 							</a>
 						</div>
-						<?php // Eventyay docs: use div.pretix-widget-compat when custom elements are unavailable. ?>
-						<div
-							class="pretix-widget-compat"
-							event="<?php echo esc_url( $ticket_widget_assets['event_url'] ); ?>"
-							<?php if ( $ticket_widget_skip_ssl ) : ?>
-								skip-ssl-check
-							<?php endif; ?>
-						></div>
-						<noscript>
+						<?php if ( $show_ticket_widget ) : ?>
+							<?php // Eventyay docs: use div.pretix-widget-compat when custom elements are unavailable. ?>
+							<div
+								class="pretix-widget-compat"
+								event="<?php echo esc_url( $ticket_widget_assets['event_url'] ); ?>"
+								<?php if ( $ticket_widget_skip_ssl ) : ?>
+									skip-ssl-check
+								<?php endif; ?>
+							></div>
+							<noscript>
+								<p class="wpfa-event-ticket-fallback">
+									<?php esc_html_e( 'JavaScript is required to show Eventyay tickets here.', 'wpfaevent' ); ?>
+									<a href="<?php echo esc_url( $ticket_widget_assets['event_url'] ); ?>" target="_blank" rel="noopener">
+										<?php esc_html_e( 'Buy tickets on Eventyay', 'wpfaevent' ); ?>
+									</a>
+								</p>
+							</noscript>
+						<?php else : ?>
 							<p class="wpfa-event-ticket-fallback">
-								<?php esc_html_e( 'JavaScript is required to show Eventyay tickets here.', 'wpfaevent' ); ?>
 								<a href="<?php echo esc_url( $ticket_widget_assets['event_url'] ); ?>" target="_blank" rel="noopener">
 									<?php esc_html_e( 'Buy tickets on Eventyay', 'wpfaevent' ); ?>
 								</a>
 							</p>
-						</noscript>
+						<?php endif; ?>
 					</div>
 				</div>
 			</section>

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -148,7 +148,7 @@ if ( $show_ticket_widget ) {
 				'}',
 				'if(!trigger){return;}',
 				'var label=((trigger.textContent||trigger.value||"")+"").toLowerCase();',
-				'if(label.indexOf("register")===-1&&label.indexOf("checkout")===-1&&label.indexOf("buy")===-1&&label.indexOf("ticket")===-1){return;}',
+				'if(label.indexOf("register")===-1&&label.indexOf("checkout")===-1&&label.indexOf("buy")===-1&&label.indexOf("ticket")===-1&&label.indexOf("cart")===-1&&label.indexOf("add")===-1){return;}',
 				'event.preventDefault();',
 				'event.stopPropagation();',
 				'window.location.href=redirectUrl;',
@@ -270,7 +270,7 @@ if ( $show_ticket_widget ) {
 						<p><?php esc_html_e( 'Registration', 'wpfaevent' ); ?></p>
 						<strong><?php esc_html_e( 'Open', 'wpfaevent' ); ?></strong>
 					</div>
-					<?php if ( $show_ticket_section && $show_ticket_widget ) : ?>
+					<?php if ( $show_ticket_section ) : ?>
 						<a class="wpfa-event-register" href="#tickets">
 							<?php echo esc_html( $register_text ); ?>
 						</a>
@@ -363,10 +363,10 @@ if ( $show_ticket_widget ) {
 					<div class="wpfa-event-section-head">
 						<div>
 							<h2 id="wpfa-event-tickets-title"><?php esc_html_e( 'Tickets', 'wpfaevent' ); ?></h2>
-							<?php if ( $show_ticket_widget ) : ?>
-								<p><?php esc_html_e( 'Select ticket options and continue checkout through Eventyay.', 'wpfaevent' ); ?></p>
-							<?php else : ?>
+							<?php if ( $ticket_widget_redirect ) : ?>
 								<p><?php echo esc_html( $ticket_widget_message ); ?></p>
+							<?php elseif ( $show_ticket_widget ) : ?>
+								<p><?php esc_html_e( 'Select ticket options and continue checkout through Eventyay.', 'wpfaevent' ); ?></p>
 							<?php endif; ?>
 						</div>
 						<a href="<?php echo esc_url( $ticket_widget_assets['event_url'] ); ?>" target="_blank" rel="noopener">
@@ -381,10 +381,10 @@ if ( $show_ticket_widget ) {
 					>
 						<div class="wpfa-event-ticket-backup" role="note">
 							<strong><?php esc_html_e( 'Tickets are handled by Eventyay.', 'wpfaevent' ); ?></strong>
-							<?php if ( $show_ticket_widget ) : ?>
-								<p><?php esc_html_e( 'If ticket options do not appear here, open the Eventyay ticket shop directly.', 'wpfaevent' ); ?></p>
-							<?php else : ?>
+							<?php if ( $ticket_widget_redirect ) : ?>
 								<p><?php echo esc_html( $ticket_widget_message ); ?></p>
+							<?php else : ?>
+								<p><?php esc_html_e( 'If ticket options do not appear here, open the Eventyay ticket shop directly.', 'wpfaevent' ); ?></p>
 							<?php endif; ?>
 							<a class="wpfa-event-ticket-backup-button" href="<?php echo esc_url( $ticket_widget_assets['event_url'] ); ?>" target="_blank" rel="noopener">
 								<?php esc_html_e( 'Buy tickets on Eventyay', 'wpfaevent' ); ?>


### PR DESCRIPTION
Resolves #199

### Description
This PR resolves the CORS block occurring when trying to add items to the cart/register on the embedded ticket widget on non-SSL or IP-based hosts.

### Changes
- Traverse the event path using `event.composedPath()` in `sendToEventyay` click handler to correctly identify clicked buttons/inputs/links inside the widget's Shadow DOM.
- Fallback to the existing `event.target.closest()` if `composedPath` is not supported.
- Intercept click events on the capture phase, preventing the default AJAX POST request to Eventyay/Pretix and redirecting the browser to the Eventyay event checkout page.

## Summary by Sourcery

Handle cases where the Eventyay ticket widget cannot be embedded due to SSL or IP host constraints by detecting unsupported environments, redirecting checkout interactions directly to the Eventyay event page, and keeping a functional tickets section with appropriate messaging.

New Features:
- Add a configurable ticket section that remains available even when the embedded Eventyay widget cannot be used.

Bug Fixes:
- Redirect checkout actions from the embedded Eventyay ticket widget to the Eventyay event page on hosts where the widget cannot be embedded, avoiding CORS and SSL/IP issues.

Enhancements:
- Detect when the site is non-SSL or uses an IP host and disable embedding the Eventyay checkout widget in those cases, while still exposing ticket access.
- Improve click and submit handling inside the Eventyay widget, including Shadow DOM support, to reliably capture checkout-related interactions for redirection.
- Adjust template logic so navigation, registration links, and ticket availability indicators are driven by a dedicated ticket section flag rather than the widget embed state.