### PR TITLE
fix: prevent schedule filter overflow

### DIFF
--- a/public/css/templates/schedule.css
+++ b/public/css/templates/schedule.css
@@ -122,7 +122,8 @@
 }
 
 .wpfaevent .wpfa-schedule-filter-form.has-language-filter.has-session-filters {
-	grid-template-columns: repeat(4, minmax(150px, 220px)) minmax(220px, 320px) auto auto;
+	grid-template-columns: repeat(4, minmax(0, 1fr)) minmax(0, 1.5fr) auto auto;
+	width: 100%;
 }
 
 .wpfaevent .wpfa-schedule-filter-form label {


### PR DESCRIPTION
## Summary

- allow the fully populated schedule filter columns to shrink within the available desktop space
- keep the room filter proportionally wider for longer option labels
- preserve the existing action sizing and tablet/mobile layouts

Closes and Fixes: #260

## Validation

- `git diff --check`
- `composer phpcs`
- `composer phpstan`
- `composer test` could not start because the local WordPress test suite is not installed (`WP test suite not found`)

## Scope

CSS-only change in `public/css/templates/schedule.css`.


## Screenshot Before vs After

Before

<img width="1438" height="397" alt="Screenshot 2026-08-29 at 11 37 56 PM" src="https://github.com/user-attachments/assets/dcfbf5de-66a4-4f80-8de6-68cf853f7328" />

After 

<img width="1440" height="397" alt="Screenshot 2026-08-29 at 11 45 34 PM" src="https://github.com/user-attachments/assets/e1d14373-a887-4824-9d42-2a18561fc589" />