### PR TITLE
fix: import Eventyay sponsor tiers correctly

### DIFF
--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -1865,8 +1865,15 @@ class Wpfaevent_Eventyay_Importer {
 		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
 		$source_id        = $this->eventyay_resource_identifier( $sponsor_resource );
 		$name             = $this->eventyay_first_present_text( $sponsor_resource, array( 'name', 'title', 'label' ) );
-		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'type', 'level_name', 'level-name', 'tier', 'category' ) );
+		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'level_name', 'level-name', 'tier', 'category', 'sponsor_type', 'sponsor-type', 'sponsorship_type', 'sponsorship-type', 'package', 'package_name', 'package-name' ) );
 		$level            = $this->eventyay_first_present_raw( $sponsor_resource, array( 'level', 'position', 'order', 'sort_order', 'sort-order' ) );
+
+		if ( '' === $type ) {
+			$fallback_type = $this->eventyay_first_present_text( $sponsor_resource, array( 'type' ) );
+			if ( ! in_array( strtolower( $fallback_type ), array( 'sponsor', 'sponsors' ), true ) ) {
+				$type = $fallback_type;
+			}
+		}
 
 		$desc  = $this->eventyay_first_present_rich_text( $sponsor_resource, array( 'description', 'subtitle', 'summary' ) );
 		$image = $this->eventyay_url_value( $this->eventyay_first_present_raw( $sponsor_resource, array( 'logo-url', 'logo_url', 'logo', 'image', 'image-url', 'image_url' ) ), $settings['base_url'] );

--- a/includes/eventyay-importer/class-wpfaevent-jsonapi-parser.php
+++ b/includes/eventyay-importer/class-wpfaevent-jsonapi-parser.php
@@ -220,8 +220,15 @@ class Wpfaevent_JSONAPI_Parser {
 		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
 		$source_id        = $this->eventyay_resource_identifier( $sponsor_resource );
 		$name             = $this->eventyay_first_present_text( $sponsor_resource, array( 'name', 'title', 'label' ) );
-		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'type', 'level_name', 'level-name', 'tier', 'category' ) );
+		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'level_name', 'level-name', 'tier', 'category', 'sponsor_type', 'sponsor-type', 'sponsorship_type', 'sponsorship-type', 'package', 'package_name', 'package-name' ) );
 		$level            = $this->eventyay_first_present_raw( $sponsor_resource, array( 'level', 'position', 'order', 'sort_order', 'sort-order' ) );
+
+		if ( '' === $type ) {
+			$fallback_type = $this->eventyay_first_present_text( $sponsor_resource, array( 'type' ) );
+			if ( ! in_array( strtolower( $fallback_type ), array( 'sponsor', 'sponsors' ), true ) ) {
+				$type = $fallback_type;
+			}
+		}
 
 		return array(
 			'id'          => $source_id ? 'eventyay-sponsor-' . sanitize_key( $source_id ) : 'eventyay-sponsor-' . sanitize_title( $name ),

--- a/tests/unit/JSONAPIParserTest.php
+++ b/tests/unit/JSONAPIParserTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Unit tests for Eventyay JSON:API sponsor normalization.
+ *
+ * @package Wpfaevent
+ */
+
+/**
+ * Covers sponsor tier extraction for Eventyay imports.
+ */
+class JSONAPIParserTest extends WP_UnitTestCase {
+
+	/**
+	 * Verify JSON:API resource type does not override sponsor tier labels.
+	 */
+	public function test_normalize_eventyay_sponsor_resource_prefers_tier_fields_over_resource_type() {
+		$parser  = new Wpfaevent_JSONAPI_Parser();
+		$sponsor = $parser->normalize_eventyay_sponsor_resource(
+			array(
+				'type'       => 'sponsor',
+				'id'         => '1321',
+				'attributes' => array(
+					'name'       => 'AWS',
+					'level_name' => 'Gold Sponsors',
+					'level'      => 1,
+				),
+			),
+			array(
+				'base_url' => 'https://eventyay.com',
+			)
+		);
+
+		$this->assertSame( 'Gold Sponsors', $sponsor['type'] );
+		$this->assertSame( 1, $sponsor['level'] );
+	}
+
+	/**
+	 * Verify generic JSON:API resource type values are ignored when no tier field exists.
+	 */
+	public function test_normalize_eventyay_sponsor_resource_ignores_generic_sponsor_resource_type() {
+		$parser  = new Wpfaevent_JSONAPI_Parser();
+		$sponsor = $parser->normalize_eventyay_sponsor_resource(
+			array(
+				'type'       => 'sponsor',
+				'id'         => '1329',
+				'attributes' => array(
+					'name'  => 'Navicat',
+					'level' => 2,
+				),
+			),
+			array(
+				'base_url' => 'https://eventyay.com',
+			)
+		);
+
+		$this->assertSame( '', $sponsor['type'] );
+		$this->assertSame( 2, $sponsor['level'] );
+	}
+}


### PR DESCRIPTION
## Summary
- prefer actual Eventyay sponsor tier and package fields over the generic JSON:API resource type
- ignore fallback `type` values when they are just `sponsor` or `sponsors`
- add a regression test covering tier extraction from JSON:API sponsor resources

## Testing
- `composer phpcs`
- `composer phpstan`
- PHPUnit regression test added but not executed locally because `WP_TESTS_DIR` was unavailable

Closes #224


## Screencast

https://github.com/user-attachments/assets/f81420ca-51fb-4ef6-899f-a8ca4926ff96

