### PR TITLE
ci: add opt-in EC2 deployment workflow

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -1,0 +1,68 @@
+name: Deploy Plugin to EC2
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-ec2-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-latest
+    environment: production
+    if: vars.EC2_DEPLOY_ENABLED == 'true'
+    steps:
+      - name: Deploy plugin over SSH
+        uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
+        with:
+          host: ${{ vars.EC2_HOST }}
+          username: ${{ vars.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: ${{ vars.EC2_PORT || 22 }}
+          fingerprint: ${{ vars.EC2_HOST_FINGERPRINT }}
+          command_timeout: 10m
+          script: |
+            set -eu
+
+            PLUGIN_PATH="${{ vars.EC2_PLUGIN_PATH }}"
+            DEPLOY_BRANCH="${{ vars.EC2_DEPLOY_BRANCH || 'main' }}"
+
+            if [ -z "$PLUGIN_PATH" ]; then
+              echo "EC2_PLUGIN_PATH GitHub variable is not set."
+              exit 1
+            fi
+
+            if [ ! -d "$PLUGIN_PATH/.git" ]; then
+              echo "Expected a git checkout at $PLUGIN_PATH but .git was not found."
+              exit 1
+            fi
+
+            cd "$PLUGIN_PATH"
+
+            if [ -n "$(git status --porcelain)" ]; then
+              echo "Deployment aborted because the plugin checkout has uncommitted changes."
+              git status --short
+              exit 1
+            fi
+
+            git fetch origin "$DEPLOY_BRANCH"
+            git checkout "$DEPLOY_BRANCH"
+            git pull --ff-only origin "$DEPLOY_BRANCH"
+
+            if ! command -v composer >/dev/null 2>&1; then
+              echo "Composer is required on the EC2 instance."
+              exit 1
+            fi
+
+            composer install --no-dev --prefer-dist --optimize-autoloader --no-interaction
+
+            if command -v wp >/dev/null 2>&1; then
+              wp cache flush || true
+            fi

--- a/docs/deploy-ec2.md
+++ b/docs/deploy-ec2.md
@@ -1,0 +1,70 @@
+# Deploying WPFAevent to EC2 with GitHub Actions
+
+The [`Deploy Plugin to EC2`](../.github/workflows/deploy-ec2.yml) workflow updates a
+git checkout on an EC2 instance after a commit reaches `main`. It can also be run
+manually. The deployment job is skipped until a repository administrator opts in
+by setting `EC2_DEPLOY_ENABLED` to `true`.
+
+Only repository administrators can complete the GitHub configuration. Secrets in
+a fork are not available to the upstream repository.
+
+## Prepare the EC2 instance
+
+Install Git, PHP, Composer, and WP-CLI if the site uses it. Clone this repository
+at the WordPress plugin path, for example:
+
+```bash
+cd /var/www/html/wp-content/plugins
+git clone https://github.com/fossasia/WPFAevent.git event-plugin
+cd event-plugin
+composer install --no-dev --prefer-dist --optimize-autoloader
+```
+
+The SSH user must be able to update this checkout. Keep production-only files and
+configuration outside the checkout because deployment stops when tracked or
+untracked files are present.
+
+## Configure SSH access
+
+Create a dedicated SSH key for deployment. Add its public key to the deployment
+user's `~/.ssh/authorized_keys` file on EC2. Store the complete private key as the
+`EC2_SSH_KEY` Actions secret in the repository's `production` environment.
+
+Retrieve the server's SHA256 host-key fingerprint from a trusted administrative
+connection and compare it with the fingerprint reported by EC2 before saving it.
+Do not obtain and trust the fingerprint through the deployment connection itself.
+
+## Enable deployment and configure the production environment
+
+In **Settings → Secrets and variables → Actions**, create the repository variable
+`EC2_DEPLOY_ENABLED` with the value `true`. Keeping this variable unset prevents
+the upstream workflow from attempting a deployment before an environment is
+ready.
+
+Next, in **Settings → Environments**, create an environment named `production`.
+Add deployment protection rules and required reviewers when appropriate, then
+create the following environment variables:
+
+| Variable | Required | Example |
+| --- | --- | --- |
+| `EC2_HOST` | Yes | `ec2-host.example.com` |
+| `EC2_USER` | Yes | `deploy` |
+| `EC2_PORT` | No | `22` |
+| `EC2_PLUGIN_PATH` | Yes | `/var/www/html/wp-content/plugins/event-plugin` |
+| `EC2_DEPLOY_BRANCH` | No | `main` |
+| `EC2_HOST_FINGERPRINT` | Yes | `SHA256:...` |
+
+Environment-level configuration limits the credentials to the production job and
+allows GitHub's deployment approvals to protect access.
+
+## Verify the deployment
+
+1. Open **Actions → Deploy Plugin to EC2**.
+2. Select **Run workflow** and run it from `main`.
+3. Confirm that SSH host verification succeeds, the checkout fast-forwards, and
+   Composer completes.
+4. Confirm the deployed commit on EC2 with `git rev-parse HEAD`.
+
+Subsequent pushes to `main` run the same deployment automatically. The workflow
+uses `git pull --ff-only` and refuses to deploy over local changes so a divergent
+or manually modified production checkout fails safely.


### PR DESCRIPTION
## Summary

- add an opt-in deployment from `main` to an EC2-hosted WordPress plugin checkout
- pin the SSH action to a commit and verify the EC2 host fingerprint
- scope credentials to a protected `production` environment
- document server preparation, repository settings, and deployment verification

The job remains skipped until an upstream administrator sets the repository variable `EC2_DEPLOY_ENABLED=true`. The EC2 secret and variables must be configured in the upstream repository's `production` environment; secrets from forks are not inherited.

## Validation

- `composer phpcs`
- `composer phpstan`
- `composer test` (34 tests, 81 assertions)
- YAML parse and whitespace checks

## Summary by Sourcery

Provide a guarded, documented workflow for deploying the WordPress plugin to an EC2 production checkout.

New Features:
- Add an opt-in GitHub Actions workflow that deploys the plugin from `main` to an EC2-hosted checkout over SSH.
- Protect production deployment credentials with the GitHub `production` environment and host fingerprint verification.

Enhancements:
- Safely update the EC2 checkout only when it is clean and can fast-forward, then install production dependencies and optionally flush WordPress caches.

CI:
- Add concurrency control and cancellation for overlapping EC2 deployment runs.

Deployment:
- Support automatic deployments on pushes to `main` and manual production deployment runs when explicitly enabled.

Documentation:
- Document EC2 preparation, SSH configuration, production environment variables, deployment enablement, and verification steps.