### PR TITLE
feat: add manual featured speaker ordering

### DIFF
--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -146,7 +146,7 @@ class Wpfaevent_Admin {
 		 * class.
 		 */
 
-		wp_enqueue_script( $this->plugin_name . '-admin', plugin_dir_url( __FILE__ ) . 'js/wpfaevent-admin.js', array( 'jquery' ), $this->version, false );
+		wp_enqueue_script( $this->plugin_name . '-admin', plugin_dir_url( __FILE__ ) . 'js/wpfaevent-admin.js', array( 'jquery', 'jquery-ui-sortable' ), $this->version, false );
 	}
 
 	/**

--- a/admin/class-wpfaevent-event-dashboard-data.php
+++ b/admin/class-wpfaevent-event-dashboard-data.php
@@ -77,6 +77,7 @@ class Wpfaevent_Event_Dashboard_Data {
 				$is_featured  = in_array( $sp_post->ID, $featured_ids, true );
 
 				$speakers_list[] = array(
+					'id'           => $sp_post->ID,
 					'name'         => $sp_post->post_title,
 					'title'        => $position,
 					'organization' => $organization,
@@ -432,7 +433,29 @@ class Wpfaevent_Event_Dashboard_Data {
 				continue;
 			}
 
+			$speaker_id = 0;
+			if ( ! empty( $speaker['eventyay_speaker_id'] ) && class_exists( 'Wpfaevent_Event_Speaker_Relation_Manager' ) ) {
+				$found = Wpfaevent_Event_Speaker_Relation_Manager::find_eventyay_speaker_post_ids( $speaker['eventyay_speaker_id'], $speaker['name'] );
+				if ( ! empty( $found ) ) {
+					$speaker_id = (int) $found[0];
+				}
+			}
+			if ( ! $speaker_id ) {
+				$posts = get_posts(
+					array(
+						'post_type'      => 'wpfa_speaker',
+						'title'          => $speaker['name'],
+						'posts_per_page' => 1,
+						'fields'         => 'ids',
+					)
+				);
+				if ( ! empty( $posts ) ) {
+					$speaker_id = (int) $posts[0];
+				}
+			}
+
 			$normalized[] = array(
+				'id'           => $speaker_id,
 				'name'         => sanitize_text_field( $speaker['name'] ),
 				'title'        => ! empty( $speaker['title'] ) ? sanitize_text_field( $speaker['title'] ) : '',
 				'organization' => ! empty( $speaker['organization'] ) ? sanitize_text_field( $speaker['organization'] ) : '',

--- a/admin/class-wpfaevent-event-dashboard-page.php
+++ b/admin/class-wpfaevent-event-dashboard-page.php
@@ -635,17 +635,39 @@ class Wpfaevent_Event_Dashboard_Page {
 			wp_send_json_error( array( 'message' => esc_html__( 'Invalid request or session expired.', 'wpfaevent' ) ), 403 );
 		}
 
-		if ( 'wpfa_event' !== get_post_type( $event_id ) || ! current_user_can( 'edit_post', $event_id ) ) {
+		if ( 'wpfa_event' !== get_post_type( $event_id ) ) {
+			wp_send_json_error( array( 'message' => esc_html__( 'The requested event is invalid.', 'wpfaevent' ) ), 400 );
+		}
+
+		if ( ! current_user_can( 'edit_post', $event_id ) ) {
 			wp_send_json_error( array( 'message' => esc_html__( 'You do not have permission to edit this event.', 'wpfaevent' ) ), 403 );
 		}
 
-		// Handle speaker IDs array input.
-		$speaker_ids = isset( $_POST['speaker_ids'] ) && is_array( $_POST['speaker_ids'] ) ? array_map( 'absint', wp_unslash( $_POST['speaker_ids'] ) ) : array();
-		$speaker_ids = array_filter( $speaker_ids );
-		$speaker_ids = array_values( array_unique( $speaker_ids ) );
+		$submitted_speaker_ids = isset( $_POST['speaker_ids'] ) && is_array( $_POST['speaker_ids'] ) ? array_map( 'absint', wp_unslash( $_POST['speaker_ids'] ) ) : array();
+		$linked_speaker_ids    = array();
+
+		if ( class_exists( 'Wpfaevent_Event_Speaker_Relation_Manager' ) ) {
+			$linked_speaker_ids = array_merge(
+				Wpfaevent_Event_Speaker_Relation_Manager::get_event_speaker_ids( $event_id ),
+				Wpfaevent_Event_Speaker_Relation_Manager::get_speakers_linked_to_event( $event_id ),
+				Wpfaevent_Event_Speaker_Relation_Manager::get_eventyay_speakers_linked_to_event( $event_id )
+			);
+			$linked_speaker_ids = Wpfaevent_Event_Speaker_Relation_Manager::sanitize_post_id_list( $linked_speaker_ids );
+		}
+
+		$valid_speaker_ids = array();
+		foreach ( $submitted_speaker_ids as $speaker_id ) {
+			if ( ! $speaker_id || in_array( $speaker_id, $valid_speaker_ids, true ) ) {
+				continue;
+			}
+
+			if ( in_array( $speaker_id, $linked_speaker_ids, true ) && 'wpfa_speaker' === get_post_type( $speaker_id ) ) {
+				$valid_speaker_ids[] = $speaker_id;
+			}
+		}
 
 		// Update post meta.
-		update_post_meta( $event_id, 'wpfa_event_featured_speakers', $speaker_ids );
+		update_post_meta( $event_id, 'wpfa_event_featured_speakers', $valid_speaker_ids );
 		update_post_meta( $event_id, 'wpfa_event_featured_speakers_manual', 'yes' );
 
 		wp_send_json_success(

--- a/admin/class-wpfaevent-event-dashboard-page.php
+++ b/admin/class-wpfaevent-event-dashboard-page.php
@@ -616,4 +616,42 @@ class Wpfaevent_Event_Dashboard_Page {
 			'display' => $display_value,
 		);
 	}
+
+	/**
+	 * Save the selected featured speakers and their exact order via AJAX.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function handle_save_featured_speakers_ajax() {
+		if ( ! Wpfaevent_Roles::current_user_can_manage_dashboard() ) {
+			wp_send_json_error( array( 'message' => esc_html__( 'You are not allowed to edit this event.', 'wpfaevent' ) ), 403 );
+		}
+
+		$event_id = isset( $_POST['event_id'] ) ? absint( wp_unslash( $_POST['event_id'] ) ) : 0;
+		$nonce    = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+
+		if ( ! $event_id || ! wp_verify_nonce( $nonce, 'wpfaevent_save_featured_speakers_' . $event_id ) ) {
+			wp_send_json_error( array( 'message' => esc_html__( 'Invalid request or session expired.', 'wpfaevent' ) ), 403 );
+		}
+
+		if ( 'wpfa_event' !== get_post_type( $event_id ) || ! current_user_can( 'edit_post', $event_id ) ) {
+			wp_send_json_error( array( 'message' => esc_html__( 'You do not have permission to edit this event.', 'wpfaevent' ) ), 403 );
+		}
+
+		// Handle speaker IDs array input.
+		$speaker_ids = isset( $_POST['speaker_ids'] ) && is_array( $_POST['speaker_ids'] ) ? array_map( 'absint', wp_unslash( $_POST['speaker_ids'] ) ) : array();
+		$speaker_ids = array_filter( $speaker_ids );
+		$speaker_ids = array_values( array_unique( $speaker_ids ) );
+
+		// Update post meta.
+		update_post_meta( $event_id, 'wpfa_event_featured_speakers', $speaker_ids );
+		update_post_meta( $event_id, 'wpfa_event_featured_speakers_manual', 'yes' );
+
+		wp_send_json_success(
+			array(
+				'message' => esc_html__( 'Featured speakers saved successfully.', 'wpfaevent' ),
+			)
+		);
+	}
 }

--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -418,7 +418,7 @@
 }
 
 /**
- * Featured Speakers Dashboard Sorting (Issue #249)
+ * Featured Speakers Dashboard Sorting
  */
 .wpfaevent-sortable-list {
 	margin: 15px 0 0;

--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -416,3 +416,39 @@
 .wpfaevent-meta-card-field.span-2 {
 	grid-column: span 2;
 }
+
+/**
+ * Featured Speakers Dashboard Sorting (Issue #249)
+ */
+.wpfaevent-sortable-list {
+	margin: 15px 0 0;
+	padding: 0;
+	list-style: none;
+}
+
+.wpfaevent-sortable-item {
+	transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.wpfaevent-sortable-item.ui-sortable-helper {
+	box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+	background: #f8fafc !important;
+	border-color: #cbd5e1 !important;
+}
+
+.wpfaevent-sortable-placeholder {
+	height: 54px;
+	border: 2px dashed #cbd5e0;
+	border-radius: 8px;
+	margin-bottom: 8px;
+	background: #f8fafc;
+}
+
+.wpfaevent-toggle-feature-btn {
+	transition: all 0.2s ease;
+}
+
+.wpfaevent-toggle-feature-btn:hover {
+	transform: scale(1.02);
+}
+

--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -451,4 +451,3 @@
 .wpfaevent-toggle-feature-btn:hover {
 	transform: scale(1.02);
 }
-

--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -418,25 +418,220 @@
 }
 
 /**
+ * Event Dashboard Layout
+ */
+.wpfaevent-dashboard-shell .wpfaevent-notice-message {
+	white-space: pre-wrap;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-dashboard-table {
+	margin-top: 12px;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-edit-field-btn--inline {
+	margin-left: 8px;
+	vertical-align: middle;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-description-section {
+	margin-top: 20px;
+	border-top: 1px solid var(--wpfa-border);
+	padding-top: 15px;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-description-heading {
+	margin-bottom: 10px;
+	font-size: 14px;
+	font-weight: 600;
+	color: #1e293b;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-description-value {
+	display: block;
+	min-height: 80px;
+	margin-bottom: 8px;
+	padding: 12px;
+	border: 1px solid #e2e8f0;
+	border-radius: 8px;
+	background: #fafafa;
+	color: #555;
+	font-size: 14px;
+	line-height: 1.5;
+	white-space: pre-wrap;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-settings-list {
+	margin: 12px 0 0 18px;
+	list-style: disc;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-dashboard-card-footer {
+	margin-top: 15px;
+	border-top: 1px solid var(--wpfa-border);
+	padding-top: 10px;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-dashboard-card-footer--spread {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-asset-placeholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 140px;
+	margin-bottom: 10px;
+	border: 1px dashed #ccc;
+	border-radius: 10px;
+	background: #fafafa;
+	color: #888;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-asset-meta {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-top: 8px;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-dashboard-card--full {
+	max-width: none;
+	margin-top: 20px;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-inline-input {
+	vertical-align: middle;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-inline-input--textarea {
+	width: 100%;
+	min-height: 120px;
+	margin-bottom: 8px;
+	font-family: inherit;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-inline-editor-form {
+	display: inline-flex;
+	gap: 6px;
+	align-items: center;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-inline-editor-form.is-textarea {
+	display: block;
+	width: 100%;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-inline-actions {
+	display: inline-flex;
+	gap: 6px;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-inline-actions--compact {
+	gap: 5px;
+}
+
+.wpfaevent-dashboard-shell .wpfaevent-inline-actions.is-textarea {
+	display: flex;
+}
+
+.wpfaevent-dashboard-shell .notice {
+	margin: 0 0 20px;
+}
+
+/**
  * Featured Speakers Dashboard Sorting
  */
-.wpfaevent-sortable-list {
+#wpfaevent-speakers .wpfaevent-featured-speakers-ordering-container {
+	margin-bottom: 20px;
+	padding-bottom: 20px;
+	border-bottom: 1px solid var(--wpfa-border);
+}
+
+#wpfaevent-speakers .wpfaevent-sortable-list {
 	margin: 15px 0 0;
 	padding: 0;
 	list-style: none;
 }
 
-.wpfaevent-sortable-item {
+#wpfaevent-speakers .wpfaevent-sortable-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 8px;
+	padding: 10px 12px;
+	border: 1px solid #e4ebf3;
+	border-radius: 8px;
+	background: #fff;
+	cursor: move;
 	transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.wpfaevent-sortable-item.ui-sortable-helper {
+#wpfaevent-speakers .wpfaevent-featured-speaker-details {
+	display: flex;
+	gap: 10px;
+	align-items: center;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-drag-handle {
+	color: #a0aec0;
+	cursor: move;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-thumbnail {
+	border-radius: 50%;
+	object-fit: cover;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-thumbnail--sortable {
+	width: 32px;
+	height: 32px;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-thumbnail--option {
+	width: 38px;
+	height: 38px;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-name {
+	font-size: 13px;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-title {
+	font-size: 11px;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-options {
+	max-height: 400px;
+	margin-top: 15px;
+	padding-right: 5px;
+	overflow-y: auto;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-option {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 8px;
+	padding: 10px 12px;
+	border: 1px solid #e4ebf3;
+	border-radius: 8px;
+	background: #fff;
+}
+
+#wpfaevent-speakers .wpfaevent-featured-speaker-option.is-featured {
+	background: #f0fdf4;
+}
+
+#wpfaevent-speakers .wpfaevent-sortable-item.ui-sortable-helper {
 	box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 	background: #f8fafc !important;
 	border-color: #cbd5e1 !important;
 }
 
-.wpfaevent-sortable-placeholder {
+#wpfaevent-speakers .wpfaevent-sortable-placeholder {
 	height: 54px;
 	border: 2px dashed #cbd5e0;
 	border-radius: 8px;
@@ -444,10 +639,28 @@
 	background: #f8fafc;
 }
 
-.wpfaevent-toggle-feature-btn {
+#wpfaevent-speakers .wpfaevent-sortable-placeholder-item {
+	padding: 15px;
+	border: 1px dashed #cbd5e0;
+	border-radius: 8px;
+	background: #f8fafc;
+	color: #718096;
+	text-align: center;
+}
+
+#wpfaevent-speakers .wpfaevent-toggle-feature-btn {
+	border-color: #d1d5db;
+	background: #fff;
+	color: #374151;
 	transition: all 0.2s ease;
 }
 
-.wpfaevent-toggle-feature-btn:hover {
+#wpfaevent-speakers .wpfaevent-toggle-feature-btn.is-featured {
+	border-color: #bbf7d0;
+	background: #e8f5e9;
+	color: #1b5e20;
+}
+
+#wpfaevent-speakers .wpfaevent-toggle-feature-btn:hover {
 	transform: scale(1.02);
 }

--- a/admin/js/wpfaevent-admin.js
+++ b/admin/js/wpfaevent-admin.js
@@ -207,6 +207,167 @@
 				}
 			});
 		}
+
+		// Featured Speakers Manual Ordering (Issue #249)
+		const $speakersSection = $('#wpfaevent-speakers');
+		if ($speakersSection.length) {
+			const $sortableList = $('#wpfaevent-featured-speakers-sortable');
+			const $allSpeakersList = $('.wpfaevent-all-speakers-container');
+			const eventId = $('.wpfaevent-dashboard-shell').data('event-id');
+			const speakersNonce = $speakersSection.data('speakers-nonce');
+
+			if ($sortableList.length && $.fn.sortable) {
+				$sortableList.sortable({
+					handle: '.dashicons-menu',
+					placeholder: 'wpfaevent-sortable-placeholder',
+					update: function() {
+						saveFeaturedSpeakersOrder();
+					}
+				});
+			}
+
+			// Handle Toggle Feature Button Click
+			$allSpeakersList.on('click', '.wpfaevent-toggle-feature-btn', function(e) {
+				e.preventDefault();
+				const $btn = $(this);
+				const speakerId = $btn.data('speaker-id');
+				const isFeatured = $btn.hasClass('is-featured');
+
+				if (isFeatured) {
+					unfeatureSpeaker(speakerId);
+				} else {
+					featureSpeaker(speakerId);
+				}
+			});
+
+			// Handle Remove Featured Button Click
+			$speakersSection.on('click', '.wpfaevent-unfeature-btn', function(e) {
+				e.preventDefault();
+				const speakerId = $(this).data('speaker-id');
+				unfeatureSpeaker(speakerId);
+			});
+
+			function featureSpeaker(speakerId) {
+				const $allCard = $(`.wpfaevent-toggle-feature-btn[data-speaker-id="${speakerId}"]`).closest('.wpfaevent-list-item');
+				if (!$allCard.length) {
+					return;
+				}
+
+				const $toggleBtn = $allCard.find('.wpfaevent-toggle-feature-btn');
+				$toggleBtn.addClass('is-featured')
+					.text('Featured')
+					.css({
+						'border-color': '#bbf7d0',
+						'background': '#e8f5e9',
+						'color': '#1b5e20'
+					});
+				$allCard.css('background', '#f0fdf4');
+
+				// Remove placeholder if it exists
+				$sortableList.find('.wpfaevent-sortable-placeholder-item').remove();
+
+				if (!$sortableList.find(`li[data-speaker-id="${speakerId}"]`).length) {
+					const name = $allCard.find('strong').text();
+					const title = $allCard.find('.description').text();
+					const imgUrl = $allCard.find('img').attr('src');
+
+					const newLi = `
+						<li class="wpfaevent-sortable-item" data-speaker-id="${speakerId}" style="display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; border: 1px solid #e4ebf3; border-radius: 8px; margin-bottom: 8px; background: #fff; cursor: move;">
+							<div style="display: flex; align-items: center; gap: 10px;">
+								<span class="dashicons dashicons-menu" style="color: #a0aec0; cursor: move;"></span>
+								${imgUrl ? `<img src="${imgUrl}" alt="${name}" style="width: 32px; height: 32px; border-radius: 50%; object-fit: cover;">` : ''}
+								<div>
+									<strong style="font-size: 13px;">${name}</strong>
+									<div class="description" style="font-size: 11px;">${title}</div>
+								</div>
+							</div>
+							<button type="button" class="button button-small wpfaevent-unfeature-btn" data-speaker-id="${speakerId}">Remove Featured</button>
+						</li>
+					`;
+					$sortableList.append(newLi);
+				}
+
+				saveFeaturedSpeakersOrder();
+			}
+
+			function unfeatureSpeaker(speakerId) {
+				const $allCard = $(`.wpfaevent-toggle-feature-btn[data-speaker-id="${speakerId}"]`).closest('.wpfaevent-list-item');
+				if ($allCard.length) {
+					const $toggleBtn = $allCard.find('.wpfaevent-toggle-feature-btn');
+					$toggleBtn.removeClass('is-featured')
+						.text('Feature')
+						.css({
+							'border-color': '#d1d5db',
+							'background': '#fff',
+							'color': '#374151'
+						});
+					$allCard.css('background', '#fff');
+				}
+
+				$sortableList.find(`li[data-speaker-id="${speakerId}"]`).remove();
+
+				if ($sortableList.find('.wpfaevent-sortable-item').length === 0) {
+					const placeholder = `
+						<li class="wpfaevent-sortable-placeholder-item" style="padding: 15px; text-align: center; border: 1px dashed #cbd5e0; border-radius: 8px; color: #718096; background: #f8fafc;">
+							No featured speakers. Toggle featured status on speakers below to add them.
+						</li>
+					`;
+					$sortableList.html(placeholder);
+				}
+
+				saveFeaturedSpeakersOrder();
+			}
+
+			function saveFeaturedSpeakersOrder() {
+				const speakerIds = [];
+				$sortableList.find('.wpfaevent-sortable-item').each(function() {
+					const id = $(this).data('speaker-id');
+					if (id) {
+						speakerIds.push(id);
+					}
+				});
+
+				$.ajax({
+					url: ajaxurl,
+					type: 'POST',
+					data: {
+						action: 'wpfaevent_save_featured_speakers',
+						event_id: eventId,
+						speaker_ids: speakerIds,
+						nonce: speakersNonce
+					},
+					success: function(response) {
+						if (response.success) {
+							drawDashboardNotice('success', response.data.message);
+						} else {
+							drawDashboardNotice('error', response.data.message || 'Failed to save featured speakers.');
+						}
+					},
+					error: function() {
+						drawDashboardNotice('error', 'An error occurred while saving.');
+					}
+				});
+			}
+
+			function drawDashboardNotice(type, message) {
+				const container = document.querySelector('.wpfaevent-notification-container') || document.querySelector('.wpfaevent-dashboard-shell');
+				if (!container) return;
+
+				const notice = document.createElement('div');
+				notice.className = 'notice notice-' + type + ' is-dismissible';
+				notice.style.margin = '0 0 20px';
+				const p = document.createElement('p');
+				p.textContent = message;
+				notice.appendChild(p);
+
+				const existing = container.querySelectorAll('.notice.wpfaevent-edit-notice');
+				existing.forEach(el => el.remove());
+
+				notice.classList.add('wpfaevent-edit-notice');
+				container.insertBefore(notice, container.firstChild);
+				notice.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+			}
+		}
 	});
 
 	function getEventTitle(event) {

--- a/admin/js/wpfaevent-admin.js
+++ b/admin/js/wpfaevent-admin.js
@@ -215,104 +215,203 @@
 			const $allSpeakersList = $('.wpfaevent-all-speakers-container');
 			const eventId = $('.wpfaevent-dashboard-shell').data('event-id');
 			const speakersNonce = $speakersSection.data('speakers-nonce');
+			let saveInProgress = false;
+			let queuedSpeakerIds = null;
+			let latestSaveRevision = 0;
 
 			if ($sortableList.length && $.fn.sortable) {
 				$sortableList.sortable({
 					handle: '.dashicons-menu',
 					placeholder: 'wpfaevent-sortable-placeholder',
-					update: function() {
+					update() {
 						saveFeaturedSpeakersOrder();
-					}
+					},
 				});
 			}
 
 			// Handle Toggle Feature Button Click
-			$allSpeakersList.on('click', '.wpfaevent-toggle-feature-btn', function(e) {
-				e.preventDefault();
-				const $btn = $(this);
-				const speakerId = $btn.data('speaker-id');
-				const isFeatured = $btn.hasClass('is-featured');
+			$allSpeakersList.on(
+				'click',
+				'.wpfaevent-toggle-feature-btn',
+				function (e) {
+					e.preventDefault();
+					const $btn = $(this);
+					const speakerId = $btn.data('speaker-id');
+					const isFeatured = $btn.hasClass('is-featured');
 
-				if (isFeatured) {
-					unfeatureSpeaker(speakerId);
-				} else {
-					featureSpeaker(speakerId);
+					if (isFeatured) {
+						unfeatureSpeaker(speakerId);
+					} else {
+						featureSpeaker(speakerId);
+					}
 				}
-			});
+			);
 
 			// Handle Remove Featured Button Click
-			$speakersSection.on('click', '.wpfaevent-unfeature-btn', function(e) {
-				e.preventDefault();
-				const speakerId = $(this).data('speaker-id');
-				unfeatureSpeaker(speakerId);
-			});
+			$speakersSection.on(
+				'click',
+				'.wpfaevent-unfeature-btn',
+				function (e) {
+					e.preventDefault();
+					const speakerId = $(this).data('speaker-id');
+					unfeatureSpeaker(speakerId);
+				}
+			);
 
 			function featureSpeaker(speakerId) {
-				const $allCard = $(`.wpfaevent-toggle-feature-btn[data-speaker-id="${speakerId}"]`).closest('.wpfaevent-list-item');
+				speakerId = normalizeSpeakerId(speakerId);
+				if (!speakerId) {
+					return;
+				}
+
+				const $allCard = findSpeakerElement(
+					$allSpeakersList.find('.wpfaevent-toggle-feature-btn'),
+					speakerId
+				).closest('.wpfaevent-list-item');
 				if (!$allCard.length) {
 					return;
 				}
 
-				const $toggleBtn = $allCard.find('.wpfaevent-toggle-feature-btn');
-				$toggleBtn.addClass('is-featured')
-					.text('Featured')
-					.css({
-						'border-color': '#bbf7d0',
-						'background': '#e8f5e9',
-						'color': '#1b5e20'
-					});
+				const $toggleBtn = $allCard.find(
+					'.wpfaevent-toggle-feature-btn'
+				);
+				$toggleBtn.addClass('is-featured').text('Featured').css({
+					'border-color': '#bbf7d0',
+					background: '#e8f5e9',
+					color: '#1b5e20',
+				});
 				$allCard.css('background', '#f0fdf4');
 
 				// Remove placeholder if it exists
-				$sortableList.find('.wpfaevent-sortable-placeholder-item').remove();
+				$sortableList
+					.find('.wpfaevent-sortable-placeholder-item')
+					.remove();
 
-				if (!$sortableList.find(`li[data-speaker-id="${speakerId}"]`).length) {
+				if (
+					!findSpeakerElement(
+						$sortableList.find('.wpfaevent-sortable-item'),
+						speakerId
+					).length
+				) {
 					const name = $allCard.find('strong').text();
 					const title = $allCard.find('.description').text();
-					const imgUrl = $allCard.find('img').attr('src');
+					const imgUrl = getSafeImageUrl(
+						$allCard.find('img').attr('src')
+					);
+					const $newLi = $('<li>')
+						.addClass('wpfaevent-sortable-item')
+						.attr('data-speaker-id', speakerId)
+						.css({
+							display: 'flex',
+							'align-items': 'center',
+							'justify-content': 'space-between',
+							padding: '10px 12px',
+							border: '1px solid #e4ebf3',
+							'border-radius': '8px',
+							'margin-bottom': '8px',
+							background: '#fff',
+							cursor: 'move',
+						});
+					const $speakerSummary = $('<div>').css({
+						display: 'flex',
+						'align-items': 'center',
+						gap: '10px',
+					});
 
-					const newLi = `
-						<li class="wpfaevent-sortable-item" data-speaker-id="${speakerId}" style="display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; border: 1px solid #e4ebf3; border-radius: 8px; margin-bottom: 8px; background: #fff; cursor: move;">
-							<div style="display: flex; align-items: center; gap: 10px;">
-								<span class="dashicons dashicons-menu" style="color: #a0aec0; cursor: move;"></span>
-								${imgUrl ? `<img src="${imgUrl}" alt="${name}" style="width: 32px; height: 32px; border-radius: 50%; object-fit: cover;">` : ''}
-								<div>
-									<strong style="font-size: 13px;">${name}</strong>
-									<div class="description" style="font-size: 11px;">${title}</div>
-								</div>
-							</div>
-							<button type="button" class="button button-small wpfaevent-unfeature-btn" data-speaker-id="${speakerId}">Remove Featured</button>
-						</li>
-					`;
-					$sortableList.append(newLi);
+					$speakerSummary.append(
+						$('<span>')
+							.addClass('dashicons dashicons-menu')
+							.css({ color: '#a0aec0', cursor: 'move' })
+					);
+
+					if (imgUrl) {
+						$speakerSummary.append(
+							$('<img>').attr({ src: imgUrl, alt: name }).css({
+								width: '32px',
+								height: '32px',
+								'border-radius': '50%',
+								'object-fit': 'cover',
+							})
+						);
+					}
+
+					$speakerSummary.append(
+						$('<div>')
+							.append(
+								$('<strong>')
+									.css('font-size', '13px')
+									.text(name)
+							)
+							.append(
+								$('<div>')
+									.addClass('description')
+									.css('font-size', '11px')
+									.text(title)
+							)
+					);
+
+					$newLi.append($speakerSummary).append(
+						$('<button>')
+							.attr({
+								type: 'button',
+								'data-speaker-id': speakerId,
+							})
+							.addClass(
+								'button button-small wpfaevent-unfeature-btn'
+							)
+							.text('Remove Featured')
+					);
+					$sortableList.append($newLi);
 				}
 
 				saveFeaturedSpeakersOrder();
 			}
 
 			function unfeatureSpeaker(speakerId) {
-				const $allCard = $(`.wpfaevent-toggle-feature-btn[data-speaker-id="${speakerId}"]`).closest('.wpfaevent-list-item');
+				speakerId = normalizeSpeakerId(speakerId);
+				if (!speakerId) {
+					return;
+				}
+
+				const $allCard = findSpeakerElement(
+					$allSpeakersList.find('.wpfaevent-toggle-feature-btn'),
+					speakerId
+				).closest('.wpfaevent-list-item');
 				if ($allCard.length) {
-					const $toggleBtn = $allCard.find('.wpfaevent-toggle-feature-btn');
-					$toggleBtn.removeClass('is-featured')
-						.text('Feature')
-						.css({
-							'border-color': '#d1d5db',
-							'background': '#fff',
-							'color': '#374151'
-						});
+					const $toggleBtn = $allCard.find(
+						'.wpfaevent-toggle-feature-btn'
+					);
+					$toggleBtn.removeClass('is-featured').text('Feature').css({
+						'border-color': '#d1d5db',
+						background: '#fff',
+						color: '#374151',
+					});
 					$allCard.css('background', '#fff');
 				}
 
-				$sortableList.find(`li[data-speaker-id="${speakerId}"]`).remove();
+				findSpeakerElement(
+					$sortableList.find('.wpfaevent-sortable-item'),
+					speakerId
+				).remove();
 
-				if ($sortableList.find('.wpfaevent-sortable-item').length === 0) {
-					const placeholder = `
-						<li class="wpfaevent-sortable-placeholder-item" style="padding: 15px; text-align: center; border: 1px dashed #cbd5e0; border-radius: 8px; color: #718096; background: #f8fafc;">
-							No featured speakers. Toggle featured status on speakers below to add them.
-						</li>
-					`;
-					$sortableList.html(placeholder);
+				if (
+					$sortableList.find('.wpfaevent-sortable-item').length === 0
+				) {
+					$sortableList.empty().append(
+						$('<li>')
+							.addClass('wpfaevent-sortable-placeholder-item')
+							.css({
+								padding: '15px',
+								'text-align': 'center',
+								border: '1px dashed #cbd5e0',
+								'border-radius': '8px',
+								color: '#718096',
+								background: '#f8fafc',
+							})
+							.text(
+								'No featured speakers. Toggle featured status on speakers below to add them.'
+							)
+					);
 				}
 
 				saveFeaturedSpeakersOrder();
@@ -320,12 +419,31 @@
 
 			function saveFeaturedSpeakersOrder() {
 				const speakerIds = [];
-				$sortableList.find('.wpfaevent-sortable-item').each(function() {
-					const id = $(this).data('speaker-id');
-					if (id) {
-						speakerIds.push(id);
-					}
-				});
+				$sortableList
+					.find('.wpfaevent-sortable-item')
+					.each(function () {
+						const id = normalizeSpeakerId(
+							$(this).attr('data-speaker-id')
+						);
+						if (id) {
+							speakerIds.push(id);
+						}
+					});
+				queuedSpeakerIds = speakerIds;
+				latestSaveRevision++;
+				processFeaturedSpeakersSave();
+			}
+
+			function processFeaturedSpeakersSave() {
+				if (saveInProgress || queuedSpeakerIds === null) {
+					return;
+				}
+
+				const speakerIds = queuedSpeakerIds;
+				const saveRevision = latestSaveRevision;
+				let saveResult = null;
+				queuedSpeakerIds = null;
+				saveInProgress = true;
 
 				$.ajax({
 					url: ajaxurl,
@@ -334,24 +452,86 @@
 						action: 'wpfaevent_save_featured_speakers',
 						event_id: eventId,
 						speaker_ids: speakerIds,
-						nonce: speakersNonce
+						nonce: speakersNonce,
 					},
-					success: function(response) {
+					success(response) {
 						if (response.success) {
-							drawDashboardNotice('success', response.data.message);
+							saveResult = {
+								type: 'success',
+								message: response.data.message,
+							};
 						} else {
-							drawDashboardNotice('error', response.data.message || 'Failed to save featured speakers.');
+							saveResult = {
+								type: 'error',
+								message:
+									response.data.message ||
+									'Failed to save featured speakers.',
+							};
 						}
 					},
-					error: function() {
-						drawDashboardNotice('error', 'An error occurred while saving.');
-					}
+					error() {
+						saveResult = {
+							type: 'error',
+							message: 'An error occurred while saving.',
+						};
+					},
+					complete() {
+						saveInProgress = false;
+
+						if (queuedSpeakerIds !== null) {
+							processFeaturedSpeakersSave();
+							return;
+						}
+
+						if (saveRevision === latestSaveRevision && saveResult) {
+							drawDashboardNotice(
+								saveResult.type,
+								saveResult.message
+							);
+						}
+					},
 				});
 			}
 
+			function normalizeSpeakerId(speakerId) {
+				const normalized = Number(speakerId);
+				return Number.isSafeInteger(normalized) && normalized > 0
+					? normalized
+					: 0;
+			}
+
+			function findSpeakerElement($elements, speakerId) {
+				return $elements.filter(function () {
+					return (
+						normalizeSpeakerId($(this).attr('data-speaker-id')) ===
+						speakerId
+					);
+				});
+			}
+
+			function getSafeImageUrl(imageUrl) {
+				if (!imageUrl) {
+					return '';
+				}
+
+				try {
+					const parsedUrl = new URL(imageUrl, document.baseURI);
+					return ['http:', 'https:'].includes(parsedUrl.protocol)
+						? parsedUrl.href
+						: '';
+				} catch {
+					return '';
+				}
+			}
+
 			function drawDashboardNotice(type, message) {
-				const container = document.querySelector('.wpfaevent-notification-container') || document.querySelector('.wpfaevent-dashboard-shell');
-				if (!container) return;
+				const container =
+					document.querySelector(
+						'.wpfaevent-notification-container'
+					) || document.querySelector('.wpfaevent-dashboard-shell');
+				if (!container) {
+					return;
+				}
 
 				const notice = document.createElement('div');
 				notice.className = 'notice notice-' + type + ' is-dismissible';
@@ -360,8 +540,10 @@
 				p.textContent = message;
 				notice.appendChild(p);
 
-				const existing = container.querySelectorAll('.notice.wpfaevent-edit-notice');
-				existing.forEach(el => el.remove());
+				const existing = container.querySelectorAll(
+					'.notice.wpfaevent-edit-notice'
+				);
+				existing.forEach((el) => el.remove());
 
 				notice.classList.add('wpfaevent-edit-notice');
 				container.insertBefore(notice, container.firstChild);

--- a/admin/js/wpfaevent-admin.js
+++ b/admin/js/wpfaevent-admin.js
@@ -208,7 +208,7 @@
 			});
 		}
 
-		// Featured Speakers Manual Ordering (Issue #249)
+		// Featured Speakers Manual Ordering
 		const $speakersSection = $('#wpfaevent-speakers');
 		if ($speakersSection.length) {
 			const $sortableList = $('#wpfaevent-featured-speakers-sortable');
@@ -275,12 +275,8 @@
 				const $toggleBtn = $allCard.find(
 					'.wpfaevent-toggle-feature-btn'
 				);
-				$toggleBtn.addClass('is-featured').text('Featured').css({
-					'border-color': '#bbf7d0',
-					background: '#e8f5e9',
-					color: '#1b5e20',
-				});
-				$allCard.css('background', '#f0fdf4');
+				$toggleBtn.addClass('is-featured').text('Featured');
+				$allCard.addClass('is-featured');
 
 				// Remove placeholder if it exists
 				$sortableList
@@ -300,52 +296,40 @@
 					);
 					const $newLi = $('<li>')
 						.addClass('wpfaevent-sortable-item')
-						.attr('data-speaker-id', speakerId)
-						.css({
-							display: 'flex',
-							'align-items': 'center',
-							'justify-content': 'space-between',
-							padding: '10px 12px',
-							border: '1px solid #e4ebf3',
-							'border-radius': '8px',
-							'margin-bottom': '8px',
-							background: '#fff',
-							cursor: 'move',
-						});
-					const $speakerSummary = $('<div>').css({
-						display: 'flex',
-						'align-items': 'center',
-						gap: '10px',
-					});
+						.attr('data-speaker-id', speakerId);
+					const $speakerSummary = $('<div>').addClass(
+						'wpfaevent-featured-speaker-details'
+					);
 
 					$speakerSummary.append(
-						$('<span>')
-							.addClass('dashicons dashicons-menu')
-							.css({ color: '#a0aec0', cursor: 'move' })
+						$('<span>').addClass(
+							'dashicons dashicons-menu wpfaevent-featured-speaker-drag-handle'
+						)
 					);
 
 					if (imgUrl) {
 						$speakerSummary.append(
-							$('<img>').attr({ src: imgUrl, alt: name }).css({
-								width: '32px',
-								height: '32px',
-								'border-radius': '50%',
-								'object-fit': 'cover',
-							})
+							$('<img>')
+								.attr({ src: imgUrl, alt: name })
+								.addClass(
+									'wpfaevent-featured-speaker-thumbnail wpfaevent-featured-speaker-thumbnail--sortable'
+								)
 						);
 					}
 
 					$speakerSummary.append(
 						$('<div>')
+							.addClass('wpfaevent-featured-speaker-copy')
 							.append(
 								$('<strong>')
-									.css('font-size', '13px')
+									.addClass('wpfaevent-featured-speaker-name')
 									.text(name)
 							)
 							.append(
 								$('<div>')
-									.addClass('description')
-									.css('font-size', '11px')
+									.addClass(
+										'description wpfaevent-featured-speaker-title'
+									)
 									.text(title)
 							)
 					);
@@ -381,12 +365,8 @@
 					const $toggleBtn = $allCard.find(
 						'.wpfaevent-toggle-feature-btn'
 					);
-					$toggleBtn.removeClass('is-featured').text('Feature').css({
-						'border-color': '#d1d5db',
-						background: '#fff',
-						color: '#374151',
-					});
-					$allCard.css('background', '#fff');
+					$toggleBtn.removeClass('is-featured').text('Feature');
+					$allCard.removeClass('is-featured');
 				}
 
 				findSpeakerElement(
@@ -397,21 +377,15 @@
 				if (
 					$sortableList.find('.wpfaevent-sortable-item').length === 0
 				) {
-					$sortableList.empty().append(
-						$('<li>')
-							.addClass('wpfaevent-sortable-placeholder-item')
-							.css({
-								padding: '15px',
-								'text-align': 'center',
-								border: '1px dashed #cbd5e0',
-								'border-radius': '8px',
-								color: '#718096',
-								background: '#f8fafc',
-							})
-							.text(
-								'No featured speakers. Toggle featured status on speakers below to add them.'
-							)
-					);
+					$sortableList
+						.empty()
+						.append(
+							$('<li>')
+								.addClass('wpfaevent-sortable-placeholder-item')
+								.text(
+									'No featured speakers. Toggle featured status on speakers below to add them.'
+								)
+						);
 				}
 
 				saveFeaturedSpeakersOrder();
@@ -535,7 +509,6 @@
 
 				const notice = document.createElement('div');
 				notice.className = 'notice notice-' + type + ' is-dismissible';
-				notice.style.margin = '0 0 20px';
 				const p = document.createElement('p');
 				p.textContent = message;
 				notice.appendChild(p);

--- a/admin/partials/event-dashboard.php
+++ b/admin/partials/event-dashboard.php
@@ -343,7 +343,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 				<div class="wpfaevent-featured-speakers-ordering-container" style="margin-bottom: 20px; border-bottom: 1px solid var(--wpfa-border); padding-bottom: 20px;">
 					<h3><?php esc_html_e( 'Featured Speakers Order (Drag to Reorder)', 'wpfaevent' ); ?></h3>
 					<p class="description"><?php esc_html_e( 'Drag and drop featured speakers to set their exact order on the public page.', 'wpfaevent' ); ?></p>
-					
+
 					<ul id="wpfaevent-featured-speakers-sortable" class="wpfaevent-sortable-list" style="margin: 15px 0 0; padding: 0; list-style: none;">
 						<?php
 						$saved_featured_ids = class_exists( 'Wpfaevent_Event_Speaker_Relation_Manager' ) ? Wpfaevent_Event_Speaker_Relation_Manager::get_event_featured_speaker_ids( $event['id'] ) : array();
@@ -399,7 +399,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 				<div class="wpfaevent-all-speakers-container">
 					<h3><?php esc_html_e( 'All Event Speakers', 'wpfaevent' ); ?></h3>
 					<p class="description"><?php esc_html_e( 'Mark speakers as featured to show them in the featured speakers list.', 'wpfaevent' ); ?></p>
-					
+
 					<div class="wpfaevent-list" style="margin-top: 15px; max-height: 400px; overflow-y: auto; padding-right: 5px;">
 						<?php
 						foreach ( $speakers as $speaker ) :

--- a/admin/partials/event-dashboard.php
+++ b/admin/partials/event-dashboard.php
@@ -334,42 +334,111 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 	</div>
 
 	<div class="wpfaevent-dashboard-split">
-		<div id="wpfaevent-speakers" class="wpfaevent-dashboard-card wpfaevent-dashboard-section">
+		<div id="wpfaevent-speakers" class="wpfaevent-dashboard-card wpfaevent-dashboard-section" data-speakers-nonce="<?php echo esc_attr( wp_create_nonce( 'wpfaevent_save_featured_speakers_' . $event['id'] ) ); ?>">
 			<h2><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h2>
 			<?php if ( ! empty( $speakers ) ) : ?>
 				<?php $total_speakers_count = count( $speakers ); ?>
-				<div class="wpfaevent-list">
-					<?php foreach ( array_slice( $speakers, 0, 5 ) as $speaker ) : ?>
-						<div class="wpfaevent-list-item">
-							<?php if ( ! empty( $speaker['image'] ) ) : ?>
-								<img src="<?php echo esc_url( $speaker['image'] ); ?>" alt="<?php echo esc_attr( $speaker['name'] ); ?>">
-							<?php endif; ?>
-							<div class="wpfaevent-list-copy">
-								<strong><?php echo esc_html( $speaker['name'] ); ?></strong>
-								<div class="description"><?php echo esc_html( trim( $speaker['title'] . ( $speaker['organization'] ? ' - ' . $speaker['organization'] : '' ) ) ); ?></div>
-							</div>
-							<?php if ( ! empty( $speaker['featured'] ) ) : ?>
-								<span class="wpfaevent-badge"><?php esc_html_e( 'Featured', 'wpfaevent' ); ?></span>
-							<?php endif; ?>
-						</div>
-					<?php endforeach; ?>
+
+				<!-- Section for Featured Speakers Ordering -->
+				<div class="wpfaevent-featured-speakers-ordering-container" style="margin-bottom: 20px; border-bottom: 1px solid var(--wpfa-border); padding-bottom: 20px;">
+					<h3><?php esc_html_e( 'Featured Speakers Order (Drag to Reorder)', 'wpfaevent' ); ?></h3>
+					<p class="description"><?php esc_html_e( 'Drag and drop featured speakers to set their exact order on the public page.', 'wpfaevent' ); ?></p>
+					
+					<ul id="wpfaevent-featured-speakers-sortable" class="wpfaevent-sortable-list" style="margin: 15px 0 0; padding: 0; list-style: none;">
+						<?php
+						$saved_featured_ids = class_exists( 'Wpfaevent_Event_Speaker_Relation_Manager' ) ? Wpfaevent_Event_Speaker_Relation_Manager::get_event_featured_speaker_ids( $event['id'] ) : array();
+
+						$featured_by_id = array();
+						foreach ( $speakers as $speaker ) {
+							if ( ! empty( $speaker['id'] ) ) {
+								$featured_by_id[ $speaker['id'] ] = $speaker;
+							}
+						}
+
+						$ordered_featured = array();
+						foreach ( $saved_featured_ids as $fid ) {
+							if ( isset( $featured_by_id[ $fid ] ) ) {
+								$ordered_featured[] = $featured_by_id[ $fid ];
+								unset( $featured_by_id[ $fid ] );
+							}
+						}
+						foreach ( $speakers as $speaker ) {
+							if ( ! empty( $speaker['featured'] ) && ! empty( $speaker['id'] ) && isset( $featured_by_id[ $speaker['id'] ] ) ) {
+								$ordered_featured[] = $speaker;
+							}
+						}
+
+						if ( ! empty( $ordered_featured ) ) :
+							foreach ( $ordered_featured as $fs ) :
+								$fs_id    = isset( $fs['id'] ) ? $fs['id'] : '';
+								$fs_image = ! empty( $fs['image'] ) ? $fs['image'] : ( defined( 'WPFAEVENT_URL' ) ? WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg' : '' );
+								?>
+								<li class="wpfaevent-sortable-item" data-speaker-id="<?php echo esc_attr( (string) $fs_id ); ?>" style="display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; border: 1px solid #e4ebf3; border-radius: 8px; margin-bottom: 8px; background: #fff; cursor: move;">
+									<div style="display: flex; align-items: center; gap: 10px;">
+										<span class="dashicons dashicons-menu" style="color: #a0aec0; cursor: move;"></span>
+										<?php if ( $fs_image ) : ?>
+											<img src="<?php echo esc_url( $fs_image ); ?>" alt="<?php echo esc_attr( $fs['name'] ); ?>" style="width: 32px; height: 32px; border-radius: 50%; object-fit: cover;">
+										<?php endif; ?>
+										<div>
+											<strong style="font-size: 13px;"><?php echo esc_html( $fs['name'] ); ?></strong>
+											<div class="description" style="font-size: 11px;"><?php echo esc_html( trim( $fs['title'] ) ); ?></div>
+										</div>
+									</div>
+									<button type="button" class="button button-small wpfaevent-unfeature-btn" data-speaker-id="<?php echo esc_attr( (string) $fs_id ); ?>"><?php esc_html_e( 'Remove Featured', 'wpfaevent' ); ?></button>
+								</li>
+							<?php endforeach; ?>
+						<?php else : ?>
+							<li class="wpfaevent-sortable-placeholder-item" style="padding: 15px; text-align: center; border: 1px dashed #cbd5e0; border-radius: 8px; color: #718096; background: #f8fafc;">
+								<?php esc_html_e( 'No featured speakers. Toggle featured status on speakers below to add them.', 'wpfaevent' ); ?>
+							</li>
+						<?php endif; ?>
+					</ul>
 				</div>
+
+				<!-- Section for All Speakers -->
+				<div class="wpfaevent-all-speakers-container">
+					<h3><?php esc_html_e( 'All Event Speakers', 'wpfaevent' ); ?></h3>
+					<p class="description"><?php esc_html_e( 'Mark speakers as featured to show them in the featured speakers list.', 'wpfaevent' ); ?></p>
+					
+					<div class="wpfaevent-list" style="margin-top: 15px; max-height: 400px; overflow-y: auto; padding-right: 5px;">
+						<?php
+						foreach ( $speakers as $speaker ) :
+							$sp_id          = isset( $speaker['id'] ) ? $speaker['id'] : '';
+							$sp_image       = ! empty( $speaker['image'] ) ? $speaker['image'] : ( defined( 'WPFAEVENT_URL' ) ? WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg' : '' );
+							$is_sp_featured = ! empty( $speaker['featured'] );
+							?>
+							<div class="wpfaevent-list-item" style="display: flex; justify-content: space-between; align-items: center; padding: 10px 12px; border: 1px solid #e4ebf3; border-radius: 8px; margin-bottom: 8px; background: <?php echo $is_sp_featured ? '#f0fdf4' : '#fff'; ?>;">
+								<div style="display: flex; align-items: center; gap: 10px;">
+									<?php if ( $sp_image ) : ?>
+										<img src="<?php echo esc_url( $sp_image ); ?>" alt="<?php echo esc_attr( $speaker['name'] ); ?>" style="width: 38px; height: 38px; border-radius: 50%; object-fit: cover;">
+									<?php endif; ?>
+									<div>
+										<strong style="font-size: 13px;"><?php echo esc_html( $speaker['name'] ); ?></strong>
+										<div class="description" style="font-size: 11px;"><?php echo esc_html( trim( $speaker['title'] . ( $speaker['organization'] ? ' - ' . $speaker['organization'] : '' ) ) ); ?></div>
+									</div>
+								</div>
+								<div>
+									<?php if ( ! empty( $sp_id ) ) : ?>
+										<?php if ( $is_sp_featured ) : ?>
+											<button type="button" class="button button-small wpfaevent-toggle-feature-btn is-featured" data-speaker-id="<?php echo esc_attr( (string) $sp_id ); ?>" style="border-color: #bbf7d0; background: #e8f5e9; color: #1b5e20;"><?php esc_html_e( 'Featured', 'wpfaevent' ); ?></button>
+										<?php else : ?>
+											<button type="button" class="button button-small wpfaevent-toggle-feature-btn" data-speaker-id="<?php echo esc_attr( (string) $sp_id ); ?>" style="border-color: #d1d5db; background: #fff; color: #374151;"><?php esc_html_e( 'Feature', 'wpfaevent' ); ?></button>
+										<?php endif; ?>
+									<?php endif; ?>
+								</div>
+							</div>
+						<?php endforeach; ?>
+					</div>
+				</div>
+
 				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px; display: flex; justify-content: space-between; align-items: center;">
 					<span class="description">
 						<?php
-						if ( $total_speakers_count <= 5 ) {
-							printf(
-								/* translators: %d: count of speakers */
-								esc_html( _n( 'Showing %d speaker', 'Showing %d speakers', $total_speakers_count, 'wpfaevent' ) ),
-								absint( $total_speakers_count )
-							);
-						} else {
-							printf(
-								/* translators: %d: count of speakers */
-								esc_html__( 'Showing 5 of %d speakers', 'wpfaevent' ),
-								absint( $total_speakers_count )
-							);
-						}
+						printf(
+							/* translators: %d: count of speakers */
+							esc_html( _n( 'Total: %d speaker', 'Total: %d speakers', $total_speakers_count, 'wpfaevent' ) ),
+							absint( $total_speakers_count )
+						);
 						?>
 					</span>
 					<a class="wpfaevent-module-link" href="<?php echo esc_url( $module_urls['speakers'] ); ?>">

--- a/admin/partials/event-dashboard.php
+++ b/admin/partials/event-dashboard.php
@@ -36,7 +36,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 		<div class="wpfaevent-notification-container"></div>
 		<?php if ( ! empty( $dashboard_notice['message'] ) ) : ?>
 			<div class="notice notice-<?php echo esc_attr( ! empty( $dashboard_notice['type'] ) ? $dashboard_notice['type'] : 'info' ); ?> is-dismissible">
-				<p style="white-space: pre-wrap;"><?php echo esc_html( $dashboard_notice['message'] ); ?></p>
+				<p class="wpfaevent-notice-message"><?php echo esc_html( $dashboard_notice['message'] ); ?></p>
 			</div>
 		<?php endif; ?>
 	<h1>
@@ -106,7 +106,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 	<div id="wpfaevent-overview" class="wpfaevent-dashboard-columns wpfaevent-dashboard-section">
 		<div class="wpfaevent-dashboard-card">
 			<h2><?php esc_html_e( 'Event Overview', 'wpfaevent' ); ?></h2>
-			<table class="widefat striped" style="margin-top:12px;">
+			<table class="widefat striped wpfaevent-dashboard-table">
 				<tbody>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Status', 'wpfaevent' ); ?></th>
@@ -121,7 +121,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 						<td>
 							<div class="wpfaevent-field-container">
 								<span class="wpfaevent-field-value"><?php echo esc_html( ! empty( $event['start_date'] ) ? $event['start_date'] : __( 'Not set', 'wpfaevent' ) ); ?></span>
-								<button type="button" class="wpfaevent-edit-field-btn button button-small button-link" style="margin-left: 8px;"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
+								<button type="button" class="wpfaevent-edit-field-btn wpfaevent-edit-field-btn--inline button button-small button-link"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
 							</div>
 						</td>
 					</tr>
@@ -130,7 +130,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 						<td>
 							<div class="wpfaevent-field-container">
 								<span class="wpfaevent-field-value"><?php echo esc_html( ! empty( $event['end_date'] ) ? $event['end_date'] : __( 'Not set', 'wpfaevent' ) ); ?></span>
-								<button type="button" class="wpfaevent-edit-field-btn button button-small button-link" style="margin-left: 8px;"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
+								<button type="button" class="wpfaevent-edit-field-btn wpfaevent-edit-field-btn--inline button button-small button-link"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
 							</div>
 						</td>
 					</tr>
@@ -143,7 +143,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 						<td>
 							<div class="wpfaevent-field-container">
 								<span class="wpfaevent-field-value"><?php echo esc_html( ! empty( $event['location'] ) ? $event['location'] : __( 'Not set', 'wpfaevent' ) ); ?></span>
-								<button type="button" class="wpfaevent-edit-field-btn button button-small button-link" style="margin-left: 8px;"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
+								<button type="button" class="wpfaevent-edit-field-btn wpfaevent-edit-field-btn--inline button button-small button-link"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
 							</div>
 						</td>
 					</tr>
@@ -152,7 +152,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 						<td>
 							<div class="wpfaevent-field-container">
 								<span class="wpfaevent-field-value"><?php echo esc_html( ! empty( $event['languages'] ) ? implode( ', ', $event['languages'] ) : __( 'Not set', 'wpfaevent' ) ); ?></span>
-								<button type="button" class="wpfaevent-edit-field-btn button button-small button-link" style="margin-left: 8px;"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
+								<button type="button" class="wpfaevent-edit-field-btn wpfaevent-edit-field-btn--inline button button-small button-link"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
 							</div>
 						</td>
 					</tr>
@@ -171,11 +171,11 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 				</tbody>
 			</table>
 
-			<div style="margin-top: 20px; border-top: 1px solid var(--wpfa-border); padding-top: 15px;">
-				<h3 style="margin-bottom: 10px; font-weight: 600; font-size: 14px; color: #1e293b;"><?php esc_html_e( 'Description / Additional Information', 'wpfaevent' ); ?></h3>
+			<div class="wpfaevent-description-section">
+				<h3 class="wpfaevent-description-heading"><?php esc_html_e( 'Description / Additional Information', 'wpfaevent' ); ?></h3>
 				<div class="wpfaevent-editable-row" data-field="post_content" data-type="textarea" data-label="<?php esc_attr_e( 'Description', 'wpfaevent' ); ?>" data-raw-value="<?php echo esc_attr( ! empty( $event['description'] ) ? $event['description'] : '' ); ?>">
 					<div class="wpfaevent-field-container">
-						<span class="wpfaevent-field-value" style="display: block; font-size: 14px; line-height: 1.5; color: #555; background: #fafafa; border: 1px solid #e2e8f0; border-radius: 8px; padding: 12px; min-height: 80px; white-space: pre-wrap; margin-bottom: 8px;"><?php echo esc_html( ! empty( $event['description'] ) ? wp_strip_all_tags( $event['description'] ) : __( 'No description set.', 'wpfaevent' ) ); ?></span>
+						<span class="wpfaevent-field-value wpfaevent-description-value"><?php echo esc_html( ! empty( $event['description'] ) ? wp_strip_all_tags( $event['description'] ) : __( 'No description set.', 'wpfaevent' ) ); ?></span>
 						<button type="button" class="wpfaevent-edit-field-btn button button-small button-link"><?php esc_html_e( 'Edit Description', 'wpfaevent' ); ?></button>
 					</div>
 				</div>
@@ -213,7 +213,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 	<div id="wpfaevent-source" class="wpfaevent-dashboard-split wpfaevent-dashboard-section">
 		<div class="wpfaevent-dashboard-card">
 			<h2><?php esc_html_e( 'Import Source Details', 'wpfaevent' ); ?></h2>
-			<table class="widefat striped" style="margin-top:12px;">
+			<table class="widefat striped wpfaevent-dashboard-table">
 				<tbody>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Source type', 'wpfaevent' ); ?></th>
@@ -237,7 +237,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 
 		<div id="wpfaevent-settings" class="wpfaevent-dashboard-card">
 			<h2><?php esc_html_e( 'Event Settings', 'wpfaevent' ); ?></h2>
-			<ul style="margin:12px 0 0 18px;list-style:disc;">
+			<ul class="wpfaevent-settings-list">
 				<li class="wpfaevent-editable-item" data-field="wpfa_event_url" data-type="url" data-label="<?php esc_attr_e( 'Public event URL', 'wpfaevent' ); ?>" data-raw-value="<?php echo esc_attr( ! empty( $event['event_url'] ) ? $event['event_url'] : '' ); ?>">
 					<div class="wpfaevent-field-container">
 						<span class="wpfaevent-field-value">
@@ -247,7 +247,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 								<?php esc_html_e( 'Public event URL not set.', 'wpfaevent' ); ?>
 							<?php endif; ?>
 						</span>
-						<button type="button" class="wpfaevent-edit-field-btn button button-small button-link" style="margin-left: 8px; vertical-align: middle;"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
+						<button type="button" class="wpfaevent-edit-field-btn wpfaevent-edit-field-btn--inline button button-small button-link"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
 					</div>
 				</li>
 				<li class="wpfaevent-editable-item" data-field="wpfa_event_registration_link" data-type="url" data-label="<?php esc_attr_e( 'Registration link', 'wpfaevent' ); ?>" data-raw-value="<?php echo esc_attr( ! empty( $event['register_url'] ) ? $event['register_url'] : '' ); ?>">
@@ -259,7 +259,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 								<?php esc_html_e( 'Registration link not set.', 'wpfaevent' ); ?>
 							<?php endif; ?>
 						</span>
-						<button type="button" class="wpfaevent-edit-field-btn button button-small button-link" style="margin-left: 8px; vertical-align: middle;"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
+						<button type="button" class="wpfaevent-edit-field-btn wpfaevent-edit-field-btn--inline button button-small button-link"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
 					</div>
 				</li>
 				<li class="wpfaevent-editable-item" data-field="wpfa_event_cfs_link" data-type="url" data-label="<?php esc_attr_e( 'Call for speakers link', 'wpfaevent' ); ?>" data-raw-value="<?php echo esc_attr( ! empty( $event['cfs_url'] ) ? $event['cfs_url'] : '' ); ?>">
@@ -271,7 +271,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 								<?php esc_html_e( 'Call for speakers link not set.', 'wpfaevent' ); ?>
 							<?php endif; ?>
 						</span>
-						<button type="button" class="wpfaevent-edit-field-btn button button-small button-link" style="margin-left: 8px; vertical-align: middle;"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
+						<button type="button" class="wpfaevent-edit-field-btn wpfaevent-edit-field-btn--inline button button-small button-link"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
 					</div>
 				</li>
 				<li>
@@ -301,7 +301,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 	<div class="wpfaevent-dashboard-split">
 		<div class="wpfaevent-dashboard-card">
 			<h2><?php esc_html_e( 'Content Visibility', 'wpfaevent' ); ?></h2>
-			<table class="widefat striped" style="margin-top:12px;">
+			<table class="widefat striped wpfaevent-dashboard-table">
 				<tbody>
 					<?php foreach ( $section_visibility as $section_key => $is_visible ) : ?>
 						<tr>
@@ -340,11 +340,11 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 				<?php $total_speakers_count = count( $speakers ); ?>
 
 				<!-- Section for Featured Speakers Ordering -->
-				<div class="wpfaevent-featured-speakers-ordering-container" style="margin-bottom: 20px; border-bottom: 1px solid var(--wpfa-border); padding-bottom: 20px;">
+				<div class="wpfaevent-featured-speakers-ordering-container">
 					<h3><?php esc_html_e( 'Featured Speakers Order (Drag to Reorder)', 'wpfaevent' ); ?></h3>
 					<p class="description"><?php esc_html_e( 'Drag and drop featured speakers to set their exact order on the public page.', 'wpfaevent' ); ?></p>
 
-					<ul id="wpfaevent-featured-speakers-sortable" class="wpfaevent-sortable-list" style="margin: 15px 0 0; padding: 0; list-style: none;">
+					<ul id="wpfaevent-featured-speakers-sortable" class="wpfaevent-sortable-list">
 						<?php
 						$saved_featured_ids = class_exists( 'Wpfaevent_Event_Speaker_Relation_Manager' ) ? Wpfaevent_Event_Speaker_Relation_Manager::get_event_featured_speaker_ids( $event['id'] ) : array();
 
@@ -373,22 +373,22 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 								$fs_id    = isset( $fs['id'] ) ? $fs['id'] : '';
 								$fs_image = ! empty( $fs['image'] ) ? $fs['image'] : ( defined( 'WPFAEVENT_URL' ) ? WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg' : '' );
 								?>
-								<li class="wpfaevent-sortable-item" data-speaker-id="<?php echo esc_attr( (string) $fs_id ); ?>" style="display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; border: 1px solid #e4ebf3; border-radius: 8px; margin-bottom: 8px; background: #fff; cursor: move;">
-									<div style="display: flex; align-items: center; gap: 10px;">
-										<span class="dashicons dashicons-menu" style="color: #a0aec0; cursor: move;"></span>
+								<li class="wpfaevent-sortable-item" data-speaker-id="<?php echo esc_attr( (string) $fs_id ); ?>">
+									<div class="wpfaevent-featured-speaker-details">
+										<span class="dashicons dashicons-menu wpfaevent-featured-speaker-drag-handle"></span>
 										<?php if ( $fs_image ) : ?>
-											<img src="<?php echo esc_url( $fs_image ); ?>" alt="<?php echo esc_attr( $fs['name'] ); ?>" style="width: 32px; height: 32px; border-radius: 50%; object-fit: cover;">
+											<img class="wpfaevent-featured-speaker-thumbnail wpfaevent-featured-speaker-thumbnail--sortable" src="<?php echo esc_url( $fs_image ); ?>" alt="<?php echo esc_attr( $fs['name'] ); ?>">
 										<?php endif; ?>
-										<div>
-											<strong style="font-size: 13px;"><?php echo esc_html( $fs['name'] ); ?></strong>
-											<div class="description" style="font-size: 11px;"><?php echo esc_html( trim( $fs['title'] ) ); ?></div>
+										<div class="wpfaevent-featured-speaker-copy">
+											<strong class="wpfaevent-featured-speaker-name"><?php echo esc_html( $fs['name'] ); ?></strong>
+											<div class="description wpfaevent-featured-speaker-title"><?php echo esc_html( trim( $fs['title'] ) ); ?></div>
 										</div>
 									</div>
 									<button type="button" class="button button-small wpfaevent-unfeature-btn" data-speaker-id="<?php echo esc_attr( (string) $fs_id ); ?>"><?php esc_html_e( 'Remove Featured', 'wpfaevent' ); ?></button>
 								</li>
 							<?php endforeach; ?>
 						<?php else : ?>
-							<li class="wpfaevent-sortable-placeholder-item" style="padding: 15px; text-align: center; border: 1px dashed #cbd5e0; border-radius: 8px; color: #718096; background: #f8fafc;">
+							<li class="wpfaevent-sortable-placeholder-item">
 								<?php esc_html_e( 'No featured speakers. Toggle featured status on speakers below to add them.', 'wpfaevent' ); ?>
 							</li>
 						<?php endif; ?>
@@ -400,29 +400,29 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 					<h3><?php esc_html_e( 'All Event Speakers', 'wpfaevent' ); ?></h3>
 					<p class="description"><?php esc_html_e( 'Mark speakers as featured to show them in the featured speakers list.', 'wpfaevent' ); ?></p>
 
-					<div class="wpfaevent-list" style="margin-top: 15px; max-height: 400px; overflow-y: auto; padding-right: 5px;">
+					<div class="wpfaevent-list wpfaevent-featured-speaker-options">
 						<?php
 						foreach ( $speakers as $speaker ) :
 							$sp_id          = isset( $speaker['id'] ) ? $speaker['id'] : '';
 							$sp_image       = ! empty( $speaker['image'] ) ? $speaker['image'] : ( defined( 'WPFAEVENT_URL' ) ? WPFAEVENT_URL . 'assets/images/speaker-placeholder.svg' : '' );
 							$is_sp_featured = ! empty( $speaker['featured'] );
 							?>
-							<div class="wpfaevent-list-item" style="display: flex; justify-content: space-between; align-items: center; padding: 10px 12px; border: 1px solid #e4ebf3; border-radius: 8px; margin-bottom: 8px; background: <?php echo $is_sp_featured ? '#f0fdf4' : '#fff'; ?>;">
-								<div style="display: flex; align-items: center; gap: 10px;">
+							<div class="wpfaevent-list-item wpfaevent-featured-speaker-option <?php echo esc_attr( $is_sp_featured ? 'is-featured' : '' ); ?>">
+								<div class="wpfaevent-featured-speaker-details">
 									<?php if ( $sp_image ) : ?>
-										<img src="<?php echo esc_url( $sp_image ); ?>" alt="<?php echo esc_attr( $speaker['name'] ); ?>" style="width: 38px; height: 38px; border-radius: 50%; object-fit: cover;">
+										<img class="wpfaevent-featured-speaker-thumbnail wpfaevent-featured-speaker-thumbnail--option" src="<?php echo esc_url( $sp_image ); ?>" alt="<?php echo esc_attr( $speaker['name'] ); ?>">
 									<?php endif; ?>
-									<div>
-										<strong style="font-size: 13px;"><?php echo esc_html( $speaker['name'] ); ?></strong>
-										<div class="description" style="font-size: 11px;"><?php echo esc_html( trim( $speaker['title'] . ( $speaker['organization'] ? ' - ' . $speaker['organization'] : '' ) ) ); ?></div>
+									<div class="wpfaevent-featured-speaker-copy">
+										<strong class="wpfaevent-featured-speaker-name"><?php echo esc_html( $speaker['name'] ); ?></strong>
+										<div class="description wpfaevent-featured-speaker-title"><?php echo esc_html( trim( $speaker['title'] . ( $speaker['organization'] ? ' - ' . $speaker['organization'] : '' ) ) ); ?></div>
 									</div>
 								</div>
 								<div>
 									<?php if ( ! empty( $sp_id ) ) : ?>
 										<?php if ( $is_sp_featured ) : ?>
-											<button type="button" class="button button-small wpfaevent-toggle-feature-btn is-featured" data-speaker-id="<?php echo esc_attr( (string) $sp_id ); ?>" style="border-color: #bbf7d0; background: #e8f5e9; color: #1b5e20;"><?php esc_html_e( 'Featured', 'wpfaevent' ); ?></button>
+											<button type="button" class="button button-small wpfaevent-toggle-feature-btn is-featured" data-speaker-id="<?php echo esc_attr( (string) $sp_id ); ?>"><?php esc_html_e( 'Featured', 'wpfaevent' ); ?></button>
 										<?php else : ?>
-											<button type="button" class="button button-small wpfaevent-toggle-feature-btn" data-speaker-id="<?php echo esc_attr( (string) $sp_id ); ?>" style="border-color: #d1d5db; background: #fff; color: #374151;"><?php esc_html_e( 'Feature', 'wpfaevent' ); ?></button>
+											<button type="button" class="button button-small wpfaevent-toggle-feature-btn" data-speaker-id="<?php echo esc_attr( (string) $sp_id ); ?>"><?php esc_html_e( 'Feature', 'wpfaevent' ); ?></button>
 										<?php endif; ?>
 									<?php endif; ?>
 								</div>
@@ -431,7 +431,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 					</div>
 				</div>
 
-				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px; display: flex; justify-content: space-between; align-items: center;">
+				<div class="wpfaevent-dashboard-card-footer wpfaevent-dashboard-card-footer--spread">
 					<span class="description">
 						<?php
 						printf(
@@ -447,7 +447,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 				</div>
 			<?php else : ?>
 				<p class="description"><?php esc_html_e( 'No dashboard speakers were found for this event yet.', 'wpfaevent' ); ?></p>
-				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px;">
+				<div class="wpfaevent-dashboard-card-footer">
 					<a class="wpfaevent-module-link" href="<?php echo esc_url( $module_urls['speakers'] ); ?>">
 						<?php esc_html_e( 'Go to Speakers &rarr;', 'wpfaevent' ); ?>
 					</a>
@@ -472,7 +472,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 						</div>
 					<?php endforeach; ?>
 				</div>
-				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px; display: flex; justify-content: space-between; align-items: center;">
+				<div class="wpfaevent-dashboard-card-footer wpfaevent-dashboard-card-footer--spread">
 					<span class="description">
 						<?php
 						$total_sessions_count = count( $sessions );
@@ -546,7 +546,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 							</div>
 						<?php endforeach; ?>
 					</div>
-					<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px; display: flex; justify-content: space-between; align-items: center;">
+					<div class="wpfaevent-dashboard-card-footer wpfaevent-dashboard-card-footer--spread">
 						<span class="description">
 							<?php
 							if ( $total_sponsors_count <= 5 ) {
@@ -564,7 +564,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 					</div>
 				<?php else : ?>
 					<p class="description"><?php esc_html_e( 'No sponsors were found for this event yet.', 'wpfaevent' ); ?></p>
-					<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px;">
+					<div class="wpfaevent-dashboard-card-footer">
 						<a class="wpfaevent-module-link" href="<?php echo esc_url( $module_urls['sponsors'] ); ?>">
 							<?php esc_html_e( 'Go to Sponsors &rarr;', 'wpfaevent' ); ?>
 						</a>
@@ -572,7 +572,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 				<?php endif; ?>
 			<?php else : ?>
 				<p class="description"><?php esc_html_e( 'No sponsors were found for this event yet.', 'wpfaevent' ); ?></p>
-				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px;">
+				<div class="wpfaevent-dashboard-card-footer">
 					<a class="wpfaevent-module-link" href="<?php echo esc_url( $module_urls['sponsors'] ); ?>">
 						<?php esc_html_e( 'Go to Sponsors &rarr;', 'wpfaevent' ); ?>
 					</a>
@@ -607,7 +607,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 						</div>
 					<?php endforeach; ?>
 				</div>
-				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px; display: flex; justify-content: space-between; align-items: center;">
+				<div class="wpfaevent-dashboard-card-footer wpfaevent-dashboard-card-footer--spread">
 					<span class="description">
 						<?php
 						if ( $total_exhibitors_count <= 5 ) {
@@ -625,7 +625,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 				</div>
 			<?php else : ?>
 				<p class="description"><?php esc_html_e( 'No exhibitors were found for this event yet.', 'wpfaevent' ); ?></p>
-				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px;">
+				<div class="wpfaevent-dashboard-card-footer">
 					<a class="wpfaevent-module-link" href="<?php echo esc_url( $module_urls['exhibitors'] ); ?>">
 						<?php esc_html_e( 'Go to Exhibitors &rarr;', 'wpfaevent' ); ?>
 					</a>
@@ -643,14 +643,14 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 						<span class="wpfaevent-tag"><?php echo esc_html( $track ); ?></span>
 					<?php endforeach; ?>
 				</div>
-				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px;">
+				<div class="wpfaevent-dashboard-card-footer">
 					<a class="wpfaevent-module-link" href="<?php echo esc_url( $module_urls['tracks'] ); ?>">
 						<?php esc_html_e( 'Manage Tracks &rarr;', 'wpfaevent' ); ?>
 					</a>
 				</div>
 			<?php else : ?>
 				<p class="description"><?php esc_html_e( 'No tracks are attached to this event yet.', 'wpfaevent' ); ?></p>
-				<div style="margin-top: 15px; border-top: 1px solid var(--wpfa-border); padding-top: 10px;">
+				<div class="wpfaevent-dashboard-card-footer">
 					<a class="wpfaevent-module-link" href="<?php echo esc_url( $module_urls['tracks'] ); ?>">
 						<?php esc_html_e( 'Manage Tracks &rarr;', 'wpfaevent' ); ?>
 					</a>
@@ -686,13 +686,13 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 								<?php if ( ! empty( $asset['url'] ) ) : ?>
 									<img class="wpfaevent-asset-img" src="<?php echo esc_url( $asset['url'] ); ?>" alt="<?php echo esc_attr( $asset['label'] ); ?>">
 								<?php else : ?>
-									<div class="wpfaevent-asset-placeholder" style="width:100%; height:140px; border-radius:10px; border:1px dashed #ccc; display:flex; align-items:center; justify-content:center; background:#fafafa; color:#888; margin-bottom:10px;">
+									<div class="wpfaevent-asset-placeholder">
 										<?php esc_html_e( 'No image set', 'wpfaevent' ); ?>
 									</div>
 								<?php endif; ?>
 							</div>
 
-							<div style="margin-top: 8px; display: flex; justify-content: space-between; align-items: center;">
+							<div class="wpfaevent-asset-meta">
 								<strong><?php echo esc_html( $asset['label'] ); ?></strong>
 								<?php if ( $is_editable ) : ?>
 									<button type="button" class="wpfaevent-edit-field-btn button button-small button-link"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></button>
@@ -709,7 +709,7 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 		</div>
 	</div>
 
-	<div id="wpfaevent-sync" class="wpfaevent-dashboard-card wpfaevent-dashboard-section" style="margin-top:20px;max-width:none;">
+	<div id="wpfaevent-sync" class="wpfaevent-dashboard-card wpfaevent-dashboard-card--full wpfaevent-dashboard-section">
 		<h2><?php esc_html_e( 'Synchronization Status', 'wpfaevent' ); ?></h2>
 		<p><?php echo esc_html( ! empty( $sync['status'] ) ? $sync['status'] : __( 'Unknown', 'wpfaevent' ) ); ?></p>
 		<p class="description">
@@ -723,9 +723,9 @@ $custom_tab_count   = isset( $sections['custom_tab_count'] ) ? absint( $sections
 		</p>
 	</div>
 
-	<div class="wpfaevent-dashboard-card" style="margin-top:20px;max-width:none;">
+	<div class="wpfaevent-dashboard-card wpfaevent-dashboard-card--full">
 		<h2><?php esc_html_e( 'Dashboard Data Files', 'wpfaevent' ); ?></h2>
-		<table class="widefat striped" style="margin-top:12px;">
+		<table class="widefat striped wpfaevent-dashboard-table">
 			<thead>
 				<tr>
 					<th><?php esc_html_e( 'Resource', 'wpfaevent' ); ?></th>
@@ -884,10 +884,10 @@ document.addEventListener('DOMContentLoaded', function () {
 				}
 
 				// Show Save/Cancel actions in place of the edit button
-				const actionArea = parent.querySelector('div[style*="display: flex"]') || parent.lastElementChild;
+				const actionArea = parent.querySelector('.wpfaevent-asset-meta') || parent.lastElementChild;
 				actionArea.innerHTML = `
 					<strong>${label}</strong>
-					<div style="display:inline-flex; gap:5px;">
+					<div class="wpfaevent-inline-actions wpfaevent-inline-actions--compact">
 						<button type="button" class="wpfaevent-save-field-btn button button-primary button-small">Save</button>
 						<button type="button" class="wpfaevent-cancel-field-btn button button-small">Cancel</button>
 					</div>
@@ -915,19 +915,19 @@ document.addEventListener('DOMContentLoaded', function () {
 			let inputHTML = '';
 			let isTextarea = (type === 'textarea');
 			if (type === 'date') {
-				inputHTML = '<input type="date" class="wpfaevent-inline-input" value="' + rawValue + '" style="vertical-align: middle;">';
+				inputHTML = '<input type="date" class="wpfaevent-inline-input" value="' + rawValue + '">';
 			} else if (type === 'url') {
-				inputHTML = '<input type="url" class="wpfaevent-inline-input regular-text" value="' + rawValue + '" placeholder="https://" style="vertical-align: middle;">';
+				inputHTML = '<input type="url" class="wpfaevent-inline-input regular-text" value="' + rawValue + '" placeholder="https://">';
 			} else if (type === 'textarea') {
-				inputHTML = '<textarea class="wpfaevent-inline-input" style="width:100%; min-height:120px; font-family:inherit; vertical-align: middle; margin-bottom: 8px;">' + rawValue + '</textarea>';
+				inputHTML = '<textarea class="wpfaevent-inline-input wpfaevent-inline-input--textarea">' + rawValue + '</textarea>';
 			} else {
-				inputHTML = '<input type="text" class="wpfaevent-inline-input regular-text" value="' + rawValue + '" style="vertical-align: middle;">';
+				inputHTML = '<input type="text" class="wpfaevent-inline-input regular-text" value="' + rawValue + '">';
 			}
 
 			container.innerHTML = `
-				<div class="wpfaevent-inline-editor-form" style="${isTextarea ? 'display:block; width:100%;' : 'display:inline-flex; align-items:center; gap:6px;'}">
+				<div class="wpfaevent-inline-editor-form${isTextarea ? ' is-textarea' : ''}">
 					${inputHTML}
-					<div style="${isTextarea ? 'display:flex; gap:6px;' : 'display:inline-flex; gap:6px;'}">
+					<div class="wpfaevent-inline-actions${isTextarea ? ' is-textarea' : ''}">
 						<button type="button" class="wpfaevent-save-field-btn button button-primary button-small">Save</button>
 						<button type="button" class="wpfaevent-cancel-field-btn button button-small">Cancel</button>
 					</div>
@@ -1005,12 +1005,12 @@ document.addEventListener('DOMContentLoaded', function () {
 					previewContainer.innerHTML = '<img class="wpfaevent-asset-img" src="' + payload.data.value + '" alt="' + label + '">';
 				} else {
 					previewContainer.innerHTML = `
-						<div class="wpfaevent-asset-placeholder" style="width:100%; height:140px; border-radius:10px; border:1px dashed #ccc; display:flex; align-items:center; justify-content:center; background:#fafafa; color:#888; margin-bottom:10px;">
+						<div class="wpfaevent-asset-placeholder">
 							No image set
 						</div>
 					`;
 				}
-				const actionArea = parent.querySelector('div[style*="display: flex"]') || parent.lastElementChild;
+				const actionArea = parent.querySelector('.wpfaevent-asset-meta') || parent.lastElementChild;
 				if (actionArea) {
 					actionArea.innerHTML = `
 						<strong>${label}</strong>
@@ -1029,13 +1029,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
 				if (type === 'textarea') {
 					parent.querySelector('.wpfaevent-field-container').innerHTML = `
-						<span class="wpfaevent-field-value" style="display: block; font-size: 14px; line-height: 1.5; color: #555; background: #fafafa; border: 1px solid #e2e8f0; border-radius: 8px; padding: 12px; min-height: 80px; white-space: pre-wrap; margin-bottom: 8px;">${displayHTML}</span>
+						<span class="wpfaevent-field-value wpfaevent-description-value">${displayHTML}</span>
 						<button type="button" class="wpfaevent-edit-field-btn button button-small button-link">Edit Description</button>
 					`;
 				} else {
 					parent.querySelector('.wpfaevent-field-container').innerHTML = `
 						<span class="wpfaevent-field-value">${displayHTML}</span>
-						<button type="button" class="wpfaevent-edit-field-btn button button-small button-link" style="margin-left: 8px;">Edit</button>
+						<button type="button" class="wpfaevent-edit-field-btn wpfaevent-edit-field-btn--inline button button-small button-link">Edit</button>
 					`;
 				}
 			}
@@ -1053,7 +1053,6 @@ document.addEventListener('DOMContentLoaded', function () {
 		const container = document.querySelector('.wpfaevent-notification-container') || document.querySelector('.wpfaevent-dashboard-shell');
 		const notice = document.createElement('div');
 		notice.className = 'notice notice-' + type + ' is-dismissible';
-		notice.style.margin = '0 0 20px';
 		const p = document.createElement('p');
 		p.textContent = message;
 		notice.appendChild(p);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ export default [
 	},
 	{
 		ignores: [
-			
+
 			'node_modules/**',
 			'vendor/**',
 			'build/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ export default [
 	},
 	{
 		ignores: [
-			
+			'eslint.config.mjs',
 			'node_modules/**',
 			'vendor/**',
 			'build/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ export default [
 	},
 	{
 		ignores: [
-			'eslint.config.mjs',
+			
 			'node_modules/**',
 			'vendor/**',
 			'build/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ export default [
 	},
 	{
 		ignores: [
+			'eslint.config.mjs',
 			'node_modules/**',
 			'vendor/**',
 			'build/**',

--- a/includes/class-wpfaevent-event-speaker-relation-manager.php
+++ b/includes/class-wpfaevent-event-speaker-relation-manager.php
@@ -176,7 +176,16 @@ class Wpfaevent_Event_Speaker_Relation_Manager {
 	public static function resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers = array() ) {
 		$event_id    = absint( $event_id );
 		$speaker_ids = self::sanitize_post_id_list( $speaker_ids );
-		$featured    = array_values( array_intersect( self::get_event_featured_speaker_ids( $event_id ), $speaker_ids ) );
+
+		$is_manual = 'yes' === get_post_meta( $event_id, 'wpfa_event_featured_speakers_manual', true );
+
+		if ( $is_manual ) {
+			$featured = self::get_event_featured_speaker_ids( $event_id );
+			$featured = array_values( array_intersect( $featured, $speaker_ids ) );
+			return apply_filters( 'wpfa_event_featured_speaker_ids', $featured, $event_id, $speaker_ids, $dashboard_speakers );
+		}
+
+		$featured = array_values( array_intersect( self::get_event_featured_speaker_ids( $event_id ), $speaker_ids ) );
 
 		if ( is_array( $dashboard_speakers ) && ! empty( $dashboard_speakers ) ) {
 			$eventyay_map = array();

--- a/includes/class-wpfaevent-templates.php
+++ b/includes/class-wpfaevent-templates.php
@@ -745,6 +745,9 @@ class Wpfaevent_Templates {
 	 * @return void
 	 */
 	private static function register_block_assets() {
+		$event_base_path    = WPFAEVENT_PATH . 'public/css/templates/event-base.css';
+		$event_base_version = file_exists( $event_base_path ) ? (string) filemtime( $event_base_path ) : WPFAEVENT_VERSION;
+
 		wp_register_style(
 			'wpfaevent',
 			WPFAEVENT_URL . 'public/css/wpfaevent-public.css',
@@ -805,7 +808,7 @@ class Wpfaevent_Templates {
 			'wpfaevent-event-base',
 			WPFAEVENT_URL . 'public/css/templates/event-base.css',
 			array( 'wpfaevent' ),
-			WPFAEVENT_VERSION,
+			$event_base_version,
 			'all'
 		);
 

--- a/includes/class-wpfaevent.php
+++ b/includes/class-wpfaevent.php
@@ -261,6 +261,7 @@ class Wpfaevent {
 		$this->loader->add_action( 'admin_post_wpfaevent_sync_event_dashboard', $event_dashboard_page, 'handle_sync' );
 		$this->loader->add_action( 'wp_ajax_wpfaevent_sync_event_dashboard', $event_dashboard_page, 'handle_sync_ajax' );
 		$this->loader->add_action( 'wp_ajax_wpfaevent_save_dashboard_field', $event_dashboard_page, 'handle_save_field_ajax' );
+		$this->loader->add_action( 'wp_ajax_wpfaevent_save_featured_speakers', $event_dashboard_page, 'handle_save_featured_speakers_ajax' );
 
 		$partner_dashboard = new Wpfaevent_Partner_Dashboard();
 		$this->loader->add_action( 'admin_menu', $partner_dashboard, 'register_menu_pages' );

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -702,9 +702,28 @@ class Wpfaevent_Event_Template_Controller {
 
 		$dashboard_featured_speakers = array();
 		$dashboard_regular_speakers  = array();
+		$is_manual_featured_speakers = 'yes' === get_post_meta( $event_id, 'wpfa_event_featured_speakers_manual', true );
+		$dashboard_speaker_post_ids  = $is_manual_featured_speakers && class_exists( 'Wpfaevent_Meta_Event' )
+			? Wpfaevent_Meta_Event::map_dashboard_speakers_to_post_ids( $speaker_ids, $dashboard_speakers )
+			: array();
+		$manual_featured_by_id       = array();
 
-		foreach ( $dashboard_speakers as $dashboard_speaker ) {
+		foreach ( array_values( $dashboard_speakers ) as $dashboard_index => $dashboard_speaker ) {
 			if ( ! is_array( $dashboard_speaker ) || empty( $dashboard_speaker['name'] ) ) {
+				continue;
+			}
+
+			if ( $is_manual_featured_speakers ) {
+				$speaker_post_id = isset( $dashboard_speaker_post_ids[ $dashboard_index ] ) ? $dashboard_speaker_post_ids[ $dashboard_index ] : 0;
+
+				if ( $speaker_post_id && in_array( $speaker_post_id, $featured_speaker_ids, true ) ) {
+					if ( ! isset( $manual_featured_by_id[ $speaker_post_id ] ) ) {
+						$manual_featured_by_id[ $speaker_post_id ] = $dashboard_speaker;
+					}
+					continue;
+				}
+
+				$dashboard_regular_speakers[] = $dashboard_speaker;
 				continue;
 			}
 
@@ -716,12 +735,20 @@ class Wpfaevent_Event_Template_Controller {
 			$dashboard_regular_speakers[] = $dashboard_speaker;
 		}
 
+		if ( $is_manual_featured_speakers ) {
+			foreach ( $featured_speaker_ids as $featured_speaker_id ) {
+				if ( isset( $manual_featured_by_id[ $featured_speaker_id ] ) ) {
+					$dashboard_featured_speakers[] = $manual_featured_by_id[ $featured_speaker_id ];
+				}
+			}
+		}
+
 		$main_dashboard_speakers                  = array_slice( $dashboard_speakers, 0, $main_speaker_limit );
 		$main_dashboard_regular_speakers          = array_slice( $dashboard_regular_speakers, 0, $main_speaker_limit );
 		$dashboard_speaker_overflow_count         = max( 0, count( $dashboard_speakers ) - count( $main_dashboard_speakers ) );
 		$dashboard_regular_speaker_overflow_count = max( 0, count( $dashboard_regular_speakers ) - count( $main_dashboard_regular_speakers ) );
 
-		if ( ! empty( $dashboard_featured_speakers ) ) {
+		if ( ! $is_manual_featured_speakers && ! empty( $dashboard_featured_speakers ) ) {
 			usort(
 				$dashboard_featured_speakers,
 				static function ( $speaker_a, $speaker_b ) {

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -772,7 +772,7 @@ class Wpfaevent_Meta_Event {
 			$eventyay_id = isset( $dashboard_speaker['eventyay_speaker_id'] ) && is_scalar( $dashboard_speaker['eventyay_speaker_id'] )
 				? sanitize_text_field( (string) $dashboard_speaker['eventyay_speaker_id'] )
 				: '';
-			$name_key     = isset( $dashboard_speaker['name'] ) && is_scalar( $dashboard_speaker['name'] )
+			$name_key    = isset( $dashboard_speaker['name'] ) && is_scalar( $dashboard_speaker['name'] )
 				? sanitize_title( (string) $dashboard_speaker['name'] )
 				: '';
 

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -738,7 +738,16 @@ class Wpfaevent_Meta_Event {
 	public static function resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers = array() ) {
 		$event_id    = absint( $event_id );
 		$speaker_ids = self::sanitize_post_id_list( $speaker_ids );
-		$featured    = array_values( array_intersect( self::get_event_featured_speaker_ids( $event_id ), $speaker_ids ) );
+
+		$is_manual = 'yes' === get_post_meta( $event_id, 'wpfa_event_featured_speakers_manual', true );
+
+		if ( $is_manual ) {
+			$featured = self::get_event_featured_speaker_ids( $event_id );
+			$featured = array_values( array_intersect( $featured, $speaker_ids ) );
+			return apply_filters( 'wpfa_event_featured_speaker_ids', $featured, $event_id, $speaker_ids, $dashboard_speakers );
+		}
+
+		$featured = array_values( array_intersect( self::get_event_featured_speaker_ids( $event_id ), $speaker_ids ) );
 
 		if ( is_array( $dashboard_speakers ) && ! empty( $dashboard_speakers ) ) {
 			$eventyay_map = array();

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -726,6 +726,67 @@ class Wpfaevent_Meta_Event {
 	}
 
 	/**
+	 * Match imported dashboard speaker rows to linked speaker posts.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int>        $speaker_ids        Linked speaker post IDs.
+	 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
+	 * @return array<int, int> Dashboard row index to speaker post ID.
+	 */
+	public static function map_dashboard_speakers_to_post_ids( $speaker_ids, $dashboard_speakers ) {
+		$speaker_ids = self::sanitize_post_id_list( $speaker_ids );
+
+		if ( ! is_array( $dashboard_speakers ) || empty( $dashboard_speakers ) ) {
+			return array();
+		}
+
+		$eventyay_map = array();
+		$name_map     = array();
+
+		foreach ( $speaker_ids as $speaker_id ) {
+			if ( 'wpfa_speaker' !== get_post_type( $speaker_id ) ) {
+				continue;
+			}
+
+			$eventyay_id = sanitize_text_field( get_post_meta( $speaker_id, '_wpfa_eventyay_speaker_id', true ) );
+
+			if ( '' !== $eventyay_id ) {
+				$eventyay_map[ $eventyay_id ] = $speaker_id;
+			}
+
+			$name_key = sanitize_title( get_the_title( $speaker_id ) );
+
+			if ( '' !== $name_key ) {
+				$name_map[ $name_key ] = $speaker_id;
+			}
+		}
+
+		$matches = array();
+
+		foreach ( array_values( $dashboard_speakers ) as $dashboard_index => $dashboard_speaker ) {
+			if ( ! is_array( $dashboard_speaker ) ) {
+				continue;
+			}
+
+			$eventyay_id = isset( $dashboard_speaker['eventyay_speaker_id'] ) && is_scalar( $dashboard_speaker['eventyay_speaker_id'] )
+				? sanitize_text_field( (string) $dashboard_speaker['eventyay_speaker_id'] )
+				: '';
+			$name_key     = isset( $dashboard_speaker['name'] ) && is_scalar( $dashboard_speaker['name'] )
+				? sanitize_title( (string) $dashboard_speaker['name'] )
+				: '';
+
+			if ( '' !== $eventyay_id && isset( $eventyay_map[ $eventyay_id ] ) ) {
+				$matches[ $dashboard_index ] = (int) $eventyay_map[ $eventyay_id ];
+			} elseif ( '' !== $name_key && isset( $name_map[ $name_key ] ) ) {
+				$matches[ $dashboard_index ] = (int) $name_map[ $name_key ];
+			}
+		}
+
+		return $matches;
+	}
+
+	/**
 	 * Resolve featured speaker IDs from explicit event meta and dashboard speaker flags.
 	 *
 	 * @since 1.0.0
@@ -744,45 +805,28 @@ class Wpfaevent_Meta_Event {
 		if ( $is_manual ) {
 			$featured = self::get_event_featured_speaker_ids( $event_id );
 			$featured = array_values( array_intersect( $featured, $speaker_ids ) );
+			$featured = array_values(
+				array_filter(
+					$featured,
+					static function ( $speaker_id ) {
+						return 'wpfa_speaker' === get_post_type( $speaker_id );
+					}
+				)
+			);
 			return apply_filters( 'wpfa_event_featured_speaker_ids', $featured, $event_id, $speaker_ids, $dashboard_speakers );
 		}
 
 		$featured = array_values( array_intersect( self::get_event_featured_speaker_ids( $event_id ), $speaker_ids ) );
 
 		if ( is_array( $dashboard_speakers ) && ! empty( $dashboard_speakers ) ) {
-			$eventyay_map = array();
-			$name_map     = array();
+			$dashboard_speaker_ids = self::map_dashboard_speakers_to_post_ids( $speaker_ids, $dashboard_speakers );
 
-			foreach ( $speaker_ids as $speaker_id ) {
-				$eventyay_id = sanitize_text_field( get_post_meta( $speaker_id, '_wpfa_eventyay_speaker_id', true ) );
-
-				if ( '' !== $eventyay_id ) {
-					$eventyay_map[ $eventyay_id ] = $speaker_id;
-				}
-
-				$name_key = sanitize_title( get_the_title( $speaker_id ) );
-
-				if ( '' !== $name_key ) {
-					$name_map[ $name_key ] = $speaker_id;
-				}
-			}
-
-			foreach ( $dashboard_speakers as $dashboard_speaker ) {
+			foreach ( array_values( $dashboard_speakers ) as $dashboard_index => $dashboard_speaker ) {
 				if ( ! is_array( $dashboard_speaker ) || empty( $dashboard_speaker['featured'] ) ) {
 					continue;
 				}
 
-				$matched_id = 0;
-
-				if ( ! empty( $dashboard_speaker['eventyay_speaker_id'] ) && isset( $eventyay_map[ $dashboard_speaker['eventyay_speaker_id'] ] ) ) {
-					$matched_id = (int) $eventyay_map[ $dashboard_speaker['eventyay_speaker_id'] ];
-				} elseif ( ! empty( $dashboard_speaker['name'] ) ) {
-					$name_key = sanitize_title( $dashboard_speaker['name'] );
-
-					if ( isset( $name_map[ $name_key ] ) ) {
-						$matched_id = (int) $name_map[ $name_key ];
-					}
-				}
+				$matched_id = isset( $dashboard_speaker_ids[ $dashboard_index ] ) ? $dashboard_speaker_ids[ $dashboard_index ] : 0;
 
 				if ( $matched_id && ! in_array( $matched_id, $featured, true ) ) {
 					$featured[] = $matched_id;

--- a/public/class-wpfaevent-public.php
+++ b/public/class-wpfaevent-public.php
@@ -224,6 +224,11 @@ class Wpfaevent_Public {
 	 * @since    1.0.0
 	 */
 	private function register_assets() {
+		$event_base_path         = WPFAEVENT_PATH . 'public/css/templates/event-base.css';
+		$event_base_version      = file_exists( $event_base_path ) ? (string) filemtime( $event_base_path ) : $this->version;
+		$speakers_script_path    = WPFAEVENT_PATH . 'public/js/wpfaevent-speakers.js';
+		$speakers_script_version = file_exists( $speakers_script_path ) ? (string) filemtime( $speakers_script_path ) : $this->version;
+
 		wp_register_style(
 			$this->plugin_name,
 			WPFAEVENT_URL . 'public/css/wpfaevent-public.css',
@@ -285,7 +290,7 @@ class Wpfaevent_Public {
 			array(
 				$this->plugin_name,
 			),
-			$this->version,
+			$event_base_version,
 			'all'
 		);
 
@@ -364,7 +369,7 @@ class Wpfaevent_Public {
 			$this->plugin_name . '-speakers',
 			WPFAEVENT_URL . 'public/js/wpfaevent-speakers.js',
 			array( 'jquery' ),
-			$this->version,
+			$speakers_script_version,
 			true
 		);
 

--- a/public/css/templates/event-base.css
+++ b/public/css/templates/event-base.css
@@ -539,7 +539,7 @@
 }
 
 .wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 9) {
-	display: none;
+	display: none !important;
 }
 
 .wpfaevent .wpfa-event-featured-speakers-toggle {
@@ -594,11 +594,11 @@
 	}
 
 	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 9) {
-		display: flex;
+		display: flex !important;
 	}
 
 	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 17) {
-		display: none;
+		display: none !important;
 	}
 }
 
@@ -608,11 +608,11 @@
 	}
 
 	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 17) {
-		display: flex;
+		display: flex !important;
 	}
 
 	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 25) {
-		display: none;
+		display: none !important;
 	}
 }
 
@@ -622,11 +622,11 @@
 	}
 
 	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 25) {
-		display: flex;
+		display: flex !important;
 	}
 
 	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 33) {
-		display: none;
+		display: none !important;
 	}
 }
 

--- a/public/css/templates/event-base.css
+++ b/public/css/templates/event-base.css
@@ -534,6 +534,37 @@
 	margin-bottom: 0;
 }
 
+.wpfaevent .wpfa-event-detail .wpfa-featured-speakers-grid {
+	grid-template-columns: minmax(0, 1fr);
+}
+
+.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 9) {
+	display: none;
+}
+
+.wpfaevent .wpfa-event-featured-speakers-toggle {
+	background: var(--event-primary);
+	border: 1px solid var(--event-primary);
+	border-radius: var(--event-radius);
+	color: #fff;
+	cursor: pointer;
+	display: block;
+	font: inherit;
+	font-weight: 800;
+	margin: 24px auto 0;
+	padding: 10px 20px;
+}
+
+.wpfaevent .wpfa-event-featured-speakers-toggle:hover,
+.wpfaevent .wpfa-event-featured-speakers-toggle:focus-visible {
+	background: var(--event-primary-dark);
+	border-color: var(--event-primary-dark);
+}
+
+.wpfaevent .wpfa-event-featured-speakers-toggle[hidden] {
+	display: none;
+}
+
 .wpfaevent .wpfa-event-detail .wpfa-speaker-card {
 	background: #fff;
 	border: 1px solid var(--event-line);
@@ -555,6 +586,48 @@
 
 .wpfaevent .wpfa-event-featured-speakers {
 	margin-bottom: 32px;
+}
+
+@media (min-width: 769px) {
+	.wpfaevent .wpfa-event-detail .wpfa-featured-speakers-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 9) {
+		display: flex;
+	}
+
+	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 17) {
+		display: none;
+	}
+}
+
+@media (min-width: 1025px) {
+	.wpfaevent .wpfa-event-detail .wpfa-featured-speakers-grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 17) {
+		display: flex;
+	}
+
+	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 25) {
+		display: none;
+	}
+}
+
+@media (min-width: 1441px) {
+	.wpfaevent .wpfa-event-detail .wpfa-featured-speakers-grid {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
+
+	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 25) {
+		display: flex;
+	}
+
+	.wpfaevent .wpfa-event-featured-speakers--collapsed .wpfa-featured-speakers-grid > .wpfa-speaker-card:nth-child(n + 33) {
+		display: none;
+	}
 }
 
 .wpfaevent .wpfa-event-featured-speakers h3,

--- a/public/js/wpfaevent-public.js
+++ b/public/js/wpfaevent-public.js
@@ -30,6 +30,60 @@
 	 */
 
 	$(function () {
+		$('.wpfa-event-featured-speakers').each(function () {
+			const $group = $(this);
+			const $grid = $group.find('.wpfa-featured-speakers-grid').first();
+			const $toggle = $group
+				.find('.wpfa-event-featured-speakers-toggle')
+				.first();
+
+			if (!$grid.length || !$toggle.length) {
+				return;
+			}
+
+			const collapsedLabel = $toggle.text().trim();
+			const expandedLabel = $toggle.data('expanded-label');
+			const speakerCount = $grid.children('.wpfa-speaker-card').length;
+			let isExpanded = false;
+
+			const getVisibleLimit = function () {
+				if (window.innerWidth >= 1441) {
+					return 32;
+				}
+
+				if (window.innerWidth >= 1025) {
+					return 24;
+				}
+
+				if (window.innerWidth >= 769) {
+					return 16;
+				}
+
+				return 8;
+			};
+
+			const refreshGrid = function () {
+				const hasOverflow = speakerCount > getVisibleLimit();
+
+				$group.toggleClass(
+					'wpfa-event-featured-speakers--collapsed',
+					hasOverflow && !isExpanded
+				);
+				$toggle.prop('hidden', !hasOverflow);
+			};
+
+			$toggle.on('click', function () {
+				isExpanded = !isExpanded;
+				$toggle
+					.attr('aria-expanded', isExpanded ? 'true' : 'false')
+					.text(isExpanded ? expandedLabel : collapsedLabel);
+				refreshGrid();
+			});
+
+			$(window).on('resize', refreshGrid);
+			refreshGrid();
+		});
+
 		const showPublicNotice = function (message) {
 			let $notice = $('#wpfa-public-notice');
 

--- a/public/js/wpfaevent-speakers.js
+++ b/public/js/wpfaevent-speakers.js
@@ -433,7 +433,7 @@ const wpfaSpeakers = (function () {
 		// Show filtered speakers
 		filteredSpeakers.forEach((speaker) => {
 			if (speaker.element) {
-				speaker.element.style.display = 'block';
+				speaker.element.style.removeProperty('display');
 			}
 		});
 

--- a/public/js/wpfaevent-speakers.js
+++ b/public/js/wpfaevent-speakers.js
@@ -137,7 +137,6 @@ const wpfaSpeakers = (function () {
 			const link = card.querySelector('.wpfa-speaker-name a')?.href || '';
 			const speakerId = card.dataset.speakerId || '';
 
-
 			return {
 				id: speakerId,
 				name,

--- a/public/templates/page-speakers.php
+++ b/public/templates/page-speakers.php
@@ -166,6 +166,12 @@ if ( ! empty( $featured_speaker_ids ) ) {
 			$speaker_a_is_featured = in_array( absint( $speaker_a ), $featured_speaker_ids, true );
 			$speaker_b_is_featured = in_array( absint( $speaker_b ), $featured_speaker_ids, true );
 
+			if ( $speaker_a_is_featured && $speaker_b_is_featured ) {
+				$index_a = array_search( absint( $speaker_a ), $featured_speaker_ids, true );
+				$index_b = array_search( absint( $speaker_b ), $featured_speaker_ids, true );
+				return $index_a <=> $index_b;
+			}
+
 			if ( $speaker_a_is_featured !== $speaker_b_is_featured ) {
 				return $speaker_a_is_featured ? -1 : 1;
 			}

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -452,7 +452,7 @@ if ( $show_ticket_widget ) {
 						<?php if ( $featured_speaker_count ) : ?>
 							<div class="wpfa-event-featured-speakers">
 								<h3><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h3>
-								<div class="wpfa-speakers-grid wpfa-featured-speakers-grid">
+								<div id="wpfa-event-featured-speakers-grid" class="wpfa-speakers-grid wpfa-featured-speakers-grid">
 									<?php
 									$wpfa_hide_speaker_card_admin_actions = true;
 									$wpfa_schedule_display_timezone       = $selected_schedule_timezone;
@@ -471,6 +471,11 @@ if ( $show_ticket_widget ) {
 									unset( $wpfa_speaker_card_variant );
 									?>
 								</div>
+								<?php if ( 8 < $featured_speaker_count ) : ?>
+									<button type="button" class="wpfa-event-featured-speakers-toggle" aria-controls="wpfa-event-featured-speakers-grid" aria-expanded="false" data-expanded-label="<?php esc_attr_e( 'Show Less', 'wpfaevent' ); ?>">
+										<?php esc_html_e( 'View All', 'wpfaevent' ); ?>
+									</button>
+								<?php endif; ?>
 							</div>
 						<?php endif; ?>
 
@@ -510,7 +515,7 @@ if ( $show_ticket_widget ) {
 						<?php if ( ! empty( $dashboard_featured_speakers ) ) : ?>
 							<div class="wpfa-event-featured-speakers">
 								<h3><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h3>
-								<div class="wpfa-speakers-grid wpfa-featured-speakers-grid">
+								<div id="wpfa-event-featured-speakers-grid" class="wpfa-speakers-grid wpfa-featured-speakers-grid">
 									<?php foreach ( $dashboard_featured_speakers as $speaker ) : ?>
 										<?php
 										$wpfa_dashboard_speaker_is_featured = true;
@@ -521,6 +526,11 @@ if ( $show_ticket_widget ) {
 										?>
 									<?php endforeach; ?>
 								</div>
+								<?php if ( 8 < count( $dashboard_featured_speakers ) ) : ?>
+									<button type="button" class="wpfa-event-featured-speakers-toggle" aria-controls="wpfa-event-featured-speakers-grid" aria-expanded="false" data-expanded-label="<?php esc_attr_e( 'Show Less', 'wpfaevent' ); ?>">
+										<?php esc_html_e( 'View All', 'wpfaevent' ); ?>
+									</button>
+								<?php endif; ?>
 							</div>
 
 							<?php if ( ! empty( $dashboard_regular_speakers ) ) : ?>

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -450,7 +450,7 @@ if ( $show_ticket_widget ) {
 
 					<?php if ( ! empty( $speaker_ids ) ) : ?>
 						<?php if ( $featured_speaker_count ) : ?>
-							<div class="wpfa-event-featured-speakers">
+							<div class="wpfa-event-featured-speakers wpfa-event-featured-speakers--collapsed">
 								<h3><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h3>
 								<div id="wpfa-event-featured-speakers-grid" class="wpfa-speakers-grid wpfa-featured-speakers-grid">
 									<?php
@@ -513,7 +513,7 @@ if ( $show_ticket_widget ) {
 						<?php endif; ?>
 					<?php elseif ( ! empty( $dashboard_speakers ) ) : ?>
 						<?php if ( ! empty( $dashboard_featured_speakers ) ) : ?>
-							<div class="wpfa-event-featured-speakers">
+							<div class="wpfa-event-featured-speakers wpfa-event-featured-speakers--collapsed">
 								<h3><?php esc_html_e( 'Featured Speakers', 'wpfaevent' ); ?></h3>
 								<div id="wpfa-event-featured-speakers-grid" class="wpfa-speakers-grid wpfa-featured-speakers-grid">
 									<?php foreach ( $dashboard_featured_speakers as $speaker ) : ?>

--- a/tests/unit/FeaturedSpeakersGridTest.php
+++ b/tests/unit/FeaturedSpeakersGridTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Regression tests for the event featured-speaker grid.
+ *
+ * @package Wpfaevent
+ */
+
+/**
+ * Event featured-speaker grid regression tests.
+ */
+class FeaturedSpeakersGridTest extends WP_UnitTestCase {
+
+	/**
+	 * The event template provides an accessible control for both speaker sources.
+	 */
+	public function test_event_template_renders_featured_speaker_view_all_controls() {
+		$source = $this->read_project_file( 'public/templates/single-wpfa-event.php' );
+
+		$this->assertSame( 2, substr_count( $source, 'class="wpfa-event-featured-speakers-toggle"' ) );
+		$this->assertSame( 2, substr_count( $source, 'aria-controls="wpfa-event-featured-speakers-grid"' ) );
+		$this->assertStringContainsString( "esc_html_e( 'View All', 'wpfaevent' )", $source );
+		$this->assertStringContainsString( "esc_attr_e( 'Show Less', 'wpfaevent' )", $source );
+	}
+
+	/**
+	 * CSS keeps eight rows at each responsive column count.
+	 */
+	public function test_featured_speaker_grid_has_eight_row_breakpoints() {
+		$source = $this->read_project_file( 'public/css/templates/event-base.css' );
+
+		$this->assertStringContainsString( '@media (min-width: 769px)', $source );
+		$this->assertStringContainsString( '@media (min-width: 1025px)', $source );
+		$this->assertStringContainsString( '@media (min-width: 1441px)', $source );
+		$this->assertStringContainsString( 'grid-template-columns: repeat(2, minmax(0, 1fr));', $source );
+		$this->assertStringContainsString( 'grid-template-columns: repeat(3, minmax(0, 1fr));', $source );
+		$this->assertStringContainsString( 'grid-template-columns: repeat(4, minmax(0, 1fr));', $source );
+		$this->assertStringContainsString( '.wpfa-speaker-card:nth-child(n + 9)', $source );
+		$this->assertStringContainsString( '.wpfa-speaker-card:nth-child(n + 17)', $source );
+		$this->assertStringContainsString( '.wpfa-speaker-card:nth-child(n + 25)', $source );
+		$this->assertStringContainsString( '.wpfa-speaker-card:nth-child(n + 33)', $source );
+	}
+
+	/**
+	 * JavaScript expands the complete grid and recalculates overflow on resize.
+	 */
+	public function test_featured_speaker_grid_script_handles_toggle_and_resize() {
+		$source = $this->read_project_file( 'public/js/wpfaevent-public.js' );
+
+		$this->assertStringContainsString( "'wpfa-event-featured-speakers--collapsed'", $source );
+		$this->assertStringContainsString( "attr('aria-expanded', isExpanded ? 'true' : 'false')", $source );
+		$this->assertStringContainsString( "$(window).on('resize', refreshGrid);", $source );
+	}
+
+	/**
+	 * Read a repository file fixture.
+	 *
+	 * @param string $relative_path File path relative to the plugin root.
+	 * @return string
+	 */
+	private function read_project_file( $relative_path ) {
+		$path   = dirname( __DIR__, 2 ) . '/' . $relative_path;
+		$source = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a repository fixture in a unit test.
+
+		$this->assertNotFalse( $source );
+
+		return $source;
+	}
+}

--- a/tests/unit/FeaturedSpeakersGridTest.php
+++ b/tests/unit/FeaturedSpeakersGridTest.php
@@ -53,6 +53,16 @@ class FeaturedSpeakersGridTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Speaker filtering must not override the responsive grid display rules.
+	 */
+	public function test_speaker_filter_restores_stylesheet_controlled_display() {
+		$source = $this->read_project_file( 'public/js/wpfaevent-speakers.js' );
+
+		$this->assertStringContainsString( "speaker.element.style.removeProperty('display');", $source );
+		$this->assertStringNotContainsString( "speaker.element.style.display = 'block';", $source );
+	}
+
+	/**
 	 * Read a repository file fixture.
 	 *
 	 * @param string $relative_path File path relative to the plugin root.

--- a/tests/unit/FeaturedSpeakersGridTest.php
+++ b/tests/unit/FeaturedSpeakersGridTest.php
@@ -16,6 +16,7 @@ class FeaturedSpeakersGridTest extends WP_UnitTestCase {
 	public function test_event_template_renders_featured_speaker_view_all_controls() {
 		$source = $this->read_project_file( 'public/templates/single-wpfa-event.php' );
 
+		$this->assertSame( 2, substr_count( $source, 'class="wpfa-event-featured-speakers wpfa-event-featured-speakers--collapsed"' ) );
 		$this->assertSame( 2, substr_count( $source, 'class="wpfa-event-featured-speakers-toggle"' ) );
 		$this->assertSame( 2, substr_count( $source, 'aria-controls="wpfa-event-featured-speakers-grid"' ) );
 		$this->assertStringContainsString( "esc_html_e( 'View All', 'wpfaevent' )", $source );

--- a/tests/unit/FeaturedSpeakersGridTest.php
+++ b/tests/unit/FeaturedSpeakersGridTest.php
@@ -39,6 +39,8 @@ class FeaturedSpeakersGridTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '.wpfa-speaker-card:nth-child(n + 17)', $source );
 		$this->assertStringContainsString( '.wpfa-speaker-card:nth-child(n + 25)', $source );
 		$this->assertStringContainsString( '.wpfa-speaker-card:nth-child(n + 33)', $source );
+		$this->assertSame( 4, substr_count( $source, 'display: none !important;' ) );
+		$this->assertSame( 3, substr_count( $source, 'display: flex !important;' ) );
 	}
 
 	/**
@@ -60,6 +62,18 @@ class FeaturedSpeakersGridTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( "speaker.element.style.removeProperty('display');", $source );
 		$this->assertStringNotContainsString( "speaker.element.style.display = 'block';", $source );
+	}
+
+	/**
+	 * Changed speaker assets must use cache-busting file modification versions.
+	 */
+	public function test_featured_speaker_assets_use_file_modification_versions() {
+		$public_source   = $this->read_project_file( 'public/class-wpfaevent-public.php' );
+		$template_source = $this->read_project_file( 'includes/class-wpfaevent-templates.php' );
+
+		$this->assertStringContainsString( '$event_base_version', $public_source );
+		$this->assertStringContainsString( '$speakers_script_version', $public_source );
+		$this->assertStringContainsString( '$event_base_version', $template_source );
 	}
 
 	/**

--- a/tests/unit/FeaturedSpeakersScriptTest.php
+++ b/tests/unit/FeaturedSpeakersScriptTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Regression tests for the featured-speaker dashboard script.
+ *
+ * @package Wpfaevent
+ */
+
+/**
+ * Featured-speaker dashboard JavaScript regression tests.
+ */
+class FeaturedSpeakersScriptTest extends WP_UnitTestCase {
+
+	/**
+	 * Untrusted speaker values must only reach text and attribute setters.
+	 */
+	public function test_speaker_markup_and_attribute_breaking_values_use_safe_dom_sinks() {
+		$source = $this->get_featured_speakers_script();
+
+		$this->assertStringContainsString( ".text(name)", $source );
+		$this->assertStringContainsString( ".text(title)", $source );
+		$this->assertStringContainsString( ".attr({ src: imgUrl, alt: name })", $source );
+		$this->assertStringContainsString( "['http:', 'https:'].includes(parsedUrl.protocol)", $source );
+		$this->assertStringNotContainsString( '${name}', $source );
+		$this->assertStringNotContainsString( '${title}', $source );
+		$this->assertStringNotContainsString( '${imgUrl}', $source );
+		$this->assertStringNotContainsString( '${speakerId}', $source );
+		$this->assertStringNotContainsString( '.html(', $source );
+	}
+
+	/**
+	 * Saves must remain single-flight and replace queued state with the latest order.
+	 */
+	public function test_rapid_saves_are_serialized_and_only_the_latest_result_is_reported() {
+		$source = $this->get_featured_speakers_script();
+
+		$this->assertStringContainsString( 'let saveInProgress = false;', $source );
+		$this->assertStringContainsString( 'queuedSpeakerIds = speakerIds;', $source );
+		$this->assertStringContainsString( 'if (saveInProgress || queuedSpeakerIds === null)', $source );
+		$this->assertStringContainsString( 'const speakerIds = queuedSpeakerIds;', $source );
+		$this->assertStringContainsString( 'queuedSpeakerIds = null;', $source );
+		$this->assertStringContainsString( 'if (queuedSpeakerIds !== null)', $source );
+		$this->assertStringContainsString( 'processFeaturedSpeakersSave();', $source );
+		$this->assertStringContainsString( 'saveRevision === latestSaveRevision', $source );
+		$this->assertSame( 1, substr_count( $source, '$.ajax({' ) );
+	}
+
+	/**
+	 * Read only the featured-speaker section of the admin script.
+	 *
+	 * @return string
+	 */
+	private function get_featured_speakers_script() {
+		$path   = dirname( __DIR__, 2 ) . '/admin/js/wpfaevent-admin.js';
+		$source = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a repository fixture in a unit test.
+
+		$this->assertNotFalse( $source );
+
+		$start = strpos( $source, '// Featured Speakers Manual Ordering' );
+		$end   = strpos( $source, 'function getEventTitle', $start );
+
+		$this->assertNotFalse( $start );
+		$this->assertNotFalse( $end );
+
+		return substr( $source, $start, $end - $start );
+	}
+}

--- a/tests/unit/FeaturedSpeakersScriptTest.php
+++ b/tests/unit/FeaturedSpeakersScriptTest.php
@@ -16,9 +16,9 @@ class FeaturedSpeakersScriptTest extends WP_UnitTestCase {
 	public function test_speaker_markup_and_attribute_breaking_values_use_safe_dom_sinks() {
 		$source = $this->get_featured_speakers_script();
 
-		$this->assertStringContainsString( ".text(name)", $source );
-		$this->assertStringContainsString( ".text(title)", $source );
-		$this->assertStringContainsString( ".attr({ src: imgUrl, alt: name })", $source );
+		$this->assertStringContainsString( '.text(name)', $source );
+		$this->assertStringContainsString( '.text(title)', $source );
+		$this->assertStringContainsString( '.attr({ src: imgUrl, alt: name })', $source );
 		$this->assertStringContainsString( "['http:', 'https:'].includes(parsedUrl.protocol)", $source );
 		$this->assertStringNotContainsString( '${name}', $source );
 		$this->assertStringNotContainsString( '${title}', $source );

--- a/tests/unit/FeaturedSpeakersTest.php
+++ b/tests/unit/FeaturedSpeakersTest.php
@@ -59,6 +59,21 @@ class FeaturedSpeakersTest extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Remove dashboard fixture data created by a test.
+	 */
+	public function tearDown(): void {
+		$store = new Wpfaevent_Eventyay_Dashboard_Store();
+		$path  = $store->get_dashboard_json_path( 'speakers-' . $this->event_id . '.json' );
+
+		if ( $path && file_exists( $path ) ) {
+			wp_delete_file( $path );
+		}
+
+		$_POST = array();
+		parent::tearDown();
+	}
+
+	/**
 	 * Test marking and unmarking speakers as featured.
 	 */
 	public function test_resolve_featured_speakers_with_manual_mode() {
@@ -97,6 +112,72 @@ class FeaturedSpeakersTest extends WP_Ajax_UnitTestCase {
 
 		$resolved = Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $this->event_id, $this->speaker_ids );
 		$this->assertSame( $expected_order, $resolved );
+	}
+
+	/**
+	 * Public event data should use only the manually selected dashboard rows in saved order.
+	 */
+	public function test_public_event_data_applies_manual_featured_speaker_order() {
+		$dashboard_speakers = array(
+			array(
+				'name'           => 'Speaker 1',
+				'featured'       => false,
+				'featured_order' => 3,
+			),
+			array(
+				'name'           => 'Speaker 2',
+				'featured'       => true,
+				'featured_order' => 1,
+			),
+			array(
+				'name'           => 'Speaker 3',
+				'featured'       => false,
+				'featured_order' => 2,
+			),
+		);
+
+		$this->write_dashboard_speakers( $dashboard_speakers );
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers_manual', 'yes' );
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers', array( $this->speaker_ids[2], $this->speaker_ids[0] ) );
+
+		$event_data = Wpfaevent_Event_Template_Controller::get_event_template_data( $this->event_id );
+
+		$this->assertSame( array( $this->speaker_ids[2], $this->speaker_ids[0] ), $event_data['featured_speaker_ids'] );
+		$this->assertSame( array( 'Speaker 3', 'Speaker 1' ), wp_list_pluck( $event_data['dashboard_featured_speakers'], 'name' ) );
+		$this->assertSame( array( 'Speaker 2' ), wp_list_pluck( $event_data['dashboard_regular_speakers'], 'name' ) );
+	}
+
+	/**
+	 * Public event data should retain imported flags and order outside manual mode.
+	 */
+	public function test_public_event_data_preserves_automatic_featured_speakers() {
+		$dashboard_speakers = array(
+			array(
+				'name'           => 'Speaker 1',
+				'featured'       => true,
+				'featured_order' => 2,
+			),
+			array(
+				'name'           => 'Speaker 2',
+				'featured'       => false,
+				'featured_order' => 0,
+			),
+			array(
+				'name'           => 'Speaker 3',
+				'featured'       => true,
+				'featured_order' => 1,
+			),
+		);
+
+		$this->write_dashboard_speakers( $dashboard_speakers );
+		delete_post_meta( $this->event_id, 'wpfa_event_featured_speakers_manual' );
+		delete_post_meta( $this->event_id, 'wpfa_event_featured_speakers' );
+
+		$event_data = Wpfaevent_Event_Template_Controller::get_event_template_data( $this->event_id );
+
+		$this->assertSame( array( $this->speaker_ids[0], $this->speaker_ids[2] ), $event_data['featured_speaker_ids'] );
+		$this->assertSame( array( 'Speaker 3', 'Speaker 1' ), wp_list_pluck( $event_data['dashboard_featured_speakers'], 'name' ) );
+		$this->assertSame( array( 'Speaker 2' ), wp_list_pluck( $event_data['dashboard_regular_speakers'], 'name' ) );
 	}
 
 	/**
@@ -145,8 +226,65 @@ class FeaturedSpeakersTest extends WP_Ajax_UnitTestCase {
 
 		// Verify write in database.
 		$saved_ids = get_post_meta( $this->event_id, 'wpfa_event_featured_speakers', true );
-		$this->assertEqualsCanonicalizing( array( $this->speaker_ids[0] ), $saved_ids );
+		$this->assertSame( array( $this->speaker_ids[0] ), $saved_ids );
 		$this->assertSame( 'yes', get_post_meta( $this->event_id, 'wpfa_event_featured_speakers_manual', true ) );
+	}
+
+	/**
+	 * AJAX saves should discard unrelated and stale posts without changing submitted order.
+	 */
+	public function test_ajax_handler_filters_speaker_ids_against_event_relationships() {
+		$unrelated_speaker_id = $this->factory->post->create(
+			array(
+				'post_title'  => 'Unrelated Speaker',
+				'post_type'   => 'wpfa_speaker',
+				'post_status' => 'publish',
+			)
+		);
+		$unrelated_post_id    = $this->factory->post->create(
+			array(
+				'post_title'  => 'Not a Speaker',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		update_post_meta( $this->event_id, 'wpfa_event_speakers', array( $this->speaker_ids[0], $this->speaker_ids[1] ) );
+		delete_post_meta( $this->speaker_ids[2], 'wpfa_speaker_events' );
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$_POST['event_id']    = $this->event_id;
+		$_POST['nonce']       = wp_create_nonce( 'wpfaevent_save_featured_speakers_' . $this->event_id );
+		$_POST['speaker_ids'] = array(
+			(string) $this->speaker_ids[1],
+			(string) $unrelated_speaker_id,
+			(string) $this->speaker_ids[0],
+			(string) $this->speaker_ids[1],
+			(string) $this->speaker_ids[2],
+			(string) $unrelated_post_id,
+			'not-an-id',
+		);
+
+		$response = $this->execute_ajax( new Wpfaevent_Event_Dashboard_Page() );
+
+		$this->assertTrue( $response['success'] );
+		$this->assertSame(
+			array( $this->speaker_ids[1], $this->speaker_ids[0] ),
+			get_post_meta( $this->event_id, 'wpfa_event_featured_speakers', true )
+		);
+	}
+
+	/**
+	 * Store dashboard speaker rows for public event data tests.
+	 *
+	 * @param array<int, array<string, mixed>> $speakers Dashboard speaker rows.
+	 */
+	private function write_dashboard_speakers( $speakers ) {
+		$store  = new Wpfaevent_Eventyay_Dashboard_Store();
+		$result = $store->write_dashboard_json_file( 'speakers-' . $this->event_id . '.json', $speakers );
+
+		$this->assertTrue( $result );
 	}
 
 	/**

--- a/tests/unit/FeaturedSpeakersTest.php
+++ b/tests/unit/FeaturedSpeakersTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Unit tests for Featured Speakers manual ordering (Issue #249).
+ *
+ * @package Wpfaevent
+ */
+
+/**
+ * Featured Speakers manual ordering test class.
+ */
+class FeaturedSpeakersTest extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Test event ID.
+	 *
+	 * @var int
+	 */
+	private $event_id;
+
+	/**
+	 * Test speaker IDs.
+	 *
+	 * @var array<int>
+	 */
+	private $speaker_ids;
+
+	/**
+	 * Setup event and speaker fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Create test event.
+		$this->event_id = $this->factory->post->create(
+			array(
+				'post_title'  => 'Test Event',
+				'post_type'   => 'wpfa_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create test speakers.
+		$this->speaker_ids = array();
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$this->speaker_ids[] = $this->factory->post->create(
+				array(
+					'post_title'  => 'Speaker ' . $i,
+					'post_type'   => 'wpfa_speaker',
+					'post_status' => 'publish',
+				)
+			);
+		}
+
+		// Link speakers to event.
+		update_post_meta( $this->event_id, 'wpfa_event_speakers', $this->speaker_ids );
+		foreach ( $this->speaker_ids as $sid ) {
+			update_post_meta( $sid, 'wpfa_speaker_events', array( $this->event_id ) );
+		}
+	}
+
+	/**
+	 * Test marking and unmarking speakers as featured.
+	 */
+	public function test_resolve_featured_speakers_with_manual_mode() {
+		// Before manual mode is set, legacy auto fallback is used.
+		$dashboard_speakers = array(
+			array(
+				'name'     => 'Speaker 2',
+				'featured' => true,
+			),
+		);
+		$resolved           = Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $this->event_id, $this->speaker_ids, $dashboard_speakers );
+		$this->assertSame( array( $this->speaker_ids[1] ), $resolved );
+
+		// Set manual mode and feature only Speaker 2 and Speaker 3.
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers_manual', 'yes' );
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers', array( $this->speaker_ids[1], $this->speaker_ids[2] ) );
+
+		$resolved = Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $this->event_id, $this->speaker_ids, $dashboard_speakers );
+		$this->assertEqualsCanonicalizing( array( $this->speaker_ids[1], $this->speaker_ids[2] ), $resolved );
+
+		// Unmark/unfeature Speaker 2 (leave only Speaker 3 featured).
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers', array( $this->speaker_ids[2] ) );
+		$resolved = Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $this->event_id, $this->speaker_ids, $dashboard_speakers );
+		$this->assertSame( array( $this->speaker_ids[2] ), $resolved );
+	}
+
+	/**
+	 * Test saving and restoring the exact selected order.
+	 */
+	public function test_featured_speakers_order_preservation() {
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers_manual', 'yes' );
+
+		// Order: Speaker 3 then Speaker 1.
+		$expected_order = array( $this->speaker_ids[2], $this->speaker_ids[0] );
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers', $expected_order );
+
+		$resolved = Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $this->event_id, $this->speaker_ids );
+		$this->assertSame( $expected_order, $resolved );
+	}
+
+	/**
+	 * Test handling of missing/deleted speakers.
+	 */
+	public function test_gracefully_handles_deleted_speakers() {
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers_manual', 'yes' );
+		update_post_meta( $this->event_id, 'wpfa_event_featured_speakers', array( $this->speaker_ids[0], 99999, $this->speaker_ids[1] ) ); // 99999 is non-existent.
+
+		$resolved = Wpfaevent_Meta_Event::resolve_event_featured_speaker_ids( $this->event_id, $this->speaker_ids );
+		$this->assertSame( array( $this->speaker_ids[0], $this->speaker_ids[1] ), $resolved );
+	}
+
+	/**
+	 * Test authorization, nonce validation and write behavior of AJAX handler.
+	 */
+	public function test_ajax_handler_security_checks() {
+		$page = new Wpfaevent_Event_Dashboard_Page();
+
+		// 1. Logged in user with no capabilities (subscriber)
+		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+		$_POST['event_id']    = $this->event_id;
+		$_POST['nonce']       = wp_create_nonce( 'wpfaevent_save_featured_speakers_' . $this->event_id );
+		$_POST['speaker_ids'] = array( $this->speaker_ids[0] );
+
+		$res = $this->execute_ajax( $page );
+		$this->assertFalse( $res['success'] );
+		$this->assertSame( 'You are not allowed to edit this event.', $res['data']['message'] );
+
+		// 2. Logged in with correct capability, but invalid nonce
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$_POST['nonce'] = 'invalid_nonce';
+
+		$res = $this->execute_ajax( $page );
+		$this->assertFalse( $res['success'] );
+		$this->assertSame( 'Invalid request or session expired.', $res['data']['message'] );
+
+		// 3. Correct credentials, correct nonce, successful write
+		$_POST['nonce'] = wp_create_nonce( 'wpfaevent_save_featured_speakers_' . $this->event_id );
+
+		$res = $this->execute_ajax( $page );
+		$this->assertTrue( $res['success'] );
+		$this->assertSame( 'Featured speakers saved successfully.', $res['data']['message'] );
+
+		// Verify write in database.
+		$saved_ids = get_post_meta( $this->event_id, 'wpfa_event_featured_speakers', true );
+		$this->assertEqualsCanonicalizing( array( $this->speaker_ids[0] ), $saved_ids );
+		$this->assertSame( 'yes', get_post_meta( $this->event_id, 'wpfa_event_featured_speakers_manual', true ) );
+	}
+
+	/**
+	 * Helper to execute AJAX controller action under output buffer and catch response.
+	 *
+	 * @param Wpfaevent_Event_Dashboard_Page $page Dashboard page controller.
+	 * @return array
+	 */
+	private function execute_ajax( $page ) {
+		unset( $page ); // Wpfaevent_Event_Dashboard_Page is called via hook registration.
+		$_POST['action']      = 'wpfaevent_save_featured_speakers';
+		$this->_last_response = '';
+		try {
+			$this->_handleAjax( 'wpfaevent_save_featured_speakers' );
+		} catch ( WPAjaxDieStopException $e ) {
+			$this->_last_response = $e->getMessage();
+		} catch ( WPAjaxDieContinueException $e ) {
+			if ( empty( $this->_last_response ) ) {
+				$this->_last_response = $e->getMessage();
+			}
+		} catch ( Throwable $e ) {
+			unset( $e );
+		}
+		return json_decode( $this->_last_response, true );
+	}
+}


### PR DESCRIPTION
This PR implements manual featured speaker selection, drag-and-drop ordering control in the event dashboard, and public rendering ordering for issue #249.

## Summary by Sourcery

Enable event managers to manually select and order featured speakers from the event dashboard.

New Features:
- Add dashboard controls for selecting featured speakers and arranging them via drag and drop.
- Render manually selected featured speakers in the configured order on public speaker pages.

Enhancements:
- Preserve existing automatic featured-speaker behavior unless manual selection is enabled.
- Resolve speaker identifiers consistently for dashboard selection and ordering.

Tests:
- Add coverage for manual selection, order preservation, missing speakers, and AJAX authorization and persistence.


## Screencast


https://github.com/user-attachments/assets/fbf651c9-bbdf-4052-9a8b-e7425fe44396

https://github.com/user-attachments/assets/26699eec-28b8-4537-9090-24430699852a

https://github.com/user-attachments/assets/37d3fad1-2870-4501-9f1a-addd2e9df10f

https://github.com/user-attachments/assets/c743022f-8cd2-4cd2-a6ca-3d1ce56b37c3




## Summary by Sourcery

Enable event managers to manually select and order featured speakers while preserving automatic selection by default.

New Features:
- Add event dashboard controls to select featured speakers and arrange them with drag-and-drop ordering.
- Render manually selected featured speakers publicly in the configured order.

Bug Fixes:
- Filter invalid, unrelated, duplicate, and deleted speaker identifiers when saving featured speakers.

Enhancements:
- Preserve existing automatic featured-speaker behavior when manual mode is not enabled.
- Resolve dashboard speakers consistently against linked speaker posts.

Tests:
- Add coverage for manual selection, ordering, automatic fallback, missing speakers, AJAX authorization, persistence, and safe dashboard scripting.

## Summary by Sourcery

Enable event managers to manually select, order, and publish featured speakers while retaining the existing automatic behavior by default.

New Features:
- Add event dashboard controls for selecting featured speakers and arranging them with drag-and-drop ordering.
- Display manually selected featured speakers publicly in the configured order.

Bug Fixes:
- Filter invalid, unrelated, duplicate, deleted, and non-speaker identifiers when saving featured speakers.

Enhancements:
- Preserve automatic featured-speaker selection and ordering when manual mode is disabled.
- Consistently map dashboard speaker records to linked speaker posts.

Tests:
- Add coverage for manual selection, ordering, automatic fallback, missing speakers, AJAX authorization and persistence, and safe dashboard scripting.

Chores:
- Refactor dashboard presentation styles from inline declarations into reusable CSS classes.

Fixes #249

## Summary by Sourcery

Enable event managers to manually select, order, and publish featured speakers while retaining automatic selection by default.

New Features:
- Add event-dashboard controls for selecting featured speakers and arranging them with drag-and-drop ordering.
- Display manually selected featured speakers publicly in the configured order, with responsive expansion controls for larger speaker lists.

Bug Fixes:
- Filter invalid, unrelated, duplicate, deleted, and non-speaker identifiers when saving featured speakers.

Enhancements:
- Preserve existing automatic featured-speaker selection and ordering when manual mode is disabled.
- Resolve dashboard speaker records consistently against linked speaker posts.
- Move dashboard presentation styling from inline declarations into reusable CSS classes.

Tests:
- Add coverage for manual selection, order preservation, automatic fallback, missing speakers, AJAX authorization and persistence, and safe dashboard scripting.