### PR TITLE
ci: increase PHPStan analysis level from 5 to 6

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5 # TODO: raise level incrementally as codebase is cleaned up
+    level: 6 # TODO: raise level incrementally as codebase is cleaned up
 
     # Target PHP 7.4 specifically to match the plugin's platform requirement
     phpVersion: 70400


### PR DESCRIPTION
## Description

The project currently runs PHPStan at level 5. To further improve static analysis coverage and strengthen type safety, this PR updates the PHPStan configuration to level 6.

PHPStan level 6 introduces checks for missing typehints. This helps identify functions, methods, parameters, properties, and return values that lack explicit type information, improving code clarity, maintainability, and the safety of future refactoring.

## Expected Behavior

* Update the PHPStan configuration (`phpstan.neon` or `phpstan.neon.dist`) from level 5 to level 6.

## Benefits

* **Stronger type safety:** Makes expected parameter and return types more explicit.
* **Improved code readability:** Clearly communicates how functions, methods, and properties are expected to be used.
* **Better static analysis:** Allows PHPStan and IDEs to detect more potential issues.
* **Safer refactoring:** Explicit type information makes future changes easier to validate.
* **Improved maintainability:** Reduces loosely typed areas of the codebase.
* **Incremental progress:** Continues the project's progression toward stricter PHPStan analysis, with level 7 as the next target.

## Reference

* [PHPStan Rule Levels Documentation](https://phpstan.org/user-guide/rule-levels)

---

* Fixes: #196

## Summary by Sourcery

Enhancements:
- Raise the PHPStan analysis level from 5 to 6 to strengthen static type checking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased static analysis strictness to help identify potential code issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->