### PR TITLE
ci: run the PHPUnit test suite on push and pull request

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,83 @@
+name: PHPUnit
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  file-filter:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      php: ${{ steps.filter.outputs.php }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            php:
+              - '**/*.php'
+              - 'composer.json'
+              - 'phpunit.xml.dist'
+              - 'bin/install-wp-tests.sh'
+              - '.github/workflows/phpunit.yml'
+
+  phpunit:
+    name: PHPUnit Test Suite
+    needs: file-filter
+    if: |
+      always() &&
+      (github.event_name == 'push' || needs.file-filter.outputs.php == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      # The database is intentionally left uncreated so that
+      # bin/install-wp-tests.sh creates it without prompting to drop it.
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: wordpress_test_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup PHP Environment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mysqli
+          coverage: none
+          tools: composer
+
+      - name: Install MySQL client
+        run: sudo apt-get update && sudo apt-get install -y mysql-client
+
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@v4
+        with:
+          composer-options: '--prefer-dist --optimize-autoloader --no-scripts'
+
+      - name: Install the WordPress test suite
+        run: bash bin/install-wp-tests.sh wordpress_test root wordpress_test_password 127.0.0.1 latest
+
+      - name: Run PHPUnit
+        run: composer test


### PR DESCRIPTION
Closes #259

Nothing in CI runs the PHPUnit suite. No workflow, git hook, or task runner references `composer test`, so the 68 tests across 12 unit test files and 1 integration test file only run when someone runs them by hand.

Until #248 the calendar checks were the one exception, and only because they shipped as a standalone script with a dedicated workflow. That workflow is gone now, so a regression in any test can be merged without CI noticing.

### What this adds

`.github/workflows/phpunit.yml`, modelled on `phpstan.yml` as the issue suggests: the same `paths-filter` gate job, the same `always() && (push || ...)` condition, and the same `actions/checkout@v7` / `shivammathur/setup-php@v2` (PHP 8.2) / `ramsey/composer-install@v4` versions. A MySQL 8 service backs the WordPress test database, then `bin/install-wp-tests.sh` bootstraps the test library and `composer test` runs the suite.

### Documentation reference

The parts of `.github/workflows/phpunit.yml` where the choice needs justifying, and the documentation behind each.

#### 1. Job conditions - `if:` and `always()`
- **Documentation**: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions
- **Documentation**: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always
- `file-filter` is skipped on `push`, and a skipped dependency would normally skip the dependent job too. `always()` keeps `phpunit` eligible, and the rest of the condition decides: run on every push, or on a pull request only when PHP-related files changed.

#### 2. `services:` - the MySQL container
- **Documentation**: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idservices
- **Tutorial**: https://docs.github.com/en/actions/tutorials/use-containerized-services/use-docker-service-containers
- The WordPress test suite needs a real database. The service is published on `3306:3306` so the job reaches it at `127.0.0.1`.

#### 3. `services.<service_id>.options` - the health check
- **Documentation**: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idservicesservice_idoptions
- **Documentation**: https://docs.docker.com/reference/cli/docker/container/create/
- `options` is passed straight to `docker create`, which is where `--health-cmd`, `--health-interval`, `--health-timeout` and `--health-retries` are defined. GitHub waits for the container to report healthy before the first step runs, so `bin/install-wp-tests.sh` cannot start against a database that is still booting.

#### 4. `image: mysql:8.0` and `MYSQL_ROOT_PASSWORD`
- **Documentation**: https://hub.docker.com/_/mysql
- `MYSQL_ROOT_PASSWORD` is required by the official image. `MYSQL_DATABASE` is deliberately not set: `bin/install-wp-tests.sh` creates `wordpress_test` itself, and an existing database makes it prompt to drop it, which would hang a non-interactive runner.

#### 5. `dorny/paths-filter@v4`
- **Documentation**: https://github.com/dorny/paths-filter
- Same gating pattern as `phpstan.yml` and `phpcs.yml`. The filter lists the paths that can affect a test result: PHP sources, `composer.json`, `phpunit.xml.dist`, `bin/install-wp-tests.sh` and this workflow.

#### 6. `shivammathur/setup-php@v2`
- **Documentation**: https://github.com/shivammathur/setup-php
- PHP 8.2 to match `phpstan.yml` and `phpcs.yml`. `extensions: mysqli` is required by the WordPress test bootstrap; `coverage: none` disables Xdebug/PCOV, which is faster since this job does not collect coverage.

#### 7. `ramsey/composer-install@v4`
- **Documentation**: https://github.com/ramsey/composer-install
- Its `dependency-versions` input defaults to `locked`, so it installs from `composer.lock` and caches the result.

#### 8. Composer install options
- **Documentation**: https://getcomposer.org/doc/03-cli.md#install-i
- **Documentation**: https://getcomposer.org/doc/articles/autoloader-optimization.md
- `--optimize-autoloader` converts PSR-4 rules to a classmap; `--no-scripts` skips root package scripts, which CI does not need. `--prefer-dist` is the legacy alias for `--prefer-install=dist`, kept here to match the exact string already used in `phpstan.yml`.

#### 9. `bin/install-wp-tests.sh` - the WordPress test suite
- **Documentation**: https://make.wordpress.org/cli/handbook/how-to/plugin-unit-tests/
- The script is the standard one generated by `wp scaffold plugin-tests`. It downloads the WordPress core test library and creates the test database. The host is passed as `127.0.0.1` rather than `localhost` so the client uses TCP instead of a unix socket, which the service container does not expose.

### Verification

Ran on a fork PR before opening this one, so every step is confirmed on a real runner rather than only locally. Whole job took **1m04s**:

| Step | Result |
|---|---|
| Initialize containers | MySQL service up, health check passed |
| Install MySQL client | ok |
| Install PHP dependencies | ok |
| Install the WordPress test suite | connected over TCP, no prompt, no hang |
| Run PHPUnit | green on PHP 8.2 |

Locally, `composer test` against this branch gives `OK (68 tests, 223 assertions)`. I also checked the non-interactive path from a clean slate: wiped `/tmp/wordpress*`, dropped the database, and ran both steps with stdin closed. Both exited 0.
### Workflow

```mermaid
flowchart TD
    A[Push to main] --> C
    B[Pull request to main] --> D["file-filter job<br/>Checks if PHP files changed"]

    D -->|php == true| E{"Run condition:<br/>push OR php files changed"}
    C[push event] --> E

    E -->|yes| F["phpunit job starts<br/>MySQL 8 service boots"]
    E -->|no, PR skips unrelated changes| Z[Job skipped]

    F --> G[Checkout code]
    G --> H["Setup PHP 8.2<br/>+ mysqli extension"]
    H --> I[Install MySQL client]
    I --> J["Install dependencies<br/>composer install --prefer-dist --optimize-autoloader --no-scripts"]
    J --> K["Bootstrap WordPress test suite<br/>bin/install-wp-tests.sh"]
    K --> L["Run PHPUnit<br/>composer test"]
    L --> M{Result}
    M -->|pass| N[PR check: ✅ green]
    M -->|fail| O[PR check: ❌ red, blocks merge]
```


## Summary by Sourcery

Add continuous PHPUnit validation to the CI pipeline for pushes to main and relevant pull requests.

Enhancements:
- Add automated PHPUnit coverage for relevant pushes and pull requests, including WordPress and MySQL test environment setup.

CI:
- Run the PHPUnit test suite in GitHub Actions on changes affecting PHP, test configuration, dependencies, the test bootstrap script, or the workflow itself, while retaining concurrency cancellation and path-based filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated PHPUnit workflow runs for pushes and pull requests targeting the main branch.
  * Tests run in a PHP 8.2 environment with MySQL and the WordPress test suite configured.
  * Pull request test runs are limited to changes affecting PHP-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
