### PR TITLE
fix: generate blank index.php files in all subdirectories for security

### DIFF
--- a/admin/css/index.php
+++ b/admin/css/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/admin/js/index.php
+++ b/admin/js/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/admin/partials/ajax-handlers/index.php
+++ b/admin/partials/ajax-handlers/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/admin/partials/index.php
+++ b/admin/partials/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/assets/demo/index.php
+++ b/assets/demo/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/assets/images/index.php
+++ b/assets/images/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/assets/index.php
+++ b/assets/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/bin/index.php
+++ b/bin/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/docs/index.php
+++ b/docs/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/includes/cache/index.php
+++ b/includes/cache/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/includes/cli/index.php
+++ b/includes/cli/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/includes/cpt/index.php
+++ b/includes/cpt/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/includes/eventyay-importer/index.php
+++ b/includes/eventyay-importer/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/includes/helpers/index.php
+++ b/includes/helpers/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/includes/meta/index.php
+++ b/includes/meta/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/includes/taxonomies/index.php
+++ b/includes/taxonomies/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/languages/index.php
+++ b/languages/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/css/components/index.php
+++ b/public/css/components/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/css/index.php
+++ b/public/css/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/css/templates/index.php
+++ b/public/css/templates/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/js/index.php
+++ b/public/js/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/partials/code-of-conduct/index.php
+++ b/public/partials/code-of-conduct/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/partials/events/index.php
+++ b/public/partials/events/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/partials/index.php
+++ b/public/partials/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/partials/speakers/index.php
+++ b/public/partials/speakers/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */

--- a/public/templates/index.php
+++ b/public/templates/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Wpfaevent
+ */


### PR DESCRIPTION
Generates empty index.php files in all subdirectories of the plugin to prevent direct directory traversal indexing on misconfigured servers.

## Summary by Sourcery

Bug Fixes:
- Prevent directory traversal and indexing by ensuring subdirectories contain non-executable index.php stubs for secure access control.