### PR TITLE
fix: preserve sponsor group names and order

### DIFF
--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -1638,6 +1638,7 @@ class Wpfaevent_Eventyay_Importer {
 			++$result['skipped'];
 		} else {
 			$normalized_sponsors = $this->normalize_eventyay_sponsor_resources( $sponsors['resources'], $settings );
+			$normalized_sponsors = $this->filter_eventyay_sponsors_to_public_listing( $normalized_sponsors, $event, $settings, $event_slug );
 			$existing_sponsors   = $this->read_dashboard_json_file( 'sponsors-' . absint( $event_id ) . '.json', array() );
 			$sponsor_groups      = $this->merge_eventyay_sponsor_groups( $normalized_sponsors, $existing_sponsors );
 			$write_result        = $this->write_dashboard_json_file( 'sponsors-' . absint( $event_id ) . '.json', $sponsor_groups );
@@ -1666,6 +1667,184 @@ class Wpfaevent_Eventyay_Importer {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Filter API sponsor rows to the sponsor names shown on the public Eventyay page.
+	 *
+	 * Some Eventyay sponsor endpoints can include records that are not actually shown
+	 * on the public event page. When Eventyay publishes a supported-by section,
+	 * treat those visible group/name combinations as the authoritative set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $sponsors   Normalized sponsor records.
+	 * @param array  $event      Eventyay event resource.
+	 * @param array  $settings   Import settings.
+	 * @param string $event_slug Eventyay event slug.
+	 * @return array
+	 */
+	private function filter_eventyay_sponsors_to_public_listing( $sponsors, $event, $settings, $event_slug ) {
+		if ( empty( $sponsors ) ) {
+			return is_array( $sponsors ) ? $sponsors : array();
+		}
+
+		$public_groups = $this->fetch_eventyay_public_sponsor_groups( $event, $settings, $event_slug );
+		if ( is_wp_error( $public_groups ) || empty( $public_groups ) ) {
+			return $sponsors;
+		}
+
+		$filtered = array();
+		$name_map = array();
+
+		foreach ( $public_groups as $public_group ) {
+			if ( empty( $public_group['group_name'] ) || empty( $public_group['sponsors'] ) || ! is_array( $public_group['sponsors'] ) ) {
+				continue;
+			}
+
+			foreach ( array_keys( $public_group['sponsors'] ) as $name_key ) {
+				if ( '' !== $name_key && empty( $name_map[ $name_key ] ) ) {
+					$name_map[ $name_key ] = $public_group['group_name'];
+				}
+			}
+		}
+
+		foreach ( $sponsors as $sponsor ) {
+			if ( ! is_array( $sponsor ) ) {
+				continue;
+			}
+
+			$name_key = ! empty( $sponsor['name'] ) ? sanitize_title( $sponsor['name'] ) : '';
+			if ( '' !== $name_key && empty( $sponsor['type'] ) && ! empty( $name_map[ $name_key ] ) ) {
+				$sponsor['type'] = sanitize_text_field( $name_map[ $name_key ] );
+			}
+
+			$group_key = ! empty( $sponsor['type'] ) ? sanitize_title( $sponsor['type'] ) : '';
+			$name_key  = ! empty( $sponsor['name'] ) ? sanitize_title( $sponsor['name'] ) : '';
+
+			if ( '' === $group_key || '' === $name_key ) {
+				continue;
+			}
+
+			if ( ! empty( $public_groups[ $group_key ]['sponsors'][ $name_key ] ) ) {
+				$filtered[] = $sponsor;
+			}
+		}
+
+		return ! empty( $filtered ) ? $filtered : $sponsors;
+	}
+
+	/**
+	 * Fetch sponsor groups published on the public Eventyay page.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $event      Eventyay event resource.
+	 * @param array  $settings   Import settings.
+	 * @param string $event_slug Eventyay event slug.
+	 * @return array|WP_Error
+	 */
+	private function fetch_eventyay_public_sponsor_groups( $event, $settings, $event_slug ) {
+		$event_url = trailingslashit( $this->eventyay_public_event_url( $event, $settings, $event_slug ) );
+		if ( ! $event_url ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_missing_public_event_url',
+				esc_html__( 'The public Eventyay event page URL could not be resolved.', 'wpfaevent' )
+			);
+		}
+
+		$response = wp_remote_get(
+			$event_url,
+			array(
+				'timeout'     => 20,
+				'redirection' => 3,
+				'headers'     => array(
+					'Accept'     => 'text/html,application/xhtml+xml',
+					'User-Agent' => 'Mozilla/5.0 (compatible; WPFAevent importer)',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_public_event_request_failed',
+				esc_html__( 'The public Eventyay event page could not be fetched.', 'wpfaevent' ),
+				array( 'details' => $response->get_error_message() )
+			);
+		}
+
+		$status = absint( wp_remote_retrieve_response_code( $response ) );
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error(
+				'wpfaevent_eventyay_public_event_http_error',
+				esc_html__( 'The public Eventyay event page returned an unexpected response.', 'wpfaevent' ),
+				array( 'http_status' => $status )
+			);
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( '' === trim( (string) $body ) ) {
+			return array();
+		}
+
+		if ( ! class_exists( 'DOMDocument' ) || ! class_exists( 'DOMXPath' ) ) {
+			return array();
+		}
+
+		$internal_errors = libxml_use_internal_errors( true );
+		$document        = new DOMDocument();
+		$loaded          = $document->loadHTML( '<?xml encoding="utf-8" ?>' . $body );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $internal_errors );
+
+		if ( ! $loaded ) {
+			return array();
+		}
+
+		$xpath  = new DOMXPath( $document );
+		$groups = array();
+		$nodes  = $xpath->query( '//div[contains(concat(" ", normalize-space(@class), " "), " exhibition-supported-by-group ")]' );
+
+		if ( ! $nodes ) {
+			return array();
+		}
+
+		foreach ( $nodes as $group_node ) {
+			$title_nodes = $xpath->query( './/h4[1]', $group_node );
+			if ( ! $title_nodes || 0 === $title_nodes->length ) {
+				continue;
+			}
+
+			$group_name = trim( wp_strip_all_tags( $title_nodes->item(0)->textContent ) );
+			$group_key  = sanitize_title( $group_name );
+
+			if ( '' === $group_key ) {
+				continue;
+			}
+
+			$image_nodes = $xpath->query( './/img[@alt]', $group_node );
+			if ( ! $image_nodes || 0 === $image_nodes->length ) {
+				continue;
+			}
+
+			if ( ! isset( $groups[ $group_key ] ) ) {
+				$groups[ $group_key ] = array(
+					'group_name' => $group_name,
+					'sponsors'   => array(),
+				);
+			}
+
+			foreach ( $image_nodes as $image_node ) {
+				$name = trim( (string) $image_node->getAttribute( 'alt' ) );
+				$key  = sanitize_title( $name );
+
+				if ( '' !== $key ) {
+					$groups[ $group_key ]['sponsors'][ $key ] = true;
+				}
+			}
+		}
+
+		return $groups;
 	}
 
 	/**
@@ -1865,7 +2044,7 @@ class Wpfaevent_Eventyay_Importer {
 		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
 		$source_id        = $this->eventyay_resource_identifier( $sponsor_resource );
 		$name             = $this->eventyay_first_present_text( $sponsor_resource, array( 'name', 'title', 'label' ) );
-		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'type', 'level_name', 'level-name', 'tier', 'category' ) );
+		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'level_name', 'level-name', 'tier', 'category', 'type' ) );
 		$level            = $this->eventyay_first_present_raw( $sponsor_resource, array( 'level', 'position', 'order', 'sort_order', 'sort-order' ) );
 
 		$desc  = $this->eventyay_first_present_rich_text( $sponsor_resource, array( 'description', 'subtitle', 'summary' ) );
@@ -1904,20 +2083,68 @@ class Wpfaevent_Eventyay_Importer {
 	private function merge_eventyay_sponsor_groups( $imported, $existing ) {
 		$existing = is_array( $existing ) ? $existing : array();
 		$groups   = array();
+		$order    = array();
 
 		foreach ( $existing as $group ) {
-			if ( ! is_array( $group ) || $this->is_eventyay_sponsor_group( $group ) ) {
+			if ( ! is_array( $group ) ) {
+				continue;
+			}
+
+			$group_key = $this->eventyay_sponsor_group_key( $group );
+			if ( '' !== $group_key ) {
+				$order[] = $group_key;
+			}
+
+			if ( $this->is_eventyay_sponsor_group( $group ) ) {
 				continue;
 			}
 
 			$groups[] = $group;
 		}
 
-		foreach ( $this->group_eventyay_sponsors( $imported ) as $group ) {
-			$groups[] = $group;
+		$imported_groups = $this->group_eventyay_sponsors( $imported );
+		$group_map       = array();
+
+		foreach ( $groups as $group ) {
+			$group_key = $this->eventyay_sponsor_group_key( $group );
+			if ( '' !== $group_key ) {
+				$group_map[ $group_key ] = $group;
+			}
 		}
 
-		return $groups;
+		foreach ( $imported_groups as $group ) {
+			$group_key = $this->eventyay_sponsor_group_key( $group );
+			if ( '' !== $group_key ) {
+				$group_map[ $group_key ] = $group;
+
+				if ( ! in_array( $group_key, $order, true ) ) {
+					$order[] = $group_key;
+				}
+			} else {
+				$groups[] = $group;
+			}
+		}
+
+		$merged_groups = array();
+
+		foreach ( $order as $group_key ) {
+			if ( isset( $group_map[ $group_key ] ) ) {
+				$merged_groups[] = $group_map[ $group_key ];
+				unset( $group_map[ $group_key ] );
+			}
+		}
+
+		foreach ( $group_map as $group ) {
+			$merged_groups[] = $group;
+		}
+
+		foreach ( $groups as $group ) {
+			if ( ! is_array( $group ) ) {
+				$merged_groups[] = $group;
+			}
+		}
+
+		return $merged_groups;
 	}
 
 	/**
@@ -1987,6 +2214,28 @@ class Wpfaevent_Eventyay_Importer {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get a stable key for a sponsor group.
+	 *
+	 * @param array $group Sponsor group.
+	 * @return string
+	 */
+	private function eventyay_sponsor_group_key( $group ) {
+		if ( ! is_array( $group ) ) {
+			return '';
+		}
+
+		if ( ! empty( $group['eventyay_group_key'] ) ) {
+			return sanitize_key( $group['eventyay_group_key'] );
+		}
+
+		if ( ! empty( $group['group_name'] ) ) {
+			return sanitize_key( $group['group_name'] );
+		}
+
+		return '';
 	}
 
 	/**

--- a/admin/class-wpfaevent-partner-dashboard-controller.php
+++ b/admin/class-wpfaevent-partner-dashboard-controller.php
@@ -123,25 +123,8 @@ class Wpfaevent_Partner_Dashboard_Controller {
 
 		// Save the updated list back to the JSON file.
 		if ( 'sponsor' === $type ) {
-			// Structure as sponsor groups.
-			$groups = array();
-			foreach ( $updated_records as $rec ) {
-				$group_name = isset( $rec['type'] ) && $rec['type'] ? $rec['type'] : __( 'Sponsors', 'wpfaevent' );
-				if ( ! isset( $groups[ $group_name ] ) ) {
-					$groups[ $group_name ] = array(
-						'group_name' => $group_name,
-						'logo_size'  => 160,
-						'sponsors'   => array(),
-					);
-					if ( isset( $rec['source'] ) && 'eventyay' === $rec['source'] ) {
-						$groups[ $group_name ]['source'] = 'eventyay';
-					}
-				}
-				$groups[ $group_name ]['sponsors'][] = $rec;
-			}
-
-			// Clean array keys for JSON serialization.
-			$write_data = array_values( $groups );
+			$existing_groups = $this->store->read_dashboard_json_file( 'sponsors-' . $event_id . '.json', array() );
+			$write_data      = $this->build_sponsor_groups_from_records( $updated_records, $existing_groups );
 			$this->store->write_dashboard_json_file( 'sponsors-' . $event_id . '.json', $write_data );
 		} else {
 			$this->store->write_dashboard_json_file( 'exhibitors-' . $event_id . '.json', $updated_records );
@@ -176,6 +159,54 @@ class Wpfaevent_Partner_Dashboard_Controller {
 	}
 
 	/**
+	 * Save sponsor group order for an event.
+	 *
+	 * @return void
+	 */
+	public function handle_reorder_sponsor_groups() {
+		if ( ! current_user_can( 'edit_events' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to modify this page.', 'wpfaevent' ) );
+		}
+
+		$event_id = isset( $_POST['event_id'] ) ? absint( wp_unslash( $_POST['event_id'] ) ) : 0;
+		check_admin_referer( 'wpfaevent_reorder_sponsor_groups_' . $event_id );
+
+		if ( ! $event_id ) {
+			wp_die( esc_html__( 'Invalid request parameters.', 'wpfaevent' ) );
+		}
+
+		$raw_group_keys = isset( $_POST['group_keys'] ) ? wp_unslash( $_POST['group_keys'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized below.
+		$group_keys     = array();
+
+		if ( is_array( $raw_group_keys ) ) {
+			foreach ( $raw_group_keys as $group_key ) {
+				$group_key = sanitize_key( $group_key );
+
+				if ( '' !== $group_key ) {
+					$group_keys[] = $group_key;
+				}
+			}
+		}
+
+		$existing_groups = $this->store->read_dashboard_json_file( 'sponsors-' . $event_id . '.json', array() );
+		$reordered       = $this->reorder_sponsor_groups( $existing_groups, $group_keys );
+
+		$this->store->write_dashboard_json_file( 'sponsors-' . $event_id . '.json', $reordered );
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'post_type' => 'wpfa_event',
+					'page'      => 'wpfaevent-sponsors',
+					'event_id'  => $event_id,
+				),
+				admin_url( 'edit.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
 	 * GET Handler to Delete Sponsor/Exhibitor.
 	 */
 	public function handle_delete_partner() {
@@ -205,21 +236,8 @@ class Wpfaevent_Partner_Dashboard_Controller {
 
 		// Save the updated list back to the JSON file.
 		if ( 'sponsor' === $type ) {
-			// Structure as sponsor groups.
-			$groups = array();
-			foreach ( $updated_records as $rec ) {
-				$group_name = isset( $rec['type'] ) && $rec['type'] ? $rec['type'] : __( 'Sponsors', 'wpfaevent' );
-				if ( ! isset( $groups[ $group_name ] ) ) {
-					$groups[ $group_name ] = array(
-						'group_name' => $group_name,
-						'logo_size'  => 160,
-						'sponsors'   => array(),
-					);
-				}
-				$groups[ $group_name ]['sponsors'][] = $rec;
-			}
-
-			$write_data = array_values( $groups );
+			$existing_groups = $this->store->read_dashboard_json_file( 'sponsors-' . $event_id . '.json', array() );
+			$write_data      = $this->build_sponsor_groups_from_records( $updated_records, $existing_groups );
 			$this->store->write_dashboard_json_file( 'sponsors-' . $event_id . '.json', $write_data );
 		} else {
 			$this->store->write_dashboard_json_file( 'exhibitors-' . $event_id . '.json', $updated_records );
@@ -237,5 +255,150 @@ class Wpfaevent_Partner_Dashboard_Controller {
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Build grouped sponsor JSON data from flat sponsor records.
+	 *
+	 * @param array $records         Flat sponsor records.
+	 * @param array $existing_groups Existing sponsor groups.
+	 * @return array
+	 */
+	private function build_sponsor_groups_from_records( $records, $existing_groups ) {
+		$existing_groups = is_array( $existing_groups ) ? $existing_groups : array();
+		$groups          = array();
+		$order           = array();
+		$templates       = array();
+
+		foreach ( $existing_groups as $group ) {
+			if ( ! is_array( $group ) ) {
+				continue;
+			}
+
+			$group_key = $this->get_sponsor_group_key( $group );
+			if ( '' === $group_key ) {
+				continue;
+			}
+
+			$order[]                 = $group_key;
+			$templates[ $group_key ] = $group;
+		}
+
+		foreach ( $records as $record ) {
+			if ( ! is_array( $record ) ) {
+				continue;
+			}
+
+			$group_name = isset( $record['type'] ) && '' !== trim( (string) $record['type'] ) ? sanitize_text_field( $record['type'] ) : __( 'Sponsors', 'wpfaevent' );
+			$group_key  = sanitize_key( $group_name );
+
+			if ( '' === $group_key ) {
+				continue;
+			}
+
+			if ( ! isset( $groups[ $group_key ] ) ) {
+				$template = isset( $templates[ $group_key ] ) && is_array( $templates[ $group_key ] ) ? $templates[ $group_key ] : array();
+
+				$groups[ $group_key ] = array(
+					'group_name' => $group_name,
+					'logo_size'  => isset( $template['logo_size'] ) ? absint( $template['logo_size'] ) : 160,
+					'centered'   => ! empty( $template['centered'] ),
+					'sponsors'   => array(),
+				);
+
+				if ( ! empty( $template['source'] ) ) {
+					$groups[ $group_key ]['source'] = sanitize_key( $template['source'] );
+				} elseif ( isset( $record['source'] ) && 'eventyay' === $record['source'] ) {
+					$groups[ $group_key ]['source'] = 'eventyay';
+				}
+
+				if ( ! empty( $template['eventyay_group_key'] ) ) {
+					$groups[ $group_key ]['eventyay_group_key'] = sanitize_key( $template['eventyay_group_key'] );
+				}
+
+				if ( ! in_array( $group_key, $order, true ) ) {
+					$order[] = $group_key;
+				}
+			}
+
+			$groups[ $group_key ]['sponsors'][] = $record;
+		}
+
+		$ordered_groups = array();
+
+		foreach ( $order as $group_key ) {
+			if ( isset( $groups[ $group_key ] ) ) {
+				$ordered_groups[] = $groups[ $group_key ];
+				unset( $groups[ $group_key ] );
+			}
+		}
+
+		foreach ( $groups as $group ) {
+			$ordered_groups[] = $group;
+		}
+
+		return $ordered_groups;
+	}
+
+	/**
+	 * Reorder sponsor groups using submitted group keys.
+	 *
+	 * @param array $groups      Existing groups.
+	 * @param array $group_order Submitted order.
+	 * @return array
+	 */
+	private function reorder_sponsor_groups( $groups, $group_order ) {
+		$groups      = is_array( $groups ) ? $groups : array();
+		$group_order = is_array( $group_order ) ? $group_order : array();
+		$group_map   = array();
+		$ordered     = array();
+
+		foreach ( $groups as $group ) {
+			if ( ! is_array( $group ) ) {
+				continue;
+			}
+
+			$group_key = $this->get_sponsor_group_key( $group );
+			if ( '' === $group_key ) {
+				continue;
+			}
+
+			$group_map[ $group_key ] = $group;
+		}
+
+		foreach ( $group_order as $group_key ) {
+			if ( isset( $group_map[ $group_key ] ) ) {
+				$ordered[] = $group_map[ $group_key ];
+				unset( $group_map[ $group_key ] );
+			}
+		}
+
+		foreach ( $group_map as $group ) {
+			$ordered[] = $group;
+		}
+
+		return $ordered;
+	}
+
+	/**
+	 * Get the normalized key for a sponsor group.
+	 *
+	 * @param array $group Sponsor group.
+	 * @return string
+	 */
+	private function get_sponsor_group_key( $group ) {
+		if ( ! is_array( $group ) ) {
+			return '';
+		}
+
+		if ( ! empty( $group['eventyay_group_key'] ) ) {
+			return sanitize_key( $group['eventyay_group_key'] );
+		}
+
+		if ( ! empty( $group['group_name'] ) ) {
+			return sanitize_key( $group['group_name'] );
+		}
+
+		return '';
 	}
 }

--- a/admin/class-wpfaevent-partner-dashboard-controller.php
+++ b/admin/class-wpfaevent-partner-dashboard-controller.php
@@ -76,7 +76,7 @@ class Wpfaevent_Partner_Dashboard_Controller {
 		$is_new = false;
 		if ( ! $id ) {
 			$is_new = true;
-			$id     = 'manual-' . $type . '-' . wp_generate_password( 8, false );
+			$id     = $this->generate_manual_partner_id( $type );
 		}
 
 		$new_record = array(
@@ -159,6 +159,20 @@ class Wpfaevent_Partner_Dashboard_Controller {
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Generate a WordPress-safe identifier for manually created partners.
+	 *
+	 * The dashboard edit/delete flows read IDs back through sanitize_key(), so
+	 * locally generated IDs must already be normalized to preserve lookups and
+	 * nonce action strings across requests.
+	 *
+	 * @param string $type Partner type.
+	 * @return string
+	 */
+	private function generate_manual_partner_id( $type ) {
+		return sanitize_key( 'manual-' . $type . '-' . wp_generate_password( 8, false ) );
 	}
 
 	/**

--- a/admin/class-wpfaevent-partner-dashboard-renderer.php
+++ b/admin/class-wpfaevent-partner-dashboard-renderer.php
@@ -70,7 +70,8 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 		$type_label_plural = 'sponsor' === $type ? __( 'Sponsors', 'wpfaevent' ) : __( 'Exhibitors', 'wpfaevent' );
 
 		// Load records for the event.
-		$records = $this->stats->load_records( $type, $event_id );
+		$records        = $this->stats->load_records( $type, $event_id );
+		$sponsor_groups = 'sponsor' === $type ? $this->stats->load_sponsor_groups( $event_id ) : array();
 
 		// Handle CRUD Routing.
 		if ( 'new' === $action || ( 'edit' === $action && $target_id ) ) {
@@ -216,6 +217,113 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 						<div class="description"><?php esc_html_e( 'Hidden or legacy profiles.', 'wpfaevent' ); ?></div>
 					</div>
 				</div>
+
+				<?php if ( 'sponsor' === $type && ! empty( $sponsor_groups ) ) : ?>
+					<div class="wpfaevent-dashboard-card">
+						<div class="wpfaevent-list-toolbar" style="margin-bottom: 16px;">
+							<h3><?php esc_html_e( 'Sponsor Group Order', 'wpfaevent' ); ?></h3>
+							<div class="description"><?php esc_html_e( 'Move sponsor groups up or down, then save to keep that order across the dashboard and frontend.', 'wpfaevent' ); ?></div>
+						</div>
+						<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+							<input type="hidden" name="action" value="wpfaevent_reorder_sponsor_groups">
+							<input type="hidden" name="event_id" value="<?php echo esc_attr( (string) $event_id ); ?>">
+							<?php wp_nonce_field( 'wpfaevent_reorder_sponsor_groups_' . $event_id ); ?>
+							<div id="wpfaevent-sponsor-group-order-list">
+								<?php foreach ( $sponsor_groups as $index => $group ) : ?>
+									<?php
+									if ( ! is_array( $group ) ) {
+										continue;
+									}
+
+									$group_name    = ! empty( $group['group_name'] ) ? sanitize_text_field( $group['group_name'] ) : __( 'Sponsors', 'wpfaevent' );
+									$group_key     = ! empty( $group['eventyay_group_key'] ) ? sanitize_key( $group['eventyay_group_key'] ) : sanitize_key( $group_name );
+									$group_count   = isset( $group['sponsors'] ) && is_array( $group['sponsors'] ) ? count( $group['sponsors'] ) : 0;
+									$is_eventyay   = ! empty( $group['source'] ) && 'eventyay' === $group['source'];
+									$is_first_item = 0 === $index;
+									$is_last_item  = $index === count( $sponsor_groups ) - 1;
+									?>
+									<div class="wpfaevent-list-item wpfaevent-sponsor-group-order-item">
+										<input type="hidden" name="group_keys[]" value="<?php echo esc_attr( $group_key ); ?>">
+										<div class="wpfaevent-list-copy">
+											<strong><?php echo esc_html( $group_name ); ?></strong>
+											<div class="description">
+												<?php
+												printf(
+													/* translators: %d: sponsor count. */
+													esc_html( _n( '%d sponsor', '%d sponsors', $group_count, 'wpfaevent' ) ),
+													absint( $group_count )
+												);
+												?>
+											</div>
+										</div>
+										<div class="wpfaevent-row-actions">
+											<?php if ( $is_eventyay ) : ?>
+												<span class="wpfaevent-badge is-neutral is-small"><?php esc_html_e( 'Eventyay', 'wpfaevent' ); ?></span>
+											<?php endif; ?>
+											<button type="button" class="button button-small wpfaevent-move-group-up" <?php disabled( $is_first_item ); ?>><?php esc_html_e( 'Move Up', 'wpfaevent' ); ?></button>
+											<button type="button" class="button button-small wpfaevent-move-group-down" <?php disabled( $is_last_item ); ?>><?php esc_html_e( 'Move Down', 'wpfaevent' ); ?></button>
+										</div>
+									</div>
+								<?php endforeach; ?>
+							</div>
+							<p>
+								<button type="submit" class="button button-primary"><?php esc_html_e( 'Save Sponsor Group Order', 'wpfaevent' ); ?></button>
+							</p>
+						</form>
+						<script>
+							document.addEventListener('DOMContentLoaded', function() {
+								const list = document.getElementById('wpfaevent-sponsor-group-order-list');
+								if (!list) {
+									return;
+								}
+
+								const refreshButtons = function() {
+									const items = list.querySelectorAll('.wpfaevent-sponsor-group-order-item');
+									items.forEach(function(item, index) {
+										const upButton = item.querySelector('.wpfaevent-move-group-up');
+										const downButton = item.querySelector('.wpfaevent-move-group-down');
+										if (upButton) {
+											upButton.disabled = index === 0;
+										}
+										if (downButton) {
+											downButton.disabled = index === items.length - 1;
+										}
+									});
+								};
+
+								list.addEventListener('click', function(event) {
+									const button = event.target.closest('button');
+									if (!button) {
+										return;
+									}
+
+									const item = button.closest('.wpfaevent-sponsor-group-order-item');
+									if (!item) {
+										return;
+									}
+
+									if (button.classList.contains('wpfaevent-move-group-up')) {
+										const previousItem = item.previousElementSibling;
+										if (previousItem) {
+											list.insertBefore(item, previousItem);
+											refreshButtons();
+										}
+									}
+
+									if (button.classList.contains('wpfaevent-move-group-down')) {
+										const nextItem = item.nextElementSibling;
+										if (nextItem) {
+											list.insertBefore(nextItem, item);
+											refreshButtons();
+										}
+									}
+								});
+
+								refreshButtons();
+							});
+						</script>
+					</div>
+				<?php endif; ?>
 
 				<!-- CRUD Search & Filter Header -->
 				<div class="wpfaevent-list-toolbar">

--- a/admin/class-wpfaevent-partner-dashboard-statistics.php
+++ b/admin/class-wpfaevent-partner-dashboard-statistics.php
@@ -66,8 +66,7 @@ class Wpfaevent_Partner_Dashboard_Statistics {
 		}
 
 		if ( 'sponsor' === $type ) {
-			$raw_groups = $this->store->read_dashboard_json_file( 'sponsors-' . $event_id . '.json', array() );
-			$raw_groups = is_array( $raw_groups ) ? $raw_groups : array();
+			$raw_groups = $this->load_sponsor_groups( $event_id );
 			$sponsors   = array();
 
 			foreach ( $raw_groups as $group ) {
@@ -91,6 +90,22 @@ class Wpfaevent_Partner_Dashboard_Statistics {
 
 			return is_array( $exhibitors ) ? $exhibitors : array();
 		}
+	}
+
+	/**
+	 * Load sponsor groups for an event.
+	 *
+	 * @param int $event_id Event ID.
+	 * @return array
+	 */
+	public function load_sponsor_groups( $event_id ) {
+		if ( ! $event_id ) {
+			return array();
+		}
+
+		$raw_groups = $this->store->read_dashboard_json_file( 'sponsors-' . $event_id . '.json', array() );
+
+		return is_array( $raw_groups ) ? $raw_groups : array();
 	}
 
 	/**

--- a/admin/class-wpfaevent-partner-dashboard.php
+++ b/admin/class-wpfaevent-partner-dashboard.php
@@ -57,4 +57,11 @@ class Wpfaevent_Partner_Dashboard {
 	public function handle_delete_partner() {
 		$this->controller->handle_delete_partner();
 	}
+
+	/**
+	 * POST Handler to save sponsor group order.
+	 */
+	public function handle_reorder_sponsor_groups() {
+		$this->controller->handle_reorder_sponsor_groups();
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "doctrine/instantiator": "2.1.0",
+        "doctrine/instantiator": "2.0.0",
         "php-stubs/wp-cli-stubs": "^2.12",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9711ff8e1ddae5db096e0c195fc2f5c3",
+    "content-hash": "aa079bf9310f91ab386f7a848fccce27",
     "packages": [],
     "packages-dev": [
         {
@@ -105,29 +105,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.4"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5.58"
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -154,7 +155,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -170,7 +171,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T06:47:08+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/includes/class-wpfaevent-templates.php
+++ b/includes/class-wpfaevent-templates.php
@@ -821,7 +821,7 @@ class Wpfaevent_Templates {
 			'wpfaevent-schedule',
 			WPFAEVENT_URL . 'public/css/templates/schedule.css',
 			array( 'wpfaevent', 'wpfaevent-event' ),
-			WPFAEVENT_VERSION,
+			file_exists( WPFAEVENT_PATH . 'public/css/templates/schedule.css' ) ? (string) filemtime( WPFAEVENT_PATH . 'public/css/templates/schedule.css' ) : WPFAEVENT_VERSION,
 			'all'
 		);
 	}

--- a/includes/class-wpfaevent.php
+++ b/includes/class-wpfaevent.php
@@ -264,6 +264,7 @@ class Wpfaevent {
 		$this->loader->add_action( 'admin_menu', $partner_dashboard, 'register_menu_pages' );
 		$this->loader->add_action( 'admin_post_wpfaevent_save_partner', $partner_dashboard, 'handle_save_partner' );
 		$this->loader->add_action( 'admin_post_wpfaevent_delete_partner', $partner_dashboard, 'handle_delete_partner' );
+		$this->loader->add_action( 'admin_post_wpfaevent_reorder_sponsor_groups', $partner_dashboard, 'handle_reorder_sponsor_groups' );
 
 		// Add settings link to the plugins page.
 		$plugin_basename = plugin_basename( dirname( __DIR__ ) . '/wpfaevent.php' );

--- a/includes/eventyay-importer/class-wpfaevent-jsonapi-parser.php
+++ b/includes/eventyay-importer/class-wpfaevent-jsonapi-parser.php
@@ -220,7 +220,7 @@ class Wpfaevent_JSONAPI_Parser {
 		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
 		$source_id        = $this->eventyay_resource_identifier( $sponsor_resource );
 		$name             = $this->eventyay_first_present_text( $sponsor_resource, array( 'name', 'title', 'label' ) );
-		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'type', 'level_name', 'level-name', 'tier', 'category' ) );
+		$type             = $this->eventyay_first_present_text( $sponsor_resource, array( 'level_name', 'level-name', 'tier', 'category', 'type' ) );
 		$level            = $this->eventyay_first_present_raw( $sponsor_resource, array( 'level', 'position', 'order', 'sort_order', 'sort-order' ) );
 
 		return array(
@@ -934,6 +934,20 @@ class Wpfaevent_JSONAPI_Parser {
 		foreach ( $eventyay_resource as $key => $value ) {
 			if ( in_array( $key, array( 'attributes', 'relationships' ), true ) ) {
 				continue;
+			}
+
+			if (
+				'type' === $key
+				&& isset( $normalized['type'] )
+				&& is_string( $normalized['type'] )
+				&& is_scalar( $value )
+			) {
+				$attribute_type = trim( $normalized['type'] );
+				$resource_type  = trim( (string) $value );
+
+				if ( '' !== $attribute_type && '' !== $resource_type && sanitize_key( $attribute_type ) !== sanitize_key( $resource_type ) ) {
+					continue;
+				}
 			}
 
 			$normalized[ $key ] = $value;
@@ -2461,20 +2475,90 @@ class Wpfaevent_JSONAPI_Parser {
 	public function merge_eventyay_sponsor_groups( $imported, $existing ) {
 		$existing = is_array( $existing ) ? $existing : array();
 		$groups   = array();
+		$order    = array();
 
 		foreach ( $existing as $group ) {
-			if ( ! is_array( $group ) || $this->is_eventyay_sponsor_group( $group ) ) {
+			if ( ! is_array( $group ) ) {
+				continue;
+			}
+
+			$group_key = $this->eventyay_sponsor_group_key( $group );
+			if ( '' !== $group_key ) {
+				$order[] = $group_key;
+			}
+
+			if ( $this->is_eventyay_sponsor_group( $group ) ) {
 				continue;
 			}
 
 			$groups[] = $group;
 		}
 
-		foreach ( $this->group_eventyay_sponsors( $imported ) as $group ) {
-			$groups[] = $group;
+		$imported_groups = $this->group_eventyay_sponsors( $imported );
+		$group_map       = array();
+
+		foreach ( $groups as $group ) {
+			$group_key = $this->eventyay_sponsor_group_key( $group );
+			if ( '' !== $group_key ) {
+				$group_map[ $group_key ] = $group;
+			}
 		}
 
-		return $groups;
+		foreach ( $imported_groups as $group ) {
+			$group_key = $this->eventyay_sponsor_group_key( $group );
+			if ( '' !== $group_key ) {
+				$group_map[ $group_key ] = $group;
+
+				if ( ! in_array( $group_key, $order, true ) ) {
+					$order[] = $group_key;
+				}
+			} else {
+				$groups[] = $group;
+			}
+		}
+
+		$merged_groups = array();
+
+		foreach ( $order as $group_key ) {
+			if ( isset( $group_map[ $group_key ] ) ) {
+				$merged_groups[] = $group_map[ $group_key ];
+				unset( $group_map[ $group_key ] );
+			}
+		}
+
+		foreach ( $group_map as $group ) {
+			$merged_groups[] = $group;
+		}
+
+		foreach ( $groups as $group ) {
+			if ( ! is_array( $group ) ) {
+				$merged_groups[] = $group;
+			}
+		}
+
+		return $merged_groups;
+	}
+
+	/**
+	 * Get a stable key for a sponsor group.
+	 *
+	 * @param array $group Sponsor group.
+	 * @return string
+	 */
+	private function eventyay_sponsor_group_key( $group ) {
+		if ( ! is_array( $group ) ) {
+			return '';
+		}
+
+		if ( ! empty( $group['eventyay_group_key'] ) ) {
+			return sanitize_key( $group['eventyay_group_key'] );
+		}
+
+		if ( ! empty( $group['group_name'] ) ) {
+			return sanitize_key( $group['group_name'] );
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -245,6 +245,28 @@ class Wpfaevent_Event_Template_Controller {
 			}
 		}
 
+		$current_day_filter   = '';
+		$current_track_filter = '';
+		$current_room_filter  = '';
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only schedule filters.
+		if ( isset( $_GET['day'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized immediately after reading.
+			$current_day_filter = sanitize_title( wp_unslash( $_GET['day'] ) );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only schedule filters.
+		if ( isset( $_GET['track'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized immediately after reading.
+			$current_track_filter = sanitize_title( wp_unslash( $_GET['track'] ) );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only schedule filters.
+		if ( isset( $_GET['room'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized immediately after reading.
+			$current_room_filter = sanitize_title( wp_unslash( $_GET['room'] ) );
+		}
+
 		$format_timezone_label = static function ( $timezone_string ) use ( $event_timezone_string, $site_timezone_string ) {
 			$label = str_replace( '_', ' ', $timezone_string );
 
@@ -493,15 +515,39 @@ class Wpfaevent_Event_Template_Controller {
 			$event_schedule_args['schedule_tz'] = $selected_schedule_timezone_string;
 		}
 
+		if ( $current_day_filter ) {
+			$event_schedule_args['day'] = $current_day_filter;
+		}
+
+		if ( $current_track_filter ) {
+			$event_schedule_args['track'] = $current_track_filter;
+		}
+
+		if ( $current_room_filter ) {
+			$event_schedule_args['room'] = $current_room_filter;
+		}
+
 		$event_schedule_url   = add_query_arg( $event_schedule_args, $schedule_page_url );
 		$additional_page_url  = class_exists( 'Wpfaevent_Additional_Information_Helper' ) ? Wpfaevent_Additional_Information_Helper::get_additional_information_page_url() : home_url( '/additional-information/' );
 		$event_additional_url = add_query_arg( 'event', $event_slug, $additional_page_url );
 
-		$build_event_schedule_view_url = static function ( $view ) use ( $event_id, $event_timezone_string, $selected_schedule_timezone_string ) {
+		$build_event_schedule_view_url = static function ( $view ) use ( $event_id, $event_timezone_string, $selected_schedule_timezone_string, $current_day_filter, $current_track_filter, $current_room_filter ) {
 			$args = array();
 
 			if ( $selected_schedule_timezone_string && $selected_schedule_timezone_string !== $event_timezone_string ) {
 				$args['schedule_tz'] = $selected_schedule_timezone_string;
+			}
+
+			if ( $current_day_filter ) {
+				$args['day'] = $current_day_filter;
+			}
+
+			if ( $current_track_filter ) {
+				$args['track'] = $current_track_filter;
+			}
+
+			if ( $current_room_filter ) {
+				$args['room'] = $current_room_filter;
 			}
 
 			if ( 'calendar' === $view ) {
@@ -781,12 +827,61 @@ class Wpfaevent_Event_Template_Controller {
 			$time_parts                  = preg_split( '/\s*-\s*/', $schedule_item['time_label'], 2 );
 			$schedule_item['time_start'] = isset( $time_parts[0] ) ? trim( $time_parts[0] ) : $schedule_item['time_label'];
 			$schedule_item['time_end']   = isset( $time_parts[1] ) ? trim( $time_parts[1] ) : '';
+			$schedule_item['day_key']    = sanitize_title( $schedule_item['date_label'] ? $schedule_item['date_label'] : __( 'TBD', 'wpfaevent' ) );
+			$schedule_item['track_key']  = sanitize_title( $schedule_item['track'] );
+			$schedule_item['room_key']   = sanitize_title( $schedule_item['room'] );
 
 			$schedule_items[] = $schedule_item;
 		}
 
+		$event_session_filter_options = array(
+			'days'   => array(),
+			'tracks' => array(),
+			'rooms'  => array(),
+		);
+
+		foreach ( $schedule_items as $schedule_item ) {
+			$day_label = $schedule_item['date_label'] ? $schedule_item['date_label'] : __( 'TBD', 'wpfaevent' );
+
+			if ( ! empty( $schedule_item['day_key'] ) ) {
+				$event_session_filter_options['days'][ $schedule_item['day_key'] ] = $day_label;
+			}
+
+			if ( ! empty( $schedule_item['track_key'] ) && ! empty( $schedule_item['track'] ) ) {
+				$event_session_filter_options['tracks'][ $schedule_item['track_key'] ] = $schedule_item['track'];
+			}
+
+			if ( ! empty( $schedule_item['room_key'] ) && ! empty( $schedule_item['room'] ) ) {
+				$event_session_filter_options['rooms'][ $schedule_item['room_key'] ] = $schedule_item['room'];
+			}
+		}
+
+		$has_schedule_filters          = ! empty( $event_session_filter_options['days'] ) || ! empty( $event_session_filter_options['tracks'] ) || ! empty( $event_session_filter_options['rooms'] );
+		$schedule_item_matches_filters = static function ( $item ) use ( $current_day_filter, $current_track_filter, $current_room_filter ) {
+			if ( $current_day_filter && ( empty( $item['day_key'] ) || $current_day_filter !== $item['day_key'] ) ) {
+				return false;
+			}
+
+			if ( $current_track_filter && ( empty( $item['track_key'] ) || $current_track_filter !== $item['track_key'] ) ) {
+				return false;
+			}
+
+			if ( $current_room_filter && ( empty( $item['room_key'] ) || $current_room_filter !== $item['room_key'] ) ) {
+				return false;
+			}
+
+			return true;
+		};
+
+		$filtered_schedule_items = array_values(
+			array_filter(
+				$schedule_items,
+				$schedule_item_matches_filters
+			)
+		);
+
 		$schedule_preview_limit      = absint( apply_filters( 'wpfa_event_schedule_preview_limit', 3, $event_id ) );
-		$schedule_preview_items      = $schedule_preview_limit ? array_slice( $schedule_items, 0, $schedule_preview_limit ) : $schedule_items;
+		$schedule_preview_items      = $schedule_preview_limit ? array_slice( $filtered_schedule_items, 0, $schedule_preview_limit ) : $filtered_schedule_items;
 		$schedule_preview_day_groups = array();
 
 		foreach ( $schedule_preview_items as $schedule_item ) {
@@ -799,9 +894,26 @@ class Wpfaevent_Event_Template_Controller {
 			$schedule_preview_day_groups[ $day_key ][] = $schedule_item;
 		}
 
-		$schedule_hidden_count = max( 0, count( $schedule_items ) - count( $schedule_preview_items ) );
+		$schedule_hidden_count = max( 0, count( $filtered_schedule_items ) - count( $schedule_preview_items ) );
 		$first_schedule        = ! empty( $schedule_items[0] ) ? $schedule_items[0] : array();
-		$custom_sections       = array();
+		$filter_form_classes   = 'wpfa-schedule-filter-form';
+
+		if ( $has_schedule_filters ) {
+			$filter_form_classes .= ' has-session-filters';
+		}
+
+		$schedule_filter_reset_args = array();
+
+		if ( $selected_schedule_timezone_string && $selected_schedule_timezone_string !== $event_timezone_string ) {
+			$schedule_filter_reset_args['schedule_tz'] = $selected_schedule_timezone_string;
+		}
+
+		if ( 'calendar' === $current_schedule_view ) {
+			$schedule_filter_reset_args['schedule_view'] = 'calendar';
+		}
+
+		$schedule_filter_reset_url = add_query_arg( $schedule_filter_reset_args, get_permalink( $event_id ) ) . '#wpfa-event-schedule-title';
+		$custom_sections           = array();
 
 		foreach ( $custom_tabs as $custom_tab ) {
 			if ( empty( $custom_tab['slug'] ) || empty( $custom_tab['title'] ) || empty( $custom_tab['content'] ) ) {
@@ -906,6 +1018,14 @@ class Wpfaevent_Event_Template_Controller {
 			'schedule_preview_items'                   => $schedule_preview_items,
 			'schedule_preview_day_groups'              => $schedule_preview_day_groups,
 			'schedule_hidden_count'                    => $schedule_hidden_count,
+			'filtered_schedule_items'                  => $filtered_schedule_items,
+			'event_session_filter_options'             => $event_session_filter_options,
+			'has_schedule_filters'                     => $has_schedule_filters,
+			'filter_form_classes'                      => $filter_form_classes,
+			'schedule_filter_reset_url'                => $schedule_filter_reset_url,
+			'current_day_filter'                       => $current_day_filter,
+			'current_track_filter'                     => $current_track_filter,
+			'current_room_filter'                      => $current_room_filter,
 			'event_schedule_url'                       => $event_schedule_url,
 			'visible_sponsor_groups'                   => $visible_sponsor_groups,
 			'current_schedule_view'                    => $current_schedule_view,
@@ -993,6 +1113,18 @@ class Wpfaevent_Event_Template_Controller {
 			'schedule_preview_items'                   => array(),
 			'schedule_preview_day_groups'              => array(),
 			'schedule_hidden_count'                    => 0,
+			'filtered_schedule_items'                  => array(),
+			'event_session_filter_options'             => array(
+				'days'   => array(),
+				'tracks' => array(),
+				'rooms'  => array(),
+			),
+			'has_schedule_filters'                     => false,
+			'filter_form_classes'                      => 'wpfa-schedule-filter-form',
+			'schedule_filter_reset_url'                => '',
+			'current_day_filter'                       => '',
+			'current_track_filter'                     => '',
+			'current_room_filter'                      => '',
 			'event_schedule_url'                       => '',
 			'visible_sponsor_groups'                   => array(),
 			'current_schedule_view'                    => 'list',

--- a/includes/helpers/class-wpfaevent-schedule-helper.php
+++ b/includes/helpers/class-wpfaevent-schedule-helper.php
@@ -346,8 +346,13 @@ class Wpfaevent_Schedule_Helper {
 
 		if ( ! $event_id ) {
 			return array(
-				'items'  => array(),
-				'groups' => array(),
+				'items'   => array(),
+				'groups'  => array(),
+				'filters' => array(
+					'days'   => array(),
+					'tracks' => array(),
+					'rooms'  => array(),
+				),
 			);
 		}
 
@@ -362,6 +367,11 @@ class Wpfaevent_Schedule_Helper {
 		$schedule_body  = ! empty( $schedule_head ) ? array_slice( $schedule_rows, 1 ) : $schedule_rows;
 		$event_timezone = self::get_event_timezone_object( $event_id );
 		$items          = array();
+		$filters        = array(
+			'days'   => array(),
+			'tracks' => array(),
+			'rooms'  => array(),
+		);
 
 		foreach ( $schedule_body as $row_index => $row ) {
 			if ( ! is_array( $row ) ) {
@@ -392,9 +402,44 @@ class Wpfaevent_Schedule_Helper {
 			$time_parts         = preg_split( '/\s*-\s*/', $item['time_label'], 2 );
 			$item['time_start'] = isset( $time_parts[0] ) ? trim( $time_parts[0] ) : $item['time_label'];
 			$item['time_end']   = isset( $time_parts[1] ) ? trim( $time_parts[1] ) : '';
+			$item['day_key']    = self::build_schedule_filter_key( $item['date_label'] );
+			$item['track_key']  = self::build_schedule_filter_key( $item['track'] );
+			$item['room_key']   = self::build_schedule_filter_key( $item['room'] );
+
+			$sort_datetime = self::parse_schedule_datetime( $start_datetime );
+			if ( ! $sort_datetime ) {
+				$sort_datetime = self::build_schedule_fallback_datetime( $row_date, $row_time, $event_timezone );
+			}
+
+			$item['sort_key']      = $sort_datetime ? $sort_datetime->getTimestamp() : PHP_INT_MAX;
+			$item['slot_sort_key'] = $sort_datetime ? $sort_datetime->getTimestamp() : PHP_INT_MAX;
+			$item['slot_key']      = self::build_schedule_filter_key( $item['time_start'] ? $item['time_start'] : $item['time_label'] );
+
+			if ( ! empty( $item['day_key'] ) && ! isset( $filters['days'][ $item['day_key'] ] ) ) {
+				$filters['days'][ $item['day_key'] ] = $item['date_label'];
+			}
+
+			if ( ! empty( $item['track_key'] ) && ! isset( $filters['tracks'][ $item['track_key'] ] ) ) {
+				$filters['tracks'][ $item['track_key'] ] = $item['track'];
+			}
+
+			if ( ! empty( $item['room_key'] ) && ! isset( $filters['rooms'][ $item['room_key'] ] ) ) {
+				$filters['rooms'][ $item['room_key'] ] = $item['room'];
+			}
 
 			$items[] = $item;
 		}
+
+		usort(
+			$items,
+			static function ( $item_a, $item_b ) {
+				if ( $item_a['sort_key'] === $item_b['sort_key'] ) {
+					return strcasecmp( $item_a['title'], $item_b['title'] );
+				}
+
+				return ( $item_a['sort_key'] < $item_b['sort_key'] ) ? -1 : 1;
+			}
+		);
 
 		$groups = array();
 
@@ -409,9 +454,24 @@ class Wpfaevent_Schedule_Helper {
 		}
 
 		return array(
-			'items'  => $items,
-			'groups' => $groups,
+			'items'   => $items,
+			'groups'  => $groups,
+			'filters' => $filters,
 		);
+	}
+
+	/**
+	 * Build a normalized key for schedule filter controls.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $value Raw filter value.
+	 * @return string
+	 */
+	private static function build_schedule_filter_key( $value ) {
+		$value = sanitize_text_field( $value );
+
+		return '' !== trim( $value ) ? sanitize_title( $value ) : '';
 	}
 
 	/**

--- a/public/class-wpfaevent-public.php
+++ b/public/class-wpfaevent-public.php
@@ -297,7 +297,7 @@ class Wpfaevent_Public {
 				$this->plugin_name,
 				$this->plugin_name . '-event',
 			),
-			$this->version,
+			file_exists( WPFAEVENT_PATH . 'public/css/templates/schedule.css' ) ? (string) filemtime( WPFAEVENT_PATH . 'public/css/templates/schedule.css' ) : $this->version,
 			'all'
 		);
 

--- a/public/css/templates/event.css
+++ b/public/css/templates/event.css
@@ -1551,6 +1551,221 @@
 	text-decoration: underline;
 }
 
+.wpfaevent .wpfa-event-schedule .wpfa-event-section-head {
+	margin-bottom: 34px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-event-section-head h2 {
+	font-size: clamp(2rem, 3vw, 2.6rem);
+	font-weight: 900;
+	letter-spacing: -0.03em;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-event-section-head p {
+	color: #6b7a90;
+	font-size: 0.98rem;
+	max-width: 42rem;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-event-section-actions {
+	gap: 16px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-view-switch {
+	border-radius: 999px;
+	box-shadow: 0 8px 20px rgba(36, 52, 71, 0.08);
+	padding: 4px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-view-switch a {
+	border-radius: 999px;
+	font-size: 0.82rem;
+	font-weight: 800;
+	min-height: 32px;
+	min-width: 78px;
+	padding: 7px 14px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-view-switch a.is-active {
+	background: #17233a;
+	color: #fff;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-form {
+	background: rgba(255, 255, 255, 0.72);
+	border: 1px solid rgba(214, 222, 233, 0.9);
+	border-radius: 24px;
+	box-shadow: 0 10px 26px rgba(36, 52, 71, 0.06);
+	padding: 16px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-form span {
+	font-size: 0.68rem;
+	letter-spacing: 0.08em;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-form select,
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-form button,
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-reset {
+	border-radius: 999px;
+	height: 44px;
+	min-height: 44px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-form select {
+	padding: 8px 14px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-form button {
+	background: #17233a;
+	border-color: #17233a;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-form button:hover,
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-form button:focus {
+	background: #0f172a;
+	border-color: #0f172a;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-filter-reset {
+	background: #fff;
+	border-color: rgba(214, 222, 233, 0.9);
+	color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-program {
+	gap: 0;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-day {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-day + .wpfa-schedule-day {
+	margin-top: 40px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-day-head {
+	align-items: end;
+	background: transparent;
+	border-bottom: 1px solid #d7dfeb;
+	border-top: 1px solid #d7dfeb;
+	padding: 14px 0 16px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-day-head h2,
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-day-head h3 {
+	font-size: 1.02rem;
+	font-weight: 900;
+	letter-spacing: 0.11em;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-day-head p {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session {
+	align-items: start;
+	gap: 18px;
+	grid-template-columns: 108px minmax(0, 1fr);
+	padding: 18px 0;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session:hover {
+	background: transparent;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session + .wpfa-schedule-session {
+	border-top: 1px solid #d7dfeb;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-timecol {
+	padding: 14px 18px 0 0;
+	text-align: right;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-timecol::before,
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-timecol::after {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-start {
+	font-size: 1.95rem;
+	font-weight: 900;
+	letter-spacing: -0.04em;
+	line-height: 1;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-end {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-main {
+	background: linear-gradient(90deg, rgba(255, 251, 239, 0.94) 0%, rgba(255, 255, 255, 0.98) 100%);
+	border: 1px solid rgba(207, 216, 56, 0.78);
+	border-left: 5px solid var(--event-primary);
+	border-radius: 16px;
+	padding: 18px 20px 16px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-title {
+	font-size: 1.04rem;
+	line-height: 1.35;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-summary-time {
+	color: var(--event-muted);
+	font-size: 0.88rem;
+	font-weight: 700;
+	margin: 8px 0 0;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-location,
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-speakers {
+	color: #526277;
+	font-size: 0.92rem;
+	font-weight: 700;
+	line-height: 1.45;
+	margin: 8px 0 0;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-speakers {
+	color: #6b7a90;
+	font-size: 0.88rem;
+	font-weight: 600;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-meta {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px 12px;
+	margin-top: 14px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-track {
+	background: rgba(255, 255, 255, 0.82);
+	border: 1px solid var(--event-primary);
+	border-radius: 999px;
+	color: #5d6f84;
+	display: inline-flex;
+	font-size: 0.76rem;
+	font-weight: 800;
+	line-height: 1.2;
+	padding: 5px 10px;
+}
+
+.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-calendar {
+	font-size: 0.82rem;
+	margin-left: auto;
+	margin-top: 0;
+}
+
 .wpfaevent .wpfa-event-session {
 	background: #fff;
 	border: 1px solid var(--event-line);
@@ -2938,6 +3153,48 @@
 	.wpfaevent .wpfa-schedule-calendar-slots::before,
 	.wpfaevent .wpfa-schedule-calendar-slot::before {
 		display: none;
+	}
+
+	.wpfaevent .wpfa-event-schedule .wpfa-schedule-session {
+		gap: 14px;
+		grid-template-columns: 1fr;
+		padding: 18px 0;
+	}
+
+	.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-timecol {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		padding: 0;
+		text-align: left;
+	}
+
+	.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-start {
+		font-size: 1.35rem;
+	}
+
+	.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-end {
+		color: var(--event-muted);
+		display: inline-flex;
+		font-size: 0.88rem;
+		margin-top: 0;
+	}
+
+	.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-end::before {
+		content: '– ';
+	}
+
+	.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-summary-time {
+		display: none;
+	}
+
+	.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-main {
+		padding: 16px 16px 14px;
+	}
+
+	.wpfaevent .wpfa-event-schedule .wpfa-schedule-session-calendar {
+		margin-left: 0;
 	}
 
 	.wpfaevent .wpfa-schedule-calendar-slots {

--- a/public/css/templates/schedule.css
+++ b/public/css/templates/schedule.css
@@ -117,6 +117,14 @@
 	grid-template-columns: minmax(190px, 260px) minmax(260px, 456px) auto;
 }
 
+.wpfaevent .wpfa-schedule-filter-form.has-session-filters {
+	grid-template-columns: repeat(3, minmax(160px, 220px)) minmax(220px, 320px) auto auto;
+}
+
+.wpfaevent .wpfa-schedule-filter-form.has-language-filter.has-session-filters {
+	grid-template-columns: repeat(4, minmax(150px, 220px)) minmax(220px, 320px) auto auto;
+}
+
 .wpfaevent .wpfa-schedule-filter-form label {
 	display: grid;
 	gap: 5px;
@@ -143,7 +151,8 @@
 	width: 100%;
 }
 
-.wpfaevent .wpfa-schedule-filter-form button {
+.wpfaevent .wpfa-schedule-filter-form button,
+.wpfaevent .wpfa-schedule-filter-reset {
 	align-items: center;
 	align-self: end;
 	background: var(--event-primary);
@@ -163,9 +172,17 @@
 }
 
 .wpfaevent .wpfa-schedule-filter-form button:hover,
-.wpfaevent .wpfa-schedule-filter-form button:focus {
+.wpfaevent .wpfa-schedule-filter-form button:focus,
+.wpfaevent .wpfa-schedule-filter-reset:hover,
+.wpfaevent .wpfa-schedule-filter-reset:focus {
 	background: var(--event-primary-dark);
 	color: #fff;
+}
+
+.wpfaevent .wpfa-schedule-filter-reset {
+	background: transparent;
+	border-color: var(--event-line);
+	color: var(--event-primary-dark);
 }
 
 .wpfaevent .wpfa-schedule-tabs {
@@ -335,6 +352,42 @@
 	width: 2px;
 }
 
+.wpfaevent .wpfa-schedule-calendar-row {
+	display: grid;
+	gap: 14px;
+	grid-template-columns: minmax(120px, 150px) minmax(0, 1fr);
+}
+
+.wpfaevent .wpfa-schedule-calendar-time {
+	align-content: start;
+	display: grid;
+	gap: 6px;
+	padding-top: 6px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-time strong,
+.wpfaevent .wpfa-schedule-slot-count {
+	background: #f7fafc;
+	border: 1px solid var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-primary-dark);
+	display: inline-flex;
+	font-size: 0.8rem;
+	font-weight: 900;
+	line-height: 1.2;
+	padding: 6px 8px;
+	width: fit-content;
+}
+
+.wpfaevent .wpfa-schedule-slot-count {
+	color: var(--event-muted);
+}
+
+.wpfaevent .wpfa-schedule-calendar-track {
+	display: grid;
+	gap: 12px;
+}
+
 .wpfaevent .wpfa-schedule-calendar-slot {
 	background: #fff;
 	border: 1px solid var(--event-line);
@@ -343,7 +396,7 @@
 	box-shadow: 0 8px 20px rgba(36, 52, 71, 0.07);
 	display: grid;
 	gap: 8px 16px;
-	grid-template-columns: minmax(104px, 148px) minmax(0, 1fr) auto;
+	grid-template-columns: minmax(0, 1fr) auto;
 	min-width: 0;
 	position: relative;
 	padding: 16px 18px;
@@ -360,6 +413,14 @@
 	position: absolute;
 	top: 21px;
 	width: 12px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-slot-head {
+	align-items: start;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px 14px;
+	justify-content: space-between;
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot time {
@@ -384,7 +445,6 @@
 	color: var(--event-ink);
 	font-size: 1.04rem;
 	font-weight: 900;
-	grid-column: 2;
 	line-height: 1.35;
 	margin: 0;
 	overflow-wrap: anywhere;
@@ -407,7 +467,6 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 6px;
-	grid-column: 2;
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -447,8 +506,30 @@
 
 .wpfaevent .wpfa-schedule-calendar-slot .wpfa-schedule-session-calendar {
 	align-self: start;
-	grid-column: 3;
-	grid-row: 1 / span 3;
 	margin-top: 2px;
 	white-space: nowrap;
+}
+
+.wpfaevent .wpfa-schedule-day-group + .wpfa-schedule-day-group {
+	margin-top: 24px;
+}
+
+.wpfaevent .wpfa-schedule-group-count {
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-session-summary-time {
+	color: var(--event-muted);
+	font-size: 0.88rem;
+	font-weight: 700;
+	margin: 4px 0 0;
+}
+
+.wpfaevent .wpfa-schedule-empty-state {
+	background: #fff;
+	border: 1px dashed var(--event-line);
+	border-radius: var(--event-radius);
+	color: var(--event-muted);
+	margin: 0 0 18px;
+	padding: 18px;
 }

--- a/public/css/templates/schedule.css
+++ b/public/css/templates/schedule.css
@@ -546,3 +546,315 @@
 	margin: 0 0 18px;
 	padding: 18px;
 }
+
+.wpfaevent .wpfa-schedule-session-browser {
+	margin-top: 8px;
+}
+
+.wpfaevent .wpfa-schedule-head {
+	margin-bottom: 34px;
+}
+
+.wpfaevent .wpfa-schedule-head h1 {
+	font-size: clamp(2rem, 3vw, 2.6rem);
+	font-weight: 900;
+	letter-spacing: -0.03em;
+	margin-bottom: 10px;
+}
+
+.wpfaevent .wpfa-schedule-head p {
+	color: #6b7a90;
+	font-size: 0.98rem;
+	max-width: 42rem;
+}
+
+.wpfaevent .wpfa-schedule-controls {
+	gap: 16px;
+}
+
+.wpfaevent .wpfa-schedule-view-switch {
+	border-radius: 999px;
+	box-shadow: 0 8px 20px rgba(36, 52, 71, 0.08);
+	padding: 4px;
+}
+
+.wpfaevent .wpfa-schedule-view-switch a {
+	border-radius: 999px;
+	font-size: 0.82rem;
+	font-weight: 800;
+	min-height: 32px;
+	min-width: 78px;
+	padding: 7px 14px;
+}
+
+.wpfaevent .wpfa-schedule-view-switch a.is-active {
+	background: #17233a;
+	color: #fff;
+}
+
+.wpfaevent .wpfa-schedule-filter-form {
+	background: rgba(255, 255, 255, 0.72);
+	border: 1px solid rgba(214, 222, 233, 0.9);
+	border-radius: 24px;
+	box-shadow: 0 10px 26px rgba(36, 52, 71, 0.06);
+	padding: 16px;
+}
+
+.wpfaevent .wpfa-schedule-filter-form span {
+	font-size: 0.68rem;
+	letter-spacing: 0.08em;
+}
+
+.wpfaevent .wpfa-schedule-filter-form select {
+	border-radius: 999px;
+	height: 44px;
+	min-height: 44px;
+	padding: 8px 14px;
+}
+
+.wpfaevent .wpfa-schedule-filter-form button,
+.wpfaevent .wpfa-schedule-filter-reset {
+	border-radius: 999px;
+	height: 44px;
+	min-height: 44px;
+}
+
+.wpfaevent .wpfa-schedule-filter-form button {
+	background: #17233a;
+	border-color: #17233a;
+}
+
+.wpfaevent .wpfa-schedule-filter-form button:hover,
+.wpfaevent .wpfa-schedule-filter-form button:focus {
+	background: #0f172a;
+	border-color: #0f172a;
+}
+
+.wpfaevent .wpfa-schedule-filter-reset {
+	background: #fff;
+	border-color: rgba(214, 222, 233, 0.9);
+}
+
+.wpfaevent .wpfa-schedule-program {
+	gap: 0;
+}
+
+.wpfaevent .wpfa-schedule-day {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.wpfaevent .wpfa-schedule-day-group + .wpfa-schedule-day-group {
+	margin-top: 40px;
+}
+
+.wpfaevent .wpfa-schedule-day-head {
+	align-items: end;
+	background: transparent;
+	border-bottom: 1px solid #d7dfeb;
+	border-top: 1px solid #d7dfeb;
+	padding: 14px 0 16px;
+}
+
+.wpfaevent .wpfa-schedule-day-head h2,
+.wpfaevent .wpfa-schedule-day-head h3 {
+	font-size: 1.02rem;
+	font-weight: 900;
+	letter-spacing: 0.11em;
+	text-transform: uppercase;
+}
+
+.wpfaevent .wpfa-schedule-day-head p {
+	display: none;
+}
+
+.wpfaevent .wpfa-schedule-session {
+	align-items: start;
+	gap: 18px;
+	grid-template-columns: 108px minmax(0, 1fr);
+	padding: 18px 0;
+}
+
+.wpfaevent .wpfa-schedule-session:hover {
+	background: transparent;
+}
+
+.wpfaevent .wpfa-schedule-session + .wpfa-schedule-session {
+	border-top: 1px solid #d7dfeb;
+}
+
+.wpfaevent .wpfa-schedule-session-timecol {
+	padding: 14px 18px 0 0;
+	text-align: right;
+}
+
+.wpfaevent .wpfa-schedule-session-timecol::before,
+.wpfaevent .wpfa-schedule-session-timecol::after {
+	display: none;
+}
+
+.wpfaevent .wpfa-schedule-session-start {
+	font-size: 1.95rem;
+	font-weight: 900;
+	letter-spacing: -0.04em;
+	line-height: 1;
+}
+
+.wpfaevent .wpfa-schedule-session-end {
+	display: none;
+}
+
+.wpfaevent .wpfa-schedule-session-main {
+	background: linear-gradient(90deg, rgba(255, 251, 239, 0.94) 0%, rgba(255, 255, 255, 0.98) 100%);
+	border: 1px solid rgba(207, 216, 56, 0.78);
+	border-left: 5px solid var(--event-primary);
+	border-radius: 16px;
+	padding: 18px 20px 16px;
+}
+
+.wpfaevent .wpfa-schedule-session-title {
+	font-size: 1.04rem;
+	line-height: 1.35;
+	margin: 0;
+}
+
+.wpfaevent .wpfa-schedule-session-summary-time {
+	margin: 8px 0 0;
+}
+
+.wpfaevent .wpfa-schedule-session-location,
+.wpfaevent .wpfa-schedule-session-speakers {
+	color: #526277;
+	font-size: 0.92rem;
+	font-weight: 700;
+	line-height: 1.45;
+	margin: 8px 0 0;
+}
+
+.wpfaevent .wpfa-schedule-session-speakers {
+	color: #6b7a90;
+	font-size: 0.88rem;
+	font-weight: 600;
+}
+
+.wpfaevent .wpfa-schedule-session-meta {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px 12px;
+	margin-top: 14px;
+}
+
+.wpfaevent .wpfa-schedule-session-track {
+	background: rgba(255, 255, 255, 0.82);
+	border: 1px solid var(--event-primary);
+	border-radius: 999px;
+	color: #5d6f84;
+	display: inline-flex;
+	font-size: 0.76rem;
+	font-weight: 800;
+	line-height: 1.2;
+	padding: 5px 10px;
+}
+
+.wpfaevent .wpfa-schedule-session-calendar {
+	font-size: 0.82rem;
+	margin-left: auto;
+	margin-top: 0;
+}
+
+.wpfaevent .wpfa-schedule-calendar {
+	gap: 28px;
+}
+
+.wpfaevent .wpfa-schedule-calendar-row {
+	gap: 12px;
+	grid-template-columns: minmax(104px, 132px) minmax(0, 1fr);
+}
+
+.wpfaevent .wpfa-schedule-calendar-time strong,
+.wpfaevent .wpfa-schedule-slot-count {
+	border-radius: 999px;
+}
+
+@media (max-width: 1024px) {
+	.wpfaevent .wpfa-schedule-head {
+		gap: 18px;
+		grid-template-columns: 1fr;
+	}
+
+	.wpfaevent .wpfa-schedule-controls {
+		justify-items: start;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form,
+	.wpfaevent .wpfa-schedule-filter-form.has-language-filter,
+	.wpfaevent .wpfa-schedule-filter-form.has-session-filters,
+	.wpfaevent .wpfa-schedule-filter-form.has-language-filter.has-session-filters {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		justify-content: stretch;
+		width: 100%;
+	}
+}
+
+@media (max-width: 767px) {
+	.wpfaevent .wpfa-schedule {
+		padding: 32px 0 56px;
+	}
+
+	.wpfaevent .wpfa-schedule-filter-form,
+	.wpfaevent .wpfa-schedule-filter-form.has-language-filter,
+	.wpfaevent .wpfa-schedule-filter-form.has-session-filters,
+	.wpfaevent .wpfa-schedule-filter-form.has-language-filter.has-session-filters {
+		grid-template-columns: 1fr;
+		padding: 14px;
+	}
+
+	.wpfaevent .wpfa-schedule-session {
+		gap: 14px;
+		grid-template-columns: 1fr;
+		padding: 18px 0;
+	}
+
+	.wpfaevent .wpfa-schedule-session-timecol {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		padding: 0;
+		text-align: left;
+	}
+
+	.wpfaevent .wpfa-schedule-session-start {
+		font-size: 1.35rem;
+	}
+
+	.wpfaevent .wpfa-schedule-session-end {
+		color: var(--event-muted);
+		display: inline-flex;
+		font-size: 0.88rem;
+		margin-top: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-session-end::before {
+		content: '– ';
+	}
+
+	.wpfaevent .wpfa-schedule-session-summary-time {
+		display: none;
+	}
+
+	.wpfaevent .wpfa-schedule-session-main {
+		padding: 16px 16px 14px;
+	}
+
+	.wpfaevent .wpfa-schedule-session-calendar {
+		margin-left: 0;
+	}
+
+	.wpfaevent .wpfa-schedule-calendar-row {
+		grid-template-columns: 1fr;
+	}
+}

--- a/public/css/templates/schedule.css
+++ b/public/css/templates/schedule.css
@@ -386,6 +386,8 @@
 .wpfaevent .wpfa-schedule-calendar-track {
 	display: grid;
 	gap: 12px;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+	min-width: 0;
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot {
@@ -421,6 +423,7 @@
 	flex-wrap: wrap;
 	gap: 10px 14px;
 	justify-content: space-between;
+	min-width: 0;
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot time {
@@ -438,6 +441,8 @@
 	min-height: 36px;
 	padding: 6px 9px;
 	text-align: center;
+	flex: 0 0 auto;
+	max-width: 100%;
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot h3,
@@ -447,7 +452,9 @@
 	font-weight: 900;
 	line-height: 1.35;
 	margin: 0;
+	min-width: 0;
 	overflow-wrap: anywhere;
+	flex: 1 1 220px;
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot h3 a,
@@ -481,6 +488,8 @@
 	font-weight: 700;
 	line-height: 1.25;
 	padding: 5px 8px;
+	min-width: 0;
+	overflow-wrap: anywhere;
 }
 
 .wpfaevent .wpfa-schedule-calendar-actions {

--- a/public/css/templates/schedule.css
+++ b/public/css/templates/schedule.css
@@ -397,8 +397,8 @@
 	border-radius: var(--event-radius);
 	box-shadow: 0 8px 20px rgba(36, 52, 71, 0.07);
 	display: grid;
-	gap: 8px 16px;
-	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 10px 16px;
+	grid-template-columns: auto minmax(0, 1fr) auto;
 	min-width: 0;
 	position: relative;
 	padding: 16px 18px;
@@ -418,12 +418,7 @@
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot-head {
-	align-items: start;
-	display: flex;
-	flex-wrap: wrap;
-	gap: 10px 14px;
-	justify-content: space-between;
-	min-width: 0;
+	display: contents;
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot time {
@@ -437,12 +432,14 @@
 	font-size: 0.84rem;
 	font-weight: 900;
 	justify-content: center;
-	line-height: 1.2;
+	line-height: 1.25;
 	min-height: 36px;
-	padding: 6px 9px;
+	padding: 5px 8px;
 	text-align: center;
 	flex: 0 0 auto;
 	max-width: 100%;
+	grid-column: 1;
+	grid-row: 2;
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot h3,
@@ -454,7 +451,8 @@
 	margin: 0;
 	min-width: 0;
 	overflow-wrap: anywhere;
-	flex: 1 1 220px;
+	grid-column: 1 / span 2;
+	grid-row: 1;
 }
 
 .wpfaevent .wpfa-schedule-calendar-slot h3 a,
@@ -471,12 +469,16 @@
 }
 
 .wpfaevent .wpfa-schedule-calendar-meta {
+	align-items: start;
 	display: flex;
 	flex-wrap: wrap;
 	gap: 6px;
+	grid-column: 2;
+	grid-row: 2;
 	list-style: none;
 	margin: 0;
 	padding: 0;
+	min-width: 0;
 }
 
 .wpfaevent .wpfa-schedule-calendar-meta li {
@@ -515,7 +517,9 @@
 
 .wpfaevent .wpfa-schedule-calendar-slot .wpfa-schedule-session-calendar {
 	align-self: start;
-	margin-top: 2px;
+	grid-column: 3;
+	grid-row: 2;
+	margin-top: 0;
 	white-space: nowrap;
 }
 

--- a/public/partials/speakers/speaker-card.php
+++ b/public/partials/speakers/speaker-card.php
@@ -64,8 +64,10 @@ $talk_date     = get_post_meta( $sid, 'wpfa_speaker_talk_date', true );
 $talk_time     = get_post_meta( $sid, 'wpfa_speaker_talk_time', true );
 $talk_end_time = get_post_meta( $sid, 'wpfa_speaker_talk_end_time', true );
 $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
+$card_variant  = isset( $wpfa_speaker_card_variant ) ? sanitize_key( $wpfa_speaker_card_variant ) : '';
+$is_compact    = 'compact' === $card_variant;
 ?>
-<article class="wpfa-speaker-card" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( sprintf( '%d', absint( $sid ) ) ); ?>">
+<article class="wpfa-speaker-card<?php echo $is_compact ? ' wpfa-speaker-card--compact' : ''; ?>" itemscope itemtype="https://schema.org/Person" data-speaker-id="<?php echo esc_attr( sprintf( '%d', absint( $sid ) ) ); ?>">
 	<a class="wpfa-speaker-photo" href="<?php echo esc_url( $speaker_link ); ?>">
 		<?php if ( $photo_url ) : ?>
 			<div class="wpfa-speaker-photo-container">
@@ -135,7 +137,7 @@ $talk_abstract = get_post_meta( $sid, 'wpfa_speaker_talk_abstract', true );
 						</p>
 					<?php endif; ?>
 
-					<?php if ( $talk_abstract ) : ?>
+					<?php if ( $talk_abstract && ! $is_compact ) : ?>
 						<div class="wpfa-talk-abstract">
 							<?php echo wp_kses_post( wpautop( $talk_abstract ) ); ?>
 						</div>

--- a/public/templates/page-schedule.php
+++ b/public/templates/page-schedule.php
@@ -59,6 +59,9 @@ $read_filter_value = static function ( $key, $type = 'text' ) {
 $current_language     = $read_filter_value( 'language', 'slug' );
 $current_event_filter = $read_filter_value( 'event' );
 $current_view         = $read_filter_value( 'view', 'slug' );
+$current_day_filter   = $read_filter_value( 'day', 'slug' );
+$current_track_filter = $read_filter_value( 'track', 'slug' );
+$current_room_filter  = $read_filter_value( 'room', 'slug' );
 $query_page           = $read_filter_value( 'paged', 'int' );
 
 if ( $query_page ) {
@@ -121,7 +124,7 @@ $schedule_timezone_options = class_exists( 'Wpfaevent_Schedule_Helper' )
 	? Wpfaevent_Schedule_Helper::get_timezone_options( $primary_timezone_string )
 	: array( $primary_timezone_string, 'UTC' );
 
-$build_schedule_view_url = static function ( $view ) use ( $schedule_page_url, $selected_event_slug, $current_language, $selected_schedule_timezone_str, $primary_timezone_string ) {
+$build_schedule_view_url = static function ( $view ) use ( $schedule_page_url, $selected_event_slug, $current_language, $selected_schedule_timezone_str, $primary_timezone_string, $current_day_filter, $current_track_filter, $current_room_filter ) {
 	$args = array();
 
 	if ( $selected_event_slug ) {
@@ -130,6 +133,18 @@ $build_schedule_view_url = static function ( $view ) use ( $schedule_page_url, $
 
 	if ( $current_language ) {
 		$args['language'] = $current_language;
+	}
+
+	if ( $current_day_filter ) {
+		$args['day'] = $current_day_filter;
+	}
+
+	if ( $current_track_filter ) {
+		$args['track'] = $current_track_filter;
+	}
+
+	if ( $current_room_filter ) {
+		$args['room'] = $current_room_filter;
 	}
 
 	if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $primary_timezone_string ) {
@@ -209,8 +224,13 @@ $languages              = array();
 $filtered_event_ids     = array();
 $is_event_schedule      = (bool) $selected_event_id;
 $event_session_schedule = array(
-	'items'  => array(),
-	'groups' => array(),
+	'items'   => array(),
+	'groups'  => array(),
+	'filters' => array(
+		'days'   => array(),
+		'tracks' => array(),
+		'rooms'  => array(),
+	),
 );
 
 foreach ( $event_ids as $event_id ) {
@@ -252,6 +272,55 @@ asort( $languages );
 
 if ( $is_event_schedule && in_array( $selected_event_id, $filtered_event_ids, true ) && class_exists( 'Wpfaevent_Schedule_Helper' ) ) {
 	$event_session_schedule = Wpfaevent_Schedule_Helper::build_event_session_schedule( $selected_event_id, $selected_schedule_timezone );
+}
+
+$event_session_filter_options  = array(
+	'days'   => array(),
+	'tracks' => array(),
+	'rooms'  => array(),
+);
+$has_session_filters           = false;
+$visible_session_groups        = array();
+$schedule_item_matches_filters = static function ( $item ) use ( $current_day_filter, $current_track_filter, $current_room_filter ) {
+	if ( $current_day_filter && ( empty( $item['day_key'] ) || $current_day_filter !== $item['day_key'] ) ) {
+		return false;
+	}
+
+	if ( $current_track_filter && ( empty( $item['track_key'] ) || $current_track_filter !== $item['track_key'] ) ) {
+		return false;
+	}
+
+	if ( $current_room_filter && ( empty( $item['room_key'] ) || $current_room_filter !== $item['room_key'] ) ) {
+		return false;
+	}
+
+	return true;
+};
+
+if ( $is_event_schedule ) {
+	$event_session_filter_options = isset( $event_session_schedule['filters'] ) && is_array( $event_session_schedule['filters'] )
+		? $event_session_schedule['filters']
+		: $event_session_filter_options;
+	$has_session_filters          = ! empty( $event_session_filter_options['days'] ) || ! empty( $event_session_filter_options['tracks'] ) || ! empty( $event_session_filter_options['rooms'] );
+
+	if ( ! empty( $event_session_schedule['items'] ) ) {
+		$filtered_schedule_items = array_values(
+			array_filter(
+				$event_session_schedule['items'],
+				$schedule_item_matches_filters
+			)
+		);
+
+		foreach ( $filtered_schedule_items as $filtered_schedule_item ) {
+			$day_key = ! empty( $filtered_schedule_item['date_label'] ) ? $filtered_schedule_item['date_label'] : __( 'TBD', 'wpfaevent' );
+
+			if ( ! isset( $visible_session_groups[ $day_key ] ) ) {
+				$visible_session_groups[ $day_key ] = array();
+			}
+
+			$visible_session_groups[ $day_key ][] = $filtered_schedule_item;
+		}
+	}
 }
 
 usort(
@@ -330,6 +399,29 @@ $filter_form_classes = 'wpfa-schedule-filter-form';
 if ( ! empty( $languages ) ) {
 	$filter_form_classes .= ' has-language-filter';
 }
+if ( $has_session_filters ) {
+	$filter_form_classes .= ' has-session-filters';
+}
+
+$schedule_filter_reset_args = array();
+
+if ( $selected_event_slug ) {
+	$schedule_filter_reset_args['event'] = $selected_event_slug;
+}
+
+if ( $current_language ) {
+	$schedule_filter_reset_args['language'] = $current_language;
+}
+
+if ( $selected_schedule_timezone_str && $selected_schedule_timezone_str !== $primary_timezone_string ) {
+	$schedule_filter_reset_args['schedule_tz'] = $selected_schedule_timezone_str;
+}
+
+if ( 'calendar' === $current_view ) {
+	$schedule_filter_reset_args['view'] = 'calendar';
+}
+
+$schedule_filter_reset_url = add_query_arg( $schedule_filter_reset_args, $schedule_page_url );
 ?>
 <?php if ( ! $wpfaevent_is_embed ) : ?>
 <!DOCTYPE html>
@@ -379,6 +471,7 @@ if ( ! empty( $languages ) ) {
 					<div class="wpfa-schedule-controls">
 						<nav class="wpfa-schedule-view-switch" aria-label="<?php esc_attr_e( 'Schedule view', 'wpfaevent' ); ?>">
 							<a
+								data-view="list"
 								class="<?php echo esc_attr( 'list' === $current_view ? 'is-active' : '' ); ?>"
 								href="<?php echo esc_url( $build_schedule_view_url( 'list' ) ); ?>"
 								<?php if ( 'list' === $current_view ) : ?>
@@ -388,6 +481,7 @@ if ( ! empty( $languages ) ) {
 								<?php esc_html_e( 'List', 'wpfaevent' ); ?>
 							</a>
 							<a
+								data-view="calendar"
 								class="<?php echo esc_attr( 'calendar' === $current_view ? 'is-active' : '' ); ?>"
 								href="<?php echo esc_url( $build_schedule_view_url( 'calendar' ) ); ?>"
 								<?php if ( 'calendar' === $current_view ) : ?>
@@ -427,7 +521,51 @@ if ( ! empty( $languages ) ) {
 									<?php endforeach; ?>
 								</select>
 							</label>
+							<?php if ( $is_event_schedule && ! empty( $event_session_filter_options['days'] ) ) : ?>
+								<label for="wpfa-schedule-day">
+									<span><?php esc_html_e( 'Day', 'wpfaevent' ); ?></span>
+									<select id="wpfa-schedule-day" name="day">
+										<option value=""><?php esc_html_e( 'All days', 'wpfaevent' ); ?></option>
+										<?php foreach ( $event_session_filter_options['days'] as $day_key => $day_label ) : ?>
+											<option value="<?php echo esc_attr( $day_key ); ?>" <?php selected( $current_day_filter, $day_key ); ?>>
+												<?php echo esc_html( $day_label ); ?>
+											</option>
+										<?php endforeach; ?>
+									</select>
+								</label>
+							<?php endif; ?>
+							<?php if ( $is_event_schedule && ! empty( $event_session_filter_options['tracks'] ) ) : ?>
+								<label for="wpfa-schedule-track">
+									<span><?php esc_html_e( 'Track', 'wpfaevent' ); ?></span>
+									<select id="wpfa-schedule-track" name="track">
+										<option value=""><?php esc_html_e( 'All tracks', 'wpfaevent' ); ?></option>
+										<?php foreach ( $event_session_filter_options['tracks'] as $track_key => $track_label ) : ?>
+											<option value="<?php echo esc_attr( $track_key ); ?>" <?php selected( $current_track_filter, $track_key ); ?>>
+												<?php echo esc_html( $track_label ); ?>
+											</option>
+										<?php endforeach; ?>
+									</select>
+								</label>
+							<?php endif; ?>
+							<?php if ( $is_event_schedule && ! empty( $event_session_filter_options['rooms'] ) ) : ?>
+								<label for="wpfa-schedule-room">
+									<span><?php esc_html_e( 'Room', 'wpfaevent' ); ?></span>
+									<select id="wpfa-schedule-room" name="room">
+										<option value=""><?php esc_html_e( 'All rooms', 'wpfaevent' ); ?></option>
+										<?php foreach ( $event_session_filter_options['rooms'] as $room_key => $room_label ) : ?>
+											<option value="<?php echo esc_attr( $room_key ); ?>" <?php selected( $current_room_filter, $room_key ); ?>>
+												<?php echo esc_html( $room_label ); ?>
+											</option>
+										<?php endforeach; ?>
+									</select>
+								</label>
+							<?php endif; ?>
 							<button type="submit"><?php esc_html_e( 'Apply', 'wpfaevent' ); ?></button>
+							<?php if ( $is_event_schedule && $has_session_filters ) : ?>
+								<a class="wpfa-schedule-filter-reset" href="<?php echo esc_url( $schedule_filter_reset_url ); ?>">
+									<?php esc_html_e( 'Reset filters', 'wpfaevent' ); ?>
+								</a>
+							<?php endif; ?>
 						</form>
 					</div>
 				<?php endif; ?>
@@ -435,12 +573,46 @@ if ( ! empty( $languages ) ) {
 
 			<?php if ( $is_event_schedule ) : ?>
 				<?php if ( ! empty( $event_session_schedule['groups'] ) ) : ?>
-					<div class="wpfa-schedule-calendar" role="list" style="<?php echo 'calendar' === $current_view ? '' : 'display:none;'; ?>">
-						<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
-							<section class="wpfa-schedule-calendar-day" role="listitem" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading">
+					<div class="wpfa-schedule-session-browser">
+						<?php if ( empty( $visible_session_groups ) ) : ?>
+							<p class="wpfa-schedule-empty-state"><?php esc_html_e( 'No sessions match the selected filters.', 'wpfaevent' ); ?></p>
+						<?php endif; ?>
+
+						<div class="wpfa-schedule-calendar" role="list" style="<?php echo 'calendar' === $current_view ? '' : 'display:none;'; ?>">
+							<?php foreach ( $visible_session_groups as $day_label => $day_sessions ) : ?>
+								<?php
+								$calendar_day_id    = sanitize_title( $day_label ) . '-calendar-heading';
+								$calendar_time_rows = array();
+
+								foreach ( $day_sessions as $day_session ) {
+									$slot_key = ! empty( $day_session['slot_key'] ) ? $day_session['slot_key'] : sanitize_title( $day_session['time_label'] );
+
+									if ( ! isset( $calendar_time_rows[ $slot_key ] ) ) {
+										$calendar_time_rows[ $slot_key ] = array(
+											'label'    => ! empty( $day_session['time_start'] ) ? $day_session['time_start'] : $day_session['time_label'],
+											'sort_key' => isset( $day_session['slot_sort_key'] ) ? (int) $day_session['slot_sort_key'] : PHP_INT_MAX,
+											'items'    => array(),
+										);
+									}
+
+									$calendar_time_rows[ $slot_key ]['items'][] = $day_session;
+								}
+
+								uasort(
+									$calendar_time_rows,
+									static function ( $slot_a, $slot_b ) {
+										if ( $slot_a['sort_key'] === $slot_b['sort_key'] ) {
+											return strcasecmp( $slot_a['label'], $slot_b['label'] );
+										}
+
+										return ( $slot_a['sort_key'] < $slot_b['sort_key'] ) ? -1 : 1;
+									}
+								);
+								?>
+								<section class="wpfa-schedule-calendar-day wpfa-schedule-day-group" role="listitem" aria-labelledby="<?php echo esc_attr( $calendar_day_id ); ?>">
 								<header class="wpfa-schedule-calendar-day-head">
-									<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-calendar-heading"><?php echo esc_html( $day_label ); ?></h2>
-									<span>
+									<h2 id="<?php echo esc_attr( $calendar_day_id ); ?>"><?php echo esc_html( $day_label ); ?></h2>
+									<span class="wpfa-schedule-group-count">
 										<?php
 										printf(
 											/* translators: %d: number of sessions on this day. */
@@ -451,57 +623,79 @@ if ( ! empty( $languages ) ) {
 									</span>
 								</header>
 								<div class="wpfa-schedule-calendar-slots">
-									<?php foreach ( $day_sessions as $item ) : ?>
-										<article class="wpfa-schedule-calendar-slot">
-											<?php if ( ! empty( $item['time_label'] ) ) : ?>
-												<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-end="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
-											<?php endif; ?>
-											<h3><?php echo esc_html( $item['title'] ); ?></h3>
-											<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
-												<ul class="wpfa-schedule-calendar-meta">
-													<?php if ( ! empty( $item['speakers'] ) ) : ?>
-														<li><?php echo esc_html( $item['speakers'] ); ?></li>
-													<?php endif; ?>
-													<?php if ( ! empty( $item['room'] ) ) : ?>
-														<li><?php echo esc_html( $item['room'] ); ?></li>
-													<?php endif; ?>
-													<?php if ( ! empty( $item['track'] ) ) : ?>
-														<li><?php echo esc_html( $item['track'] ); ?></li>
-													<?php endif; ?>
-												</ul>
-											<?php endif; ?>
-											<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
-												<?php
-												$session_calendar_label = sprintf(
-													/* translators: %s: session title. */
-													__( 'Add %s to Google Calendar', 'wpfaevent' ),
-													$item['title']
-												);
-												?>
-												<a
-													class="wpfa-schedule-session-calendar"
-													href="<?php echo esc_url( $item['calendar_url'] ); ?>"
-													target="_blank"
-													rel="noopener"
-													aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
-												>
-													<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-												</a>
-											<?php endif; ?>
-										</article>
+									<?php foreach ( $calendar_time_rows as $calendar_time_row ) : ?>
+										<section class="wpfa-schedule-calendar-row">
+											<div class="wpfa-schedule-calendar-time">
+												<?php if ( ! empty( $calendar_time_row['label'] ) ) : ?>
+													<strong><?php echo esc_html( $calendar_time_row['label'] ); ?></strong>
+												<?php endif; ?>
+												<span class="wpfa-schedule-slot-count">
+													<?php
+													printf(
+														/* translators: %d: number of sessions in this time slot. */
+														esc_html( _n( '%d session', '%d sessions', count( $calendar_time_row['items'] ), 'wpfaevent' ) ),
+														absint( count( $calendar_time_row['items'] ) )
+													);
+													?>
+												</span>
+											</div>
+											<div class="wpfa-schedule-calendar-track">
+												<?php foreach ( $calendar_time_row['items'] as $item ) : ?>
+													<article class="wpfa-schedule-calendar-slot">
+														<div class="wpfa-schedule-calendar-slot-head">
+															<h3><?php echo esc_html( $item['title'] ); ?></h3>
+															<?php if ( ! empty( $item['time_label'] ) ) : ?>
+																<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-end="<?php echo esc_attr( $item['end_datetime'] ); ?>"><?php echo esc_html( $item['time_label'] ); ?></time>
+															<?php endif; ?>
+														</div>
+														<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
+															<ul class="wpfa-schedule-calendar-meta">
+																<?php if ( ! empty( $item['speakers'] ) ) : ?>
+																	<li><?php echo esc_html( $item['speakers'] ); ?></li>
+																<?php endif; ?>
+																<?php if ( ! empty( $item['room'] ) ) : ?>
+																	<li><?php echo esc_html( $item['room'] ); ?></li>
+																<?php endif; ?>
+																<?php if ( ! empty( $item['track'] ) ) : ?>
+																	<li><?php echo esc_html( $item['track'] ); ?></li>
+																<?php endif; ?>
+															</ul>
+														<?php endif; ?>
+														<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+															<?php
+															$session_calendar_label = sprintf(
+																/* translators: %s: session title. */
+																__( 'Add %s to Google Calendar', 'wpfaevent' ),
+																$item['title']
+															);
+															?>
+															<a
+																class="wpfa-schedule-session-calendar"
+																href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+																target="_blank"
+																rel="noopener"
+																aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+															>
+																<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+															</a>
+														<?php endif; ?>
+													</article>
+												<?php endforeach; ?>
+											</div>
+										</section>
 									<?php endforeach; ?>
 								</div>
 							</section>
 						<?php endforeach; ?>
-					</div>
+						</div>
 
-					<div class="wpfa-schedule-program" style="<?php echo 'list' === $current_view ? '' : 'display:none;'; ?>">
-						<?php foreach ( $event_session_schedule['groups'] as $day_label => $day_sessions ) : ?>
-							<section class="wpfa-schedule-day" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
+						<div class="wpfa-schedule-program" style="<?php echo 'list' === $current_view ? '' : 'display:none;'; ?>">
+							<?php foreach ( $visible_session_groups as $day_label => $day_sessions ) : ?>
+								<section class="wpfa-schedule-day wpfa-schedule-day-group" aria-labelledby="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading">
 								<header class="wpfa-schedule-day-head">
 									<div>
 										<h2 id="<?php echo esc_attr( sanitize_title( $day_label ) ); ?>-heading"><?php echo esc_html( $day_label ); ?></h2>
-										<p>
+										<p class="wpfa-schedule-group-count">
 											<?php
 											printf(
 												/* translators: %d: number of sessions on this day. */
@@ -529,6 +723,13 @@ if ( ! empty( $languages ) ) {
 
 												<div class="wpfa-schedule-session-main">
 													<h3 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h3>
+													<?php if ( ! empty( $item['time_label'] ) ) : ?>
+														<p class="wpfa-schedule-session-summary-time">
+															<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-end="<?php echo esc_attr( $item['end_datetime'] ); ?>">
+																<?php echo esc_html( $item['time_label'] ); ?>
+															</time>
+														</p>
+													<?php endif; ?>
 
 													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
 														<dl class="wpfa-schedule-session-details">
@@ -578,6 +779,7 @@ if ( ! empty( $languages ) ) {
 								</section>
 							<?php endforeach; ?>
 						</div>
+					</div>
 				<?php else : ?>
 					<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
 				<?php endif; ?>

--- a/public/templates/page-schedule.php
+++ b/public/templates/page-schedule.php
@@ -488,7 +488,7 @@ $schedule_filter_reset_url = add_query_arg( $schedule_filter_reset_args, $schedu
 									aria-current="page"
 								<?php endif; ?>
 							>
-								<?php esc_html_e( 'Calendar', 'wpfaevent' ); ?>
+								<?php esc_html_e( 'Grid', 'wpfaevent' ); ?>
 							</a>
 						</nav>
 						<form class="<?php echo esc_attr( $filter_form_classes ); ?>" action="<?php echo esc_url( $schedule_page_url ); ?>" method="get">
@@ -731,46 +731,38 @@ $schedule_filter_reset_url = add_query_arg( $schedule_filter_reset_args, $schedu
 														</p>
 													<?php endif; ?>
 
-													<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
-														<dl class="wpfa-schedule-session-details">
-															<?php if ( ! empty( $item['speakers'] ) ) : ?>
-																<div class="wpfa-schedule-detail">
-																	<dt><?php esc_html_e( 'Speaker', 'wpfaevent' ); ?></dt>
-																	<dd><?php echo esc_html( $item['speakers'] ); ?></dd>
-																</div>
-															<?php endif; ?>
-															<?php if ( ! empty( $item['room'] ) ) : ?>
-																<div class="wpfa-schedule-detail">
-																	<dt><?php esc_html_e( 'Room', 'wpfaevent' ); ?></dt>
-																	<dd><?php echo esc_html( $item['room'] ); ?></dd>
-																</div>
-															<?php endif; ?>
-															<?php if ( ! empty( $item['track'] ) ) : ?>
-																<div class="wpfa-schedule-detail">
-																	<dt><?php esc_html_e( 'Track', 'wpfaevent' ); ?></dt>
-																	<dd><?php echo esc_html( $item['track'] ); ?></dd>
-																</div>
-															<?php endif; ?>
-														</dl>
+													<?php if ( ! empty( $item['room'] ) ) : ?>
+														<p class="wpfa-schedule-session-location"><?php echo esc_html( $item['room'] ); ?></p>
 													<?php endif; ?>
 
-													<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
-														<?php
-														$session_calendar_label = sprintf(
-															/* translators: %s: session title. */
-															__( 'Add %s to Google Calendar', 'wpfaevent' ),
-															$item['title']
-														);
-														?>
-														<a
-															class="wpfa-schedule-session-calendar"
-															href="<?php echo esc_url( $item['calendar_url'] ); ?>"
-															target="_blank"
-															rel="noopener"
-															aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
-														>
-															<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-														</a>
+													<?php if ( ! empty( $item['speakers'] ) ) : ?>
+														<p class="wpfa-schedule-session-speakers"><?php echo esc_html( $item['speakers'] ); ?></p>
+													<?php endif; ?>
+
+													<?php if ( ! empty( $item['track'] ) || ! empty( $item['calendar_url'] ) ) : ?>
+														<div class="wpfa-schedule-session-meta">
+															<?php if ( ! empty( $item['track'] ) ) : ?>
+																<span class="wpfa-schedule-session-track"><?php echo esc_html( $item['track'] ); ?></span>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+																<?php
+																$session_calendar_label = sprintf(
+																	/* translators: %s: session title. */
+																	__( 'Add %s to Google Calendar', 'wpfaevent' ),
+																	$item['title']
+																);
+																?>
+																<a
+																	class="wpfa-schedule-session-calendar"
+																	href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+																	target="_blank"
+																	rel="noopener"
+																	aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+																>
+																	<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+																</a>
+															<?php endif; ?>
+														</div>
 													<?php endif; ?>
 												</div>
 											</article>

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -538,7 +538,7 @@ if ( $show_ticket_widget ) {
 											aria-current="page"
 										<?php endif; ?>
 									>
-										<?php esc_html_e( 'Calendar', 'wpfaevent' ); ?>
+										<?php esc_html_e( 'Grid', 'wpfaevent' ); ?>
 									</a>
 								</nav>
 								<a href="<?php echo esc_url( $event_schedule_url ); ?>"><?php esc_html_e( 'Full Schedule', 'wpfaevent' ); ?></a>
@@ -699,46 +699,46 @@ if ( $show_ticket_widget ) {
 												<div class="wpfa-schedule-session-main">
 													<h4 class="wpfa-schedule-session-title"><?php echo esc_html( $item['title'] ); ?></h4>
 
-														<?php if ( ! empty( $item['speakers'] ) || ! empty( $item['room'] ) || ! empty( $item['track'] ) ) : ?>
-															<dl class="wpfa-schedule-session-details">
-																<?php if ( ! empty( $item['speakers'] ) ) : ?>
-																	<div class="wpfa-schedule-detail">
-																		<dt><?php esc_html_e( 'Speaker', 'wpfaevent' ); ?></dt>
-																		<dd><?php echo esc_html( $item['speakers'] ); ?></dd>
-																	</div>
-																<?php endif; ?>
-																<?php if ( ! empty( $item['room'] ) ) : ?>
-																	<div class="wpfa-schedule-detail">
-																		<dt><?php esc_html_e( 'Room', 'wpfaevent' ); ?></dt>
-																		<dd><?php echo esc_html( $item['room'] ); ?></dd>
-																	</div>
-																<?php endif; ?>
-																<?php if ( ! empty( $item['track'] ) ) : ?>
-																	<div class="wpfa-schedule-detail">
-																		<dt><?php esc_html_e( 'Track', 'wpfaevent' ); ?></dt>
-																		<dd><?php echo esc_html( $item['track'] ); ?></dd>
-																	</div>
-																<?php endif; ?>
-															</dl>
-														<?php endif; ?>
+													<?php if ( ! empty( $item['time_label'] ) ) : ?>
+														<p class="wpfa-schedule-session-summary-time">
+															<time datetime="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-start="<?php echo esc_attr( $item['start_datetime'] ); ?>" data-utc-end="<?php echo esc_attr( $item['end_datetime'] ); ?>">
+																<?php echo esc_html( $item['time_label'] ); ?>
+															</time>
+														</p>
+													<?php endif; ?>
 
-														<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
-															<?php
-															$session_calendar_label = sprintf(
-																/* translators: %s: session title. */
-																__( 'Add %s to Google Calendar', 'wpfaevent' ),
-																$item['title']
-															);
-															?>
-															<a
-																class="wpfa-schedule-session-calendar"
-																href="<?php echo esc_url( $item['calendar_url'] ); ?>"
-																target="_blank"
-																rel="noopener"
-																aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
-															>
-																<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
-															</a>
+													<?php if ( ! empty( $item['room'] ) ) : ?>
+														<p class="wpfa-schedule-session-location"><?php echo esc_html( $item['room'] ); ?></p>
+													<?php endif; ?>
+
+													<?php if ( ! empty( $item['speakers'] ) ) : ?>
+														<p class="wpfa-schedule-session-speakers"><?php echo esc_html( $item['speakers'] ); ?></p>
+													<?php endif; ?>
+
+													<?php if ( ! empty( $item['track'] ) || ! empty( $item['calendar_url'] ) ) : ?>
+														<div class="wpfa-schedule-session-meta">
+															<?php if ( ! empty( $item['track'] ) ) : ?>
+																<span class="wpfa-schedule-session-track"><?php echo esc_html( $item['track'] ); ?></span>
+															<?php endif; ?>
+															<?php if ( ! empty( $item['calendar_url'] ) ) : ?>
+																<?php
+																$session_calendar_label = sprintf(
+																	/* translators: %s: session title. */
+																	__( 'Add %s to Google Calendar', 'wpfaevent' ),
+																	$item['title']
+																);
+																?>
+																<a
+																	class="wpfa-schedule-session-calendar"
+																	href="<?php echo esc_url( $item['calendar_url'] ); ?>"
+																	target="_blank"
+																	rel="noopener"
+																	aria-label="<?php echo esc_attr( $session_calendar_label ); ?>"
+																>
+																	<?php esc_html_e( 'Add to calendar', 'wpfaevent' ); ?>
+																</a>
+															<?php endif; ?>
+														</div>
 														<?php endif; ?>
 													</div>
 												</article>

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -75,6 +75,14 @@ $dashboard_speakers                       = $event_data['dashboard_speakers'];
 $schedule_preview_items                   = $event_data['schedule_preview_items'];
 $schedule_preview_day_groups              = $event_data['schedule_preview_day_groups'];
 $schedule_hidden_count                    = $event_data['schedule_hidden_count'];
+$filtered_schedule_items                  = $event_data['filtered_schedule_items'];
+$event_session_filter_options             = $event_data['event_session_filter_options'];
+$has_schedule_filters                     = $event_data['has_schedule_filters'];
+$filter_form_classes                      = $event_data['filter_form_classes'];
+$schedule_filter_reset_url                = $event_data['schedule_filter_reset_url'];
+$current_day_filter                       = $event_data['current_day_filter'];
+$current_track_filter                     = $event_data['current_track_filter'];
+$current_room_filter                      = $event_data['current_room_filter'];
 $event_schedule_url                       = $event_data['event_schedule_url'];
 $visible_sponsor_groups                   = $event_data['visible_sponsor_groups'];
 $current_schedule_view                    = $event_data['current_schedule_view'];
@@ -534,7 +542,7 @@ if ( $show_ticket_widget ) {
 									</a>
 								</nav>
 								<a href="<?php echo esc_url( $event_schedule_url ); ?>"><?php esc_html_e( 'Full Schedule', 'wpfaevent' ); ?></a>
-								<form class="wpfa-event-timezone-form" action="<?php echo esc_url( get_permalink( $event_id ) . '#wpfa-event-schedule-title' ); ?>" method="get">
+								<form class="<?php echo esc_attr( $filter_form_classes ); ?>" action="<?php echo esc_url( get_permalink( $event_id ) . '#wpfa-event-schedule-title' ); ?>" method="get">
 									<?php if ( 'calendar' === $current_schedule_view ) : ?>
 										<input type="hidden" name="schedule_view" value="calendar">
 									<?php endif; ?>
@@ -548,7 +556,49 @@ if ( $show_ticket_widget ) {
 											<?php endforeach; ?>
 										</select>
 									</label>
-									<button type="submit"><?php esc_html_e( 'Convert', 'wpfaevent' ); ?></button>
+									<?php if ( ! empty( $event_session_filter_options['days'] ) ) : ?>
+										<label for="wpfa-event-schedule-day">
+											<span><?php esc_html_e( 'Day', 'wpfaevent' ); ?></span>
+											<select id="wpfa-event-schedule-day" class="wpfa-schedule-client-filter" name="day">
+												<option value=""><?php esc_html_e( 'All days', 'wpfaevent' ); ?></option>
+												<?php foreach ( $event_session_filter_options['days'] as $day_key => $day_label ) : ?>
+													<option value="<?php echo esc_attr( $day_key ); ?>" <?php selected( $current_day_filter, $day_key ); ?>>
+														<?php echo esc_html( $day_label ); ?>
+													</option>
+												<?php endforeach; ?>
+											</select>
+										</label>
+									<?php endif; ?>
+									<?php if ( ! empty( $event_session_filter_options['tracks'] ) ) : ?>
+										<label for="wpfa-event-schedule-track">
+											<span><?php esc_html_e( 'Track', 'wpfaevent' ); ?></span>
+											<select id="wpfa-event-schedule-track" class="wpfa-schedule-client-filter" name="track">
+												<option value=""><?php esc_html_e( 'All tracks', 'wpfaevent' ); ?></option>
+												<?php foreach ( $event_session_filter_options['tracks'] as $track_key => $track_label ) : ?>
+													<option value="<?php echo esc_attr( $track_key ); ?>" <?php selected( $current_track_filter, $track_key ); ?>>
+														<?php echo esc_html( $track_label ); ?>
+													</option>
+												<?php endforeach; ?>
+											</select>
+										</label>
+									<?php endif; ?>
+									<?php if ( ! empty( $event_session_filter_options['rooms'] ) ) : ?>
+										<label for="wpfa-event-schedule-room">
+											<span><?php esc_html_e( 'Room', 'wpfaevent' ); ?></span>
+											<select id="wpfa-event-schedule-room" class="wpfa-schedule-client-filter" name="room">
+												<option value=""><?php esc_html_e( 'All rooms', 'wpfaevent' ); ?></option>
+												<?php foreach ( $event_session_filter_options['rooms'] as $room_key => $room_label ) : ?>
+													<option value="<?php echo esc_attr( $room_key ); ?>" <?php selected( $current_room_filter, $room_key ); ?>>
+														<?php echo esc_html( $room_label ); ?>
+													</option>
+												<?php endforeach; ?>
+											</select>
+										</label>
+									<?php endif; ?>
+									<button type="submit"><?php esc_html_e( 'Apply', 'wpfaevent' ); ?></button>
+									<?php if ( $has_schedule_filters ) : ?>
+										<button type="reset" class="wpfa-schedule-filter-reset" data-reset-url="<?php echo esc_url( $schedule_filter_reset_url ); ?>"><?php esc_html_e( 'Reset filters', 'wpfaevent' ); ?></button>
+									<?php endif; ?>
 								</form>
 							</div>
 						<?php endif; ?>
@@ -709,6 +759,8 @@ if ( $show_ticket_widget ) {
 								?>
 							</p>
 						<?php endif; ?>
+					<?php elseif ( ! empty( $schedule_items ) && $has_schedule_filters && ( $current_day_filter || $current_track_filter || $current_room_filter ) && empty( $filtered_schedule_items ) ) : ?>
+						<p class="wpfa-empty-state"><?php esc_html_e( 'No sessions match the selected filters.', 'wpfaevent' ); ?></p>
 					<?php else : ?>
 						<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
 					<?php endif; ?>

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -401,6 +401,7 @@ if ( $show_ticket_widget ) {
 									$wpfa_hide_speaker_card_admin_actions = true;
 									$wpfa_schedule_display_timezone       = $selected_schedule_timezone;
 									$wpfa_featured_speaker_ids            = $featured_speaker_ids;
+									$wpfa_speaker_card_variant            = 'compact';
 									foreach ( $featured_speaker_ids as $sid ) :
 										if ( 'wpfa_speaker' !== get_post_type( $sid ) || 'publish' !== get_post_status( $sid ) ) {
 											continue;
@@ -411,6 +412,7 @@ if ( $show_ticket_widget ) {
 									unset( $wpfa_hide_speaker_card_admin_actions );
 									unset( $wpfa_schedule_display_timezone );
 									unset( $wpfa_featured_speaker_ids );
+									unset( $wpfa_speaker_card_variant );
 									?>
 								</div>
 							</div>

--- a/tests/unit/EventyaySponsorGroupsTest.php
+++ b/tests/unit/EventyaySponsorGroupsTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Unit tests for Eventyay sponsor groups.
+ *
+ * @package Wpfaevent
+ */
+
+/**
+ * Covers sponsor group naming and ordering for Eventyay imports.
+ */
+class EventyaySponsorGroupsTest extends WP_UnitTestCase {
+
+	/**
+	 * Verify JSON:API resource type does not override sponsor tier labels.
+	 */
+	public function test_normalize_eventyay_sponsor_resource_prefers_tier_fields_over_resource_type() {
+		$parser  = new Wpfaevent_JSONAPI_Parser();
+		$sponsor = $parser->normalize_eventyay_sponsor_resource(
+			array(
+				'type'       => 'sponsor',
+				'id'         => '1321',
+				'attributes' => array(
+					'name'       => 'AWS',
+					'level_name' => 'Gold Sponsors',
+					'level'      => 1,
+				),
+			),
+			array(
+				'base_url' => 'https://eventyay.com',
+			)
+		);
+
+		$this->assertSame( 'Gold Sponsors', $sponsor['type'] );
+		$this->assertSame( 1, $sponsor['level'] );
+	}
+
+	/**
+	 * Verify existing sponsor group order survives Eventyay reimports.
+	 */
+	public function test_merge_eventyay_sponsor_groups_preserves_existing_group_order() {
+		$parser   = new Wpfaevent_JSONAPI_Parser();
+		$existing = array(
+			array(
+				'group_name'         => 'Gold Sponsors',
+				'source'             => 'eventyay',
+				'eventyay_group_key' => 'gold-sponsors',
+				'sponsors'           => array(),
+			),
+			array(
+				'group_name' => 'Community Sponsors',
+				'sponsors'   => array(
+					array(
+						'name'   => 'Local Partner',
+						'type'   => 'Community Sponsors',
+						'source' => 'manual',
+					),
+				),
+			),
+			array(
+				'group_name'         => 'Platinum Sponsors',
+				'source'             => 'eventyay',
+				'eventyay_group_key' => 'platinum-sponsors',
+				'sponsors'           => array(),
+			),
+		);
+		$imported = array(
+			array(
+				'name'   => 'Acme',
+				'type'   => 'Platinum Sponsors',
+				'level'  => 1,
+				'source' => 'eventyay',
+			),
+			array(
+				'name'   => 'Beta',
+				'type'   => 'Gold Sponsors',
+				'level'  => 2,
+				'source' => 'eventyay',
+			),
+		);
+
+		$merged = $parser->merge_eventyay_sponsor_groups( $imported, $existing );
+
+		$this->assertSame( 'Gold Sponsors', $merged[0]['group_name'] );
+		$this->assertSame( 'Community Sponsors', $merged[1]['group_name'] );
+		$this->assertSame( 'Platinum Sponsors', $merged[2]['group_name'] );
+		$this->assertSame( 'Acme', $merged[2]['sponsors'][0]['name'] );
+		$this->assertSame( 'Beta', $merged[0]['sponsors'][0]['name'] );
+	}
+}

--- a/tests/unit/PartnerDashboardControllerTest.php
+++ b/tests/unit/PartnerDashboardControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Unit tests for manual partner dashboard identifiers.
+ *
+ * @package Wpfaevent
+ */
+
+/**
+ * Verify manual partner identifiers stay compatible with CRUD routing.
+ */
+class PartnerDashboardControllerTest extends WP_UnitTestCase {
+
+	/**
+	 * Manual partner IDs should already be normalized for sanitize_key() lookups.
+	 */
+	public function test_generate_manual_partner_id_returns_a_wordpress_safe_key() {
+		$controller = new Wpfaevent_Partner_Dashboard_Controller();
+		$method     = new ReflectionMethod( $controller, 'generate_manual_partner_id' );
+		$method->setAccessible( true );
+
+		$id = $method->invoke( $controller, 'sponsor' );
+
+		$this->assertStringStartsWith( 'manual-sponsor-', $id );
+		$this->assertSame( $id, sanitize_key( $id ) );
+		$this->assertMatchesRegularExpression( '/^manual-sponsor-[a-z0-9_-]+$/', $id );
+	}
+}


### PR DESCRIPTION
## Summary
- retain real Eventyay sponsor level names by preferring imported tier labels and filling missing group names from the public Eventyay sponsor listing
- add sponsor group ordering controls in the sponsor dashboard and save the selected order back to the event sponsor JSON
- preserve sponsor group order and group metadata across manual edits, deletes, and Eventyay reimports

## Testing
- composer phpcs
- composer test -- --filter EventyaySponsorGroupsTest *(blocked locally until the WordPress test database is reachable)*
- composer test *(blocked locally until the WordPress test database is reachable)*

## Screenshots / Recording
- Not captured in this environment because I do not have access to a logged-in WordPress admin session for the event dashboard UI.

Fixes #235

## Summary by Sourcery

Preserve Eventyay sponsor metadata and ordering while enhancing dashboard controls and schedule filtering and presentation.

New Features:
- Add sponsor group ordering controls to the event dashboard and persist the selected order.
- Add day, track, and room filters plus refreshed list/grid schedule presentations for event schedules.

Bug Fixes:
- Preserve imported Eventyay sponsor tier names and use the public sponsor listing to remove unpublished entries and fill missing group names.
- Preserve sponsor group names, metadata, and ordering through dashboard edits, deletions, and Eventyay reimports.
- Ensure manually created partner identifiers remain compatible with dashboard CRUD operations.

Enhancements:
- Improve sponsor group merging with stable group identity handling.
- Refresh schedule and speaker-card presentation for clearer responsive layouts.

Build:
- Pin doctrine/instantiator to version 2.0.0 and update the lockfile.
- Use the schedule stylesheet modification time for asset versioning.

Tests:
- Add coverage for Eventyay sponsor tier naming, group ordering preservation, and dashboard partner identifiers.