### PR TITLE
fix: delete legacy and imported sponsors

### DIFF
--- a/admin/class-wpfaevent-partner-dashboard-controller.php
+++ b/admin/class-wpfaevent-partner-dashboard-controller.php
@@ -221,14 +221,7 @@ class Wpfaevent_Partner_Dashboard_Controller {
 		}
 
 		$records         = $this->stats->load_records( $type, $event_id );
-		$updated_records = array();
-
-		foreach ( $records as $rec ) {
-			if ( isset( $rec['id'] ) && $rec['id'] === $id ) {
-				continue; // Skip the deleted record.
-			}
-			$updated_records[] = $rec;
-		}
+		$updated_records = $this->remove_partner_record( $records, $id );
 
 		// Save the updated list back to the JSON file.
 		if ( 'sponsor' === $type ) {
@@ -251,6 +244,36 @@ class Wpfaevent_Partner_Dashboard_Controller {
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Remove a partner using the normalized key used by dashboard URLs.
+	 *
+	 * Legacy manually created partners may contain uppercase characters in their
+	 * stored IDs. Normalize both sides so those records remain deletable.
+	 *
+	 * @param array  $records Partner records.
+	 * @param string $id      Requested partner ID.
+	 * @return array
+	 */
+	private function remove_partner_record( $records, $id ) {
+		$id = sanitize_key( $id );
+
+		if ( ! is_array( $records ) || '' === $id ) {
+			return is_array( $records ) ? $records : array();
+		}
+
+		$updated_records = array();
+
+		foreach ( $records as $record ) {
+			if ( is_array( $record ) && Wpfaevent_Partner_Helper::get_partner_key( $record ) === $id ) {
+				continue;
+			}
+
+			$updated_records[] = $record;
+		}
+
+		return $updated_records;
 	}
 
 	/**

--- a/admin/class-wpfaevent-partner-dashboard-controller.php
+++ b/admin/class-wpfaevent-partner-dashboard-controller.php
@@ -210,18 +210,19 @@ class Wpfaevent_Partner_Dashboard_Controller {
 			wp_die( esc_html__( 'You do not have sufficient permissions to modify this page.', 'wpfaevent' ) );
 		}
 
-		$id = isset( $_GET['id'] ) ? sanitize_key( $_GET['id'] ) : '';
-		check_admin_referer( 'wpfaevent_delete_partner_' . $id );
+		$id           = isset( $_GET['id'] ) ? sanitize_key( wp_unslash( $_GET['id'] ) ) : '';
+		$record_index = isset( $_GET['record_index'] ) ? absint( wp_unslash( $_GET['record_index'] ) ) : null;
+		check_admin_referer( 'wpfaevent_delete_partner_' . $id . '_' . $record_index );
 
 		$type     = isset( $_GET['type'] ) ? sanitize_key( $_GET['type'] ) : '';
 		$event_id = isset( $_GET['event_id'] ) ? absint( $_GET['event_id'] ) : 0;
 
-		if ( ! $event_id || ! $id || ! in_array( $type, array( 'sponsor', 'exhibitor' ), true ) ) {
+		if ( ! $event_id || ! $id || null === $record_index || ! in_array( $type, array( 'sponsor', 'exhibitor' ), true ) ) {
 			wp_die( esc_html__( 'Invalid request parameters.', 'wpfaevent' ) );
 		}
 
 		$records         = $this->stats->load_records( $type, $event_id );
-		$updated_records = $this->remove_partner_record( $records, $id );
+		$updated_records = $this->remove_partner_record( $records, $id, $record_index );
 
 		// Save the updated list back to the JSON file.
 		if ( 'sponsor' === $type ) {
@@ -247,33 +248,29 @@ class Wpfaevent_Partner_Dashboard_Controller {
 	}
 
 	/**
-	 * Remove a partner using the normalized key used by dashboard URLs.
+	 * Remove an indexed partner using the normalized key used by dashboard URLs.
 	 *
 	 * Legacy manually created partners may contain uppercase characters in their
-	 * stored IDs. Normalize both sides so those records remain deletable.
+	 * stored IDs. Normalize both sides so those records remain deletable, while
+	 * the record index prevents collisions from removing multiple records.
 	 *
-	 * @param array  $records Partner records.
-	 * @param string $id      Requested partner ID.
+	 * @param array  $records      Partner records.
+	 * @param string $id           Requested partner ID.
+	 * @param int    $record_index Requested record index.
 	 * @return array
 	 */
-	private function remove_partner_record( $records, $id ) {
+	private function remove_partner_record( $records, $id, $record_index ) {
 		$id = sanitize_key( $id );
 
-		if ( ! is_array( $records ) || '' === $id ) {
+		if ( ! is_array( $records ) || '' === $id || ! isset( $records[ $record_index ] ) ) {
 			return is_array( $records ) ? $records : array();
 		}
 
-		$updated_records = array();
-
-		foreach ( $records as $record ) {
-			if ( is_array( $record ) && Wpfaevent_Partner_Helper::get_partner_key( $record ) === $id ) {
-				continue;
-			}
-
-			$updated_records[] = $record;
+		if ( is_array( $records[ $record_index ] ) && Wpfaevent_Partner_Helper::get_partner_key( $records[ $record_index ] ) === $id ) {
+			unset( $records[ $record_index ] );
 		}
 
-		return $updated_records;
+		return array_values( $records );
 	}
 
 	/**

--- a/admin/class-wpfaevent-partner-dashboard-renderer.php
+++ b/admin/class-wpfaevent-partner-dashboard-renderer.php
@@ -511,7 +511,7 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 												);
 												?>
 																						"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></a>
-											<?php if ( $is_manual && $delete_id ) : ?>
+											<?php if ( $delete_id ) : ?>
 													<?php
 													$delete_url = wp_nonce_url(
 														add_query_arg(

--- a/admin/class-wpfaevent-partner-dashboard-renderer.php
+++ b/admin/class-wpfaevent-partner-dashboard-renderer.php
@@ -440,6 +440,7 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 								<?php foreach ( $paged_items as $item ) : ?>
 									<?php
 									$item_id      = isset( $item['id'] ) ? $item['id'] : '';
+									$delete_id    = Wpfaevent_Partner_Helper::get_partner_key( $item );
 									$item_name    = isset( $item['name'] ) ? $item['name'] : '';
 									$item_company = isset( $item['company'] ) ? $item['company'] : '';
 									$item_phone   = isset( $item['phone'] ) ? $item['phone'] : '';
@@ -510,19 +511,19 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 												);
 												?>
 																						"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></a>
-												<?php if ( $is_manual ) : ?>
+											<?php if ( $is_manual && $delete_id ) : ?>
 													<?php
 													$delete_url = wp_nonce_url(
 														add_query_arg(
 															array(
 																'action'   => 'wpfaevent_delete_partner',
-																'id'       => $item_id,
+														'id'       => $delete_id,
 																'type'     => $type,
 																'event_id' => $event_id,
 															),
 															admin_url( 'admin-post.php' )
 														),
-														'wpfaevent_delete_partner_' . $item_id
+												'wpfaevent_delete_partner_' . $delete_id
 													);
 													?>
 													<a class="button button-small button-link-delete" href="<?php echo esc_url( $delete_url ); ?>" onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this profile?', 'wpfaevent' ); ?>');"><?php esc_html_e( 'Delete', 'wpfaevent' ); ?></a>

--- a/admin/class-wpfaevent-partner-dashboard-renderer.php
+++ b/admin/class-wpfaevent-partner-dashboard-renderer.php
@@ -121,6 +121,13 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 			}
 		}
 
+		foreach ( $records as $record_index => &$record ) {
+			if ( is_array( $record ) ) {
+				$record['_wpfaevent_delete_index'] = $record_index;
+			}
+		}
+		unset( $record );
+
 		// Filter, search, and sort records.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$search_query = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
@@ -441,6 +448,7 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 									<?php
 									$item_id      = isset( $item['id'] ) ? $item['id'] : '';
 									$delete_id    = Wpfaevent_Partner_Helper::get_partner_key( $item );
+									$delete_index = isset( $item['_wpfaevent_delete_index'] ) ? absint( $item['_wpfaevent_delete_index'] ) : null;
 									$item_name    = isset( $item['name'] ) ? $item['name'] : '';
 									$item_company = isset( $item['company'] ) ? $item['company'] : '';
 									$item_phone   = isset( $item['phone'] ) ? $item['phone'] : '';
@@ -511,19 +519,20 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 												);
 												?>
 																						"><?php esc_html_e( 'Edit', 'wpfaevent' ); ?></a>
-											<?php if ( $delete_id ) : ?>
+												<?php if ( $delete_id && null !== $delete_index ) : ?>
 													<?php
 													$delete_url = wp_nonce_url(
 														add_query_arg(
 															array(
-																'action'   => 'wpfaevent_delete_partner',
-																'id'       => $delete_id,
-																'type'     => $type,
-																'event_id' => $event_id,
+																'action'       => 'wpfaevent_delete_partner',
+																'id'           => $delete_id,
+																'record_index' => $delete_index,
+																'type'         => $type,
+																'event_id'     => $event_id,
 															),
 															admin_url( 'admin-post.php' )
 														),
-														'wpfaevent_delete_partner_' . $delete_id
+														'wpfaevent_delete_partner_' . $delete_id . '_' . $delete_index
 													);
 													?>
 													<a class="button button-small button-link-delete" href="<?php echo esc_url( $delete_url ); ?>" onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this profile?', 'wpfaevent' ); ?>');"><?php esc_html_e( 'Delete', 'wpfaevent' ); ?></a>

--- a/admin/class-wpfaevent-partner-dashboard-renderer.php
+++ b/admin/class-wpfaevent-partner-dashboard-renderer.php
@@ -523,7 +523,7 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 															),
 															admin_url( 'admin-post.php' )
 														),
-													'wpfaevent_delete_partner_' . $delete_id
+														'wpfaevent_delete_partner_' . $delete_id
 													);
 													?>
 													<a class="button button-small button-link-delete" href="<?php echo esc_url( $delete_url ); ?>" onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this profile?', 'wpfaevent' ); ?>');"><?php esc_html_e( 'Delete', 'wpfaevent' ); ?></a>

--- a/admin/class-wpfaevent-partner-dashboard-renderer.php
+++ b/admin/class-wpfaevent-partner-dashboard-renderer.php
@@ -517,13 +517,13 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 														add_query_arg(
 															array(
 																'action'   => 'wpfaevent_delete_partner',
-														'id'       => $delete_id,
+																'id'       => $delete_id,
 																'type'     => $type,
 																'event_id' => $event_id,
 															),
 															admin_url( 'admin-post.php' )
 														),
-												'wpfaevent_delete_partner_' . $delete_id
+													'wpfaevent_delete_partner_' . $delete_id
 													);
 													?>
 													<a class="button button-small button-link-delete" href="<?php echo esc_url( $delete_url ); ?>" onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this profile?', 'wpfaevent' ); ?>');"><?php esc_html_e( 'Delete', 'wpfaevent' ); ?></a>

--- a/tests/unit/PartnerDashboardControllerTest.php
+++ b/tests/unit/PartnerDashboardControllerTest.php
@@ -45,10 +45,36 @@ class PartnerDashboardControllerTest extends WP_UnitTestCase {
 			),
 		);
 
-		$remaining = $method->invoke( $controller, $records, 'manual-sponsor-abc12xyz' );
+		$remaining = $method->invoke( $controller, $records, 'manual-sponsor-abc12xyz', 0 );
 
 		$this->assertCount( 1, $remaining );
 		$this->assertSame( 'manual-sponsor-current123', $remaining[0]['id'] );
+	}
+
+	/**
+	 * Delete requests should remove only the indexed record when normalized IDs collide.
+	 */
+	public function test_remove_partner_record_deletes_only_indexed_normalized_id_collision() {
+		$controller = new Wpfaevent_Partner_Dashboard_Controller();
+		$method     = new ReflectionMethod( $controller, 'remove_partner_record' );
+		$method->setAccessible( true );
+		$records = array(
+			array(
+				'id'     => 'manual-sponsor-AbC123',
+				'source' => 'manual',
+				'name'   => 'Uppercase Legacy Sponsor',
+			),
+			array(
+				'id'     => 'manual-sponsor-abc123',
+				'source' => 'manual',
+				'name'   => 'Lowercase Legacy Sponsor',
+			),
+		);
+
+		$remaining = $method->invoke( $controller, $records, 'manual-sponsor-abc123', 0 );
+
+		$this->assertCount( 1, $remaining );
+		$this->assertSame( 'manual-sponsor-abc123', $remaining[0]['id'] );
 	}
 
 	/**

--- a/tests/unit/PartnerDashboardControllerTest.php
+++ b/tests/unit/PartnerDashboardControllerTest.php
@@ -26,6 +26,32 @@ class PartnerDashboardControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Legacy mixed-case IDs should match the normalized IDs used in delete URLs.
+	 */
+	public function test_remove_partner_record_deletes_legacy_mixed_case_id() {
+		$controller = new Wpfaevent_Partner_Dashboard_Controller();
+		$method     = new ReflectionMethod( $controller, 'remove_partner_record' );
+		$method->setAccessible( true );
+		$records = array(
+			array(
+				'id'     => 'manual-sponsor-AbC12xYz',
+				'source' => 'manual',
+				'name'   => 'Legacy Sponsor',
+			),
+			array(
+				'id'     => 'manual-sponsor-current123',
+				'source' => 'manual',
+				'name'   => 'Current Sponsor',
+			),
+		);
+
+		$remaining = $method->invoke( $controller, $records, 'manual-sponsor-abc12xyz' );
+
+		$this->assertCount( 1, $remaining );
+		$this->assertSame( 'manual-sponsor-current123', $remaining[0]['id'] );
+	}
+
+	/**
 	 * Successful sponsor-group reorders should persist and redirect with a success notice.
 	 */
 	public function test_process_reorder_sponsor_groups_persists_reordered_groups() {


### PR DESCRIPTION
Fixes and Closes #234 

Summary

- Normalize legacy manual sponsor IDs when generating delete URLs and nonces
- Match stored partner IDs through the same normalized key during deletion
- Add regression coverage for pre-fix mixed-case sponsor IDs 

## Screencast

https://github.com/user-attachments/assets/29e2b641-1bc1-4610-ad0d-f3e45ec8d66e

## Summary by Sourcery

Fix partner deletion by normalizing IDs while targeting the specific indexed record.

Bug Fixes:
- Fix deletion of legacy and imported sponsor records whose stored IDs differ in case from normalized dashboard IDs.
- Prevent deletions from removing multiple records when normalized partner IDs collide.

Enhancements:
- Use stable record indexes and normalized partner keys for dashboard deletion requests and nonce validation.

Tests:
- Add regression tests covering mixed-case legacy IDs and normalized ID collisions during deletion.