### PR TITLE
ci: add GitHub Actions workflow for ESLint

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,52 @@
+name: ESLint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  file-filter:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      js: ${{ steps.filter.outputs.js }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            js:
+              - '**/*.js'
+              - '**/*.mjs'
+              - '**/*.cjs'
+              - 'eslint.config.mjs'
+              - 'package.json'
+              - 'package-lock.json'
+
+  eslint:
+    needs: file-filter
+    if: | 
+      always() &&
+      (github.event_name == 'push' || needs.file-filter.outputs.js == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+    
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+    
+      - name: Install dependencies
+        run: npm ci
+    
+      - name: Run ESLint
+        run: npm run lint

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,21 +32,21 @@ jobs:
 
   eslint:
     needs: file-filter
-    if: | 
+    if: |
       always() &&
       (github.event_name == 'push' || needs.file-filter.outputs.js == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-    
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'npm'
-    
+
       - name: Install dependencies
         run: npm ci
-    
+
       - name: Run ESLint
         run: npm run lint


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs ESLint automatically on JavaScript changes.

## What it does

- Runs on `pull_request` and `push` events targeting `main`.
- Sets up Node.js `24`, matching the `engines.node` field in `package.json`.
- Installs dependencies with `npm ci` for reproducible installs from `package-lock.json`.
- Runs `npm run lint` (`eslint .`) and fails the job if ESLint reports any errors.
- On pull requests, uses `dorny/paths-filter` to only run when JS-relevant files change (`**/*.js`, `**/*.mjs`, `**/*.cjs`, `eslint.config.mjs`, `package.json`, `package-lock.json`), following the same pattern already used in `phpcs.yml`. Pushes to `main` always run the full lint.

## Why this approach

The workflow structure mirrors the existing `phpcs.yml` workflow in this repo (checkout version, permissions block, path-filtering pattern) to keep CI conventions consistent across PHP and JS tooling.

## References

- [GitHub Actions documentation](https://docs.github.com/en/actions)
- [GitHub Actions workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
- [`actions/setup-node`](https://github.com/actions/setup-node)
- [`dorny/paths-filter`](https://github.com/dorny/paths-filter)
- [ESLint documentation](https://eslint.org/docs/latest/)
- [Node.js documentation](https://nodejs.org/docs/latest/api/)

---

- Closes #251

## Summary by Sourcery

Add automated ESLint checks to the GitHub Actions CI pipeline.

New Features:
- Add a GitHub Actions workflow to run ESLint for JavaScript-related changes and pushes to main.

CI:
- Filter pull request runs to relevant JavaScript and dependency configuration changes while running lint on every push to main.
- Use Node.js 24 with reproducible npm dependency installation in the lint job.