### PR TITLE
fix: remove exhibitor subtitle from event page

### DIFF
--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -868,7 +868,6 @@ if ( $show_ticket_widget ) {
 					<div class="wpfa-event-section-head">
 						<div>
 							<h2 id="wpfa-event-exhibitors-title"><?php esc_html_e( 'Exhibitors', 'wpfaevent' ); ?></h2>
-							<p><?php esc_html_e( 'Exhibitor booths and resources for this event.', 'wpfaevent' ); ?></p>
 						</div>
 					</div>
 


### PR DESCRIPTION
## Summary
- remove the Exhibitors section subtitle from single event pages
- keep the change limited to that one subtitle line only
- avoid touching any other exhibitor, sponsor, speaker, schedule, or styling logic

## Testing
- `php -l public/templates/single-wpfa-event.php`

## Context
Closes #241.

## Summary by Sourcery

Bug Fixes:
- Remove the Exhibitors section subtitle from single event pages.

## Screenshot

<img width="1440" height="262" alt="Screenshot 2026-08-21 at 7 45 55 PM" src="https://github.com/user-attachments/assets/34ebc58b-3744-4bd7-907b-a78ca87e4caf" />
