### PR TITLE
fix: dashboard editing for manually created events

### DIFF
--- a/admin/partials/event-dashboard.php
+++ b/admin/partials/event-dashboard.php
@@ -682,12 +682,6 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 <script>
 document.addEventListener('DOMContentLoaded', function () {
 	const form = document.querySelector('[data-sync-form]');
-	if (!form) {
-		return;
-	}
-
-	const submitButton = form.querySelector('button[type="submit"], input[type="submit"]');
-	const feedback = form.querySelector('[data-sync-feedback]');
 	const getButtonText = function (btn) {
 		return btn.tagName === 'INPUT' ? btn.value : btn.textContent;
 	};
@@ -698,63 +692,67 @@ document.addEventListener('DOMContentLoaded', function () {
 			btn.textContent = text;
 		}
 	};
-	const defaultLabel = submitButton ? getButtonText(submitButton) : '';
-	const loadingLabel = <?php echo wp_json_encode( __( 'Synchronizing...', 'wpfaevent' ) ); ?>;
+	if (form) {
+		const submitButton = form.querySelector('button[type="submit"], input[type="submit"]');
+		const feedback = form.querySelector('[data-sync-feedback]');
+		const defaultLabel = submitButton ? getButtonText(submitButton) : '';
+		const loadingLabel = <?php echo wp_json_encode( __( 'Synchronizing...', 'wpfaevent' ) ); ?>;
 
-	const setFeedback = function (type, message) {
-		if (!feedback) {
-			return;
-		}
-
-		feedback.className = 'wpfaevent-sync-feedback is-active is-' + type;
-		feedback.textContent = message;
-	};
-
-	form.addEventListener('submit', function (event) {
-		event.preventDefault();
-
-		if (!submitButton) {
-			form.submit();
-			return;
-		}
-
-		submitButton.disabled = true;
-		setButtonText(submitButton, loadingLabel);
-		form.setAttribute('aria-busy', 'true');
-		setFeedback('loading', loadingLabel);
-
-		const formData = new FormData(form);
-
-		window.fetch(form.dataset.ajaxUrl, {
-			method: 'POST',
-			credentials: 'same-origin',
-			body: formData
-		}).then(function (response) {
-			return response.json().catch(function () {
-				return { success: false, data: { message: <?php echo wp_json_encode( __( 'The server returned an unexpected response.', 'wpfaevent' ) ); ?> } };
-			});
-		}).then(function (payload) {
-			if (!payload || !payload.success) {
-				const message = payload && payload.data && payload.data.message ? payload.data.message : <?php echo wp_json_encode( __( 'Synchronization failed.', 'wpfaevent' ) ); ?>;
-				setFeedback('error', message);
+		const setFeedback = function (type, message) {
+			if (!feedback) {
 				return;
 			}
 
-			const message = payload.data && payload.data.message ? payload.data.message : <?php echo wp_json_encode( __( 'Synchronization completed.', 'wpfaevent' ) ); ?>;
-			setFeedback('success', message);
+			feedback.className = 'wpfaevent-sync-feedback is-active is-' + type;
+			feedback.textContent = message;
+		};
 
-			window.setTimeout(function () {
-				const nextUrl = payload.data && payload.data.dashboard_url ? payload.data.dashboard_url + '#wpfaevent-sync' : window.location.href.split('#')[0] + '#wpfaevent-sync';
-				window.location.href = nextUrl;
-			}, 900);
-		}).catch(function () {
-			setFeedback('error', <?php echo wp_json_encode( __( 'Synchronization failed. Please try again.', 'wpfaevent' ) ); ?>);
-		}).finally(function () {
-			submitButton.disabled = false;
-			setButtonText(submitButton, defaultLabel);
-			form.removeAttribute('aria-busy');
+		form.addEventListener('submit', function (event) {
+			event.preventDefault();
+
+			if (!submitButton) {
+				form.submit();
+				return;
+			}
+
+			submitButton.disabled = true;
+			setButtonText(submitButton, loadingLabel);
+			form.setAttribute('aria-busy', 'true');
+			setFeedback('loading', loadingLabel);
+
+			const formData = new FormData(form);
+
+			window.fetch(form.dataset.ajaxUrl, {
+				method: 'POST',
+				credentials: 'same-origin',
+				body: formData
+			}).then(function (response) {
+				return response.json().catch(function () {
+					return { success: false, data: { message: <?php echo wp_json_encode( __( 'The server returned an unexpected response.', 'wpfaevent' ) ); ?> } };
+				});
+			}).then(function (payload) {
+				if (!payload || !payload.success) {
+					const message = payload && payload.data && payload.data.message ? payload.data.message : <?php echo wp_json_encode( __( 'Synchronization failed.', 'wpfaevent' ) ); ?>;
+					setFeedback('error', message);
+					return;
+				}
+
+				const message = payload.data && payload.data.message ? payload.data.message : <?php echo wp_json_encode( __( 'Synchronization completed.', 'wpfaevent' ) ); ?>;
+				setFeedback('success', message);
+
+				window.setTimeout(function () {
+					const nextUrl = payload.data && payload.data.dashboard_url ? payload.data.dashboard_url + '#wpfaevent-sync' : window.location.href.split('#')[0] + '#wpfaevent-sync';
+					window.location.href = nextUrl;
+				}, 900);
+			}).catch(function () {
+				setFeedback('error', <?php echo wp_json_encode( __( 'Synchronization failed. Please try again.', 'wpfaevent' ) ); ?>);
+			}).finally(function () {
+				submitButton.disabled = false;
+				setButtonText(submitButton, defaultLabel);
+				form.removeAttribute('aria-busy');
+			});
 		});
-	});
+	}
 
 	// Inline Editor Logic
 	document.body.addEventListener('click', function (e) {


### PR DESCRIPTION
Fixes #228

## What changed
This updates the event dashboard script so the inline field editor is initialized for every event dashboard, not only dashboards that render the Eventyay sync form.

## Root cause
The dashboard JavaScript returned early when no `data-sync-form` element was present. Eventyay-imported events render that form, but manually created WordPress events do not, so their Edit buttons never attached click handlers even though the editable fields and save endpoint were already available.

## Impact
Manually created events can now edit and save dashboard fields like Event Overview, Description, and Event Settings, while imported Eventyay events keep their existing synchronization flow.

## Testing
- `php -l admin/partials/event-dashboard.php`
- `composer phpcs`
- `composer phpstan`
- `composer test` could not run because the local WordPress test suite bootstrap was missing at `/var/folders/8l/vn8q3v7s4cd7_b5lm5qs44x40000gn/T/wordpress-tests-lib`

## Summary by Sourcery

Initialize dashboard editing independently of the optional synchronization form so manually created events can update their fields.

Bug Fixes:
- Enable inline editing and saving for manually created event dashboards that do not include the Eventyay synchronization form.

Enhancements:
- Preserve the existing synchronization workflow for Eventyay-imported events while allowing dashboard editing to initialize independently.


## Screencast Before

https://github.com/user-attachments/assets/79dcb5a0-0fc5-4338-a504-d9dc6ce7055a

## Screencast After 


https://github.com/user-attachments/assets/f9098367-b743-415f-92c2-b297763c27a1



