### PR TITLE
fix: simplify speaker list link label

### DIFF
--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -445,7 +445,7 @@ if ( $show_ticket_widget ) {
 						<div>
 							<h2 id="wpfa-event-speakers-title"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></h2>
 						</div>
-						<a href="<?php echo esc_url( $speakers_url ); ?>"><?php esc_html_e( 'Open Event Speaker List', 'wpfaevent' ); ?></a>
+						<a href="<?php echo esc_url( $speakers_url ); ?>"><?php esc_html_e( 'Open Speaker List', 'wpfaevent' ); ?></a>
 					</div>
 
 					<?php if ( ! empty( $speaker_ids ) ) : ?>


### PR DESCRIPTION
## Summary

- change the speaker section link from **Open Event Speaker List** to **Open Speaker List**
- preserve the existing translatable `wpfaevent` string pattern and link behavior

Closes #266

## Validation

- `php -l public/templates/single-wpfa-event.php`
- `composer phpcs`
- `composer phpstan`
- `composer test` *(cannot run: local WordPress test suite is not installed)*

## Summary by Sourcery

Bug Fixes:
- Simplify the speaker list link label from “Open Event Speaker List” to “Open Speaker List” while preserving its translation and link behavior.


## Screenshot

Before 
<img width="302" height="93" alt="Screenshot 2026-08-31 at 1 45 44 PM" src="https://github.com/user-attachments/assets/432a59bc-4a4d-42a7-af0e-0690704c074b" />

After
<img width="228" height="95" alt="Screenshot 2026-08-31 at 1 45 57 PM" src="https://github.com/user-attachments/assets/64d766d9-f504-40a8-9727-83a4076c76d6" />
