### PR TITLE
fix: allow per-event color customization

### DIFF
--- a/admin/partials/meta-boxes/class-wpfaevent-admin-event-metabox.php
+++ b/admin/partials/meta-boxes/class-wpfaevent-admin-event-metabox.php
@@ -116,6 +116,7 @@ class Wpfaevent_Admin_Event_Metabox {
 		$lead_text  = get_post_meta( $post->ID, 'wpfa_event_lead_text', true );
 		$reg_link   = get_post_meta( $post->ID, 'wpfa_event_registration_link', true );
 		$cfs_link   = get_post_meta( $post->ID, 'wpfa_event_cfs_link', true );
+		$colors     = class_exists( 'Wpfaevent_Meta_Event' ) ? Wpfaevent_Meta_Event::get_event_colors( $post->ID ) : array();
 		$speakers   = $this->get_event_speaker_ids( $post->ID );
 
 		?>
@@ -196,6 +197,20 @@ class Wpfaevent_Admin_Event_Metabox {
 				<th><label for="wpfa_event_cfs_link"><?php esc_html_e( 'Call for Speakers Link', 'wpfaevent' ); ?></label></th>
 				<td><input type="url" id="wpfa_event_cfs_link" name="wpfa_event_cfs_link" value="<?php echo esc_attr( $cfs_link ); ?>" class="regular-text" placeholder="https://eventyay.com/e/.../cfs"></td>
 			</tr>
+			<?php if ( class_exists( 'Wpfaevent_Meta_Event' ) ) : ?>
+				<tr>
+					<th><?php esc_html_e( 'Event Colors', 'wpfaevent' ); ?></th>
+					<td>
+						<?php foreach ( Wpfaevent_Meta_Event::get_event_color_meta_fields() as $meta_key => $label ) : ?>
+							<p>
+								<label for="<?php echo esc_attr( $meta_key ); ?>"><?php echo esc_html( $label ); ?></label><br>
+								<input type="text" id="<?php echo esc_attr( $meta_key ); ?>" name="<?php echo esc_attr( $meta_key ); ?>" value="<?php echo esc_attr( isset( $colors[ $meta_key ] ) ? $colors[ $meta_key ] : '' ); ?>" class="regular-text" placeholder="#D51007">
+							</p>
+						<?php endforeach; ?>
+						<p class="description"><?php esc_html_e( 'Enter a hex or RGB color, for example #F97316. Imported Eventyay colors can be overridden here.', 'wpfaevent' ); ?></p>
+					</td>
+				</tr>
+			<?php endif; ?>
 			<tr>
 				<th><label for="wpfa_event_speakers"><?php esc_html_e( 'Speakers', 'wpfaevent' ); ?></label></th>
 				<td>
@@ -802,6 +817,17 @@ class Wpfaevent_Admin_Event_Metabox {
 				}
 
 				update_post_meta( $post_id, $field, $value );
+			}
+		}
+
+		if ( class_exists( 'Wpfaevent_Meta_Event' ) ) {
+			foreach ( array_keys( Wpfaevent_Meta_Event::get_event_color_meta_fields() ) as $meta_key ) {
+				if ( ! isset( $_POST[ $meta_key ] ) ) {
+					continue;
+				}
+
+				$color = Wpfaevent_Meta_Event::sanitize_color_value( sanitize_text_field( wp_unslash( $_POST[ $meta_key ] ) ) );
+				$this->update_or_delete_post_meta( $post_id, $meta_key, $color );
 			}
 		}
 

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -641,6 +641,14 @@ class Wpfaevent_Event_Template_Controller {
 			}
 		}
 
+		if ( ! empty( $event_colors['wpfa_event_primary_color'] ) && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+			$event_style_vars[] = '--event-primary-contrast: ' . Wpfaevent_Meta_Event::get_contrast_text_color( $event_colors['wpfa_event_primary_color'] );
+		}
+
+		if ( ! empty( $event_colors['wpfa_event_hover_button_color'] ) && class_exists( 'Wpfaevent_Meta_Event' ) ) {
+			$event_style_vars[] = '--event-primary-dark-contrast: ' . Wpfaevent_Meta_Event::get_contrast_text_color( $event_colors['wpfa_event_hover_button_color'] );
+		}
+
 		$event_style_attr = $event_style_vars ? ' style="' . esc_attr( implode( '; ', $event_style_vars ) ) . '"' : '';
 
 		foreach ( $sponsor_groups as $sponsor_group ) {

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -644,12 +644,12 @@ class Wpfaevent_Meta_Event {
 			return '#FFFFFF';
 		}
 
-		$luminance = 0;
+		$coefficients = array( 0.2126, 0.7152, 0.0722 );
+		$luminance    = 0;
 		foreach ( $rgb as $index => $channel ) {
-			$channel    = $channel / 255;
-			$channel    = $channel <= 0.03928 ? $channel / 12.92 : pow( ( $channel + 0.055 ) / 1.055, 2.4 );
-			$coefficient = array( 0.2126, 0.7152, 0.0722 );
-			$luminance  += $channel * $coefficient[ $index ];
+			$channel   = $channel / 255;
+			$channel   = $channel <= 0.03928 ? $channel / 12.92 : pow( ( $channel + 0.055 ) / 1.055, 2.4 );
+			$luminance += $channel * $coefficients[ $index ];
 		}
 
 		return $luminance > 0.179 ? '#000000' : '#FFFFFF';

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -618,6 +618,44 @@ class Wpfaevent_Meta_Event {
 	}
 
 	/**
+	 * Get an accessible text color for an event color background.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $color Background color.
+	 * @return string Accessible black or white text color.
+	 */
+	public static function get_contrast_text_color( $color ) {
+		$color = self::sanitize_color_value( $color );
+		$rgb   = array();
+
+		if ( preg_match( '/^#([0-9A-F]{3}|[0-9A-F]{6})$/', $color, $matches ) ) {
+			$hex = $matches[1];
+			if ( 3 === strlen( $hex ) ) {
+				$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+			}
+
+			$rgb = array( hexdec( substr( $hex, 0, 2 ) ), hexdec( substr( $hex, 2, 2 ) ), hexdec( substr( $hex, 4, 2 ) ) );
+		} elseif ( preg_match( '/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})/', $color, $matches ) ) {
+			$rgb = array( min( 255, (int) $matches[1] ), min( 255, (int) $matches[2] ), min( 255, (int) $matches[3] ) );
+		}
+
+		if ( 3 !== count( $rgb ) ) {
+			return '#FFFFFF';
+		}
+
+		$luminance = 0;
+		foreach ( $rgb as $index => $channel ) {
+			$channel    = $channel / 255;
+			$channel    = $channel <= 0.03928 ? $channel / 12.92 : pow( ( $channel + 0.055 ) / 1.055, 2.4 );
+			$coefficient = array( 0.2126, 0.7152, 0.0722 );
+			$luminance  += $channel * $coefficient[ $index ];
+		}
+
+		return $luminance > 0.179 ? '#000000' : '#FFFFFF';
+	}
+
+	/**
 	 * Sanitize event language values.
 	 *
 	 * @since 1.0.0

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -618,7 +618,7 @@ class Wpfaevent_Meta_Event {
 	}
 
 	/**
-	 * Get an accessible text color for an event color background.
+	 * Get an accessible text color for an opaque event color background.
 	 *
 	 * @since 1.0.0
 	 *
@@ -636,8 +636,8 @@ class Wpfaevent_Meta_Event {
 			}
 
 			$rgb = array( hexdec( substr( $hex, 0, 2 ) ), hexdec( substr( $hex, 2, 2 ) ), hexdec( substr( $hex, 4, 2 ) ) );
-		} elseif ( preg_match( '/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})/', $color, $matches ) ) {
-			$rgb = array( min( 255, (int) $matches[1] ), min( 255, (int) $matches[2] ), min( 255, (int) $matches[3] ) );
+		} elseif ( preg_match( '/^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/', $color, $matches ) ) {
+			$rgb = array( (int) $matches[1], (int) $matches[2], (int) $matches[3] );
 		}
 
 		if ( 3 !== count( $rgb ) ) {
@@ -647,8 +647,8 @@ class Wpfaevent_Meta_Event {
 		$coefficients = array( 0.2126, 0.7152, 0.0722 );
 		$luminance    = 0;
 		foreach ( $rgb as $index => $channel ) {
-			$channel   = $channel / 255;
-			$channel   = $channel <= 0.03928 ? $channel / 12.92 : pow( ( $channel + 0.055 ) / 1.055, 2.4 );
+			$channel    = $channel / 255;
+			$channel    = $channel <= 0.03928 ? $channel / 12.92 : pow( ( $channel + 0.055 ) / 1.055, 2.4 );
 			$luminance += $channel * $coefficients[ $index ];
 		}
 
@@ -709,7 +709,10 @@ class Wpfaevent_Meta_Event {
 	}
 
 	/**
-	 * Sanitize an imported event color value.
+	 * Sanitize an opaque event color value.
+	 *
+	 * Alpha colors are not supported because event colors are used as solid
+	 * backgrounds for controls and the event hero.
 	 *
 	 * @since 1.0.0
 	 *
@@ -744,8 +747,14 @@ class Wpfaevent_Meta_Event {
 			return '#' . strtoupper( $color );
 		}
 
-		if ( preg_match( '/^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(\s*,\s*(0|1|0?\.\d+))?\s*\)$/', $color ) ) {
-			return $color;
+		if ( preg_match( '/^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/', $color, $matches ) ) {
+			$red   = (int) $matches[1];
+			$green = (int) $matches[2];
+			$blue  = (int) $matches[3];
+
+			if ( 255 >= $red && 255 >= $green && 255 >= $blue ) {
+				return sprintf( 'rgb(%d, %d, %d)', $red, $green, $blue );
+			}
 		}
 
 		return '';

--- a/public/css/templates/event-base.css
+++ b/public/css/templates/event-base.css
@@ -56,7 +56,8 @@
 
 .wpfaevent .wpfa-event-hero {
 	background:
-		linear-gradient(135deg, #8f0a05 0%, #D51007 52%, #f15b53 100%);
+		linear-gradient(135deg, rgba(0, 0, 0, 0.32) 0%, transparent 52%, rgba(255, 255, 255, 0.28) 100%),
+		var(--event-primary);
 	color: #fff;
 	overflow: hidden;
 	padding: 56px 0 52px;

--- a/public/css/templates/event-base.css
+++ b/public/css/templates/event-base.css
@@ -6,7 +6,9 @@
 .wpfaevent.wpfa-single-event-template,
 .wpfaevent.wpfa-schedule-template {
 	--event-primary: var(--brand, #D51007);
+	--event-primary-contrast: #fff;
 	--event-primary-dark: #b20d06;
+	--event-primary-dark-contrast: #fff;
 	--event-ink: #243447;
 	--event-line: #dfe6ee;
 	--event-soft: #f4f7fb;
@@ -58,7 +60,7 @@
 	background:
 		linear-gradient(135deg, rgba(0, 0, 0, 0.32) 0%, transparent 52%, rgba(255, 255, 255, 0.28) 100%),
 		var(--event-primary);
-	color: #fff;
+	color: var(--event-primary-contrast);
 	overflow: hidden;
 	padding: 56px 0 52px;
 	position: relative;
@@ -101,7 +103,7 @@
 }
 
 .wpfaevent .wpfa-event-kicker {
-	color: rgba(255, 255, 255, 0.78);
+	color: var(--event-primary-contrast);
 	font-size: 0.9rem;
 	font-weight: 800;
 	letter-spacing: 0;
@@ -111,7 +113,7 @@
 }
 
 .wpfaevent .wpfa-event-hero h1 {
-	color: #fff;
+	color: var(--event-primary-contrast);
 	font-size: clamp(2.4rem, 6vw, 5.4rem);
 	font-weight: 800;
 	letter-spacing: 0;
@@ -122,7 +124,7 @@
 }
 
 .wpfaevent .wpfa-event-hero-text {
-	color: rgba(255, 255, 255, 0.9);
+	color: var(--event-primary-contrast);
 	font-size: 1.12rem;
 	font-weight: 400;
 	line-height: 1.7;
@@ -146,7 +148,7 @@
 	background: rgba(255, 255, 255, 0.16);
 	border: 1px solid rgba(255, 255, 255, 0.25);
 	border-radius: var(--event-radius);
-	color: #fff;
+	color: var(--event-primary-contrast);
 	display: inline-flex;
 	font-size: 1rem;
 	font-weight: 700;
@@ -202,7 +204,7 @@
 	background: var(--event-primary);
 	border-radius: var(--event-radius);
 	box-shadow: 0 8px 18px rgba(213, 16, 7, 0.2);
-	color: #fff;
+	color: var(--event-primary-contrast);
 	display: flex;
 	font-size: 1.12rem;
 	font-weight: 800;
@@ -216,7 +218,7 @@
 
 .wpfaevent .wpfa-event-register:hover {
 	background: var(--event-primary-dark);
-	color: #fff;
+	color: var(--event-primary-dark-contrast);
 }
 
 .wpfaevent .wpfa-event-calendar-link {

--- a/public/css/templates/event-base.css
+++ b/public/css/templates/event-base.css
@@ -57,9 +57,7 @@
 }
 
 .wpfaevent .wpfa-event-hero {
-	background:
-		linear-gradient(135deg, rgba(0, 0, 0, 0.32) 0%, transparent 52%, rgba(255, 255, 255, 0.28) 100%),
-		var(--event-primary);
+	background: var(--event-primary);
 	color: var(--event-primary-contrast);
 	overflow: hidden;
 	padding: 56px 0 52px;

--- a/tests/unit/EventColorsTest.php
+++ b/tests/unit/EventColorsTest.php
@@ -103,4 +103,41 @@ class EventColorsTest extends WP_UnitTestCase {
 		$this->assertSame( '#000000', Wpfaevent_Meta_Event::get_contrast_text_color( '#FDE68A' ) );
 		$this->assertStringContainsString( '--event-primary: #FDE68A; --event-primary-contrast: #000000', $data['event_style_attr'] );
 	}
+
+	/**
+	 * Event colors support only opaque CSS color formats.
+	 */
+	public function test_event_color_sanitizer_rejects_transparent_and_invalid_colors() {
+		$transparent_colors = array(
+			'rgba(0, 0, 0, 0)',
+			'rgba(0, 0, 0, 0.32)',
+			'rgba(255, 255, 255, 0.28)',
+			'rgba(119, 119, 119, 0.5)',
+		);
+
+		foreach ( $transparent_colors as $color ) {
+			$this->assertSame( '', Wpfaevent_Meta_Event::sanitize_color_value( $color ) );
+			$this->assertSame( '#FFFFFF', Wpfaevent_Meta_Event::get_contrast_text_color( $color ) );
+		}
+
+		$this->assertSame( '', Wpfaevent_Meta_Event::sanitize_color_value( 'rgb(256, 0, 0)' ) );
+		$this->assertSame( 'rgb(47, 143, 91)', Wpfaevent_Meta_Event::sanitize_color_value( 'rgb(47,143,91)' ) );
+	}
+
+	/**
+	 * Hero text contrast is chosen against its solid, rendered event color.
+	 */
+	public function test_event_hero_contrast_uses_solid_primary_color() {
+		$stylesheet = file_get_contents( dirname( __DIR__, 2 ) . '/public/css/templates/event-base.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a repository fixture in a unit test.
+
+		$this->assertNotFalse( $stylesheet );
+		$this->assertMatchesRegularExpression( '/\.wpfaevent \.wpfa-event-hero \{\s*background: var\(--event-primary\);/s', $stylesheet );
+		$this->assertStringNotContainsString( 'linear-gradient(135deg, rgba(0, 0, 0, 0.32)', $stylesheet );
+
+		$this->assertSame( '#000000', Wpfaevent_Meta_Event::get_contrast_text_color( '#777777' ) );
+		$this->assertSame( '#FFFFFF', Wpfaevent_Meta_Event::get_contrast_text_color( '#000000' ) );
+		$this->assertSame( '#000000', Wpfaevent_Meta_Event::get_contrast_text_color( '#FFFFFF' ) );
+		$this->assertSame( '#FFFFFF', Wpfaevent_Meta_Event::get_contrast_text_color( '#D51007' ) );
+		$this->assertSame( '#000000', Wpfaevent_Meta_Event::get_contrast_text_color( '#F97316' ) );
+	}
 }

--- a/tests/unit/EventColorsTest.php
+++ b/tests/unit/EventColorsTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Event color regression tests.
+ *
+ * @package Wpfaevent
+ */
+
+/**
+ * Verify that event colors can be edited and applied to the event hero.
+ */
+class EventColorsTest extends WP_UnitTestCase {
+
+	/**
+	 * Test event ID.
+	 *
+	 * @var int
+	 */
+	private $event_id;
+
+	/**
+	 * Set up an editable event.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->event_id = $this->factory->post->create( array( 'post_type' => 'wpfa_event' ) );
+	}
+
+	/**
+	 * The event editor displays every supported color field.
+	 */
+	public function test_event_editor_displays_color_fields() {
+		update_post_meta( $this->event_id, 'wpfa_event_primary_color', '#F97316' );
+
+		ob_start();
+		( new Wpfaevent_Admin_Event_Metabox() )->render_event_meta_box( get_post( $this->event_id ) );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Event Colors', $output );
+		foreach ( Wpfaevent_Meta_Event::get_event_color_meta_fields() as $meta_key => $label ) {
+			$this->assertStringContainsString( 'name="' . $meta_key . '"', $output );
+		}
+		$this->assertStringContainsString( 'value="#F97316"', $output );
+	}
+
+	/**
+	 * Saving the event sanitizes valid colors and removes invalid values.
+	 */
+	public function test_event_editor_saves_sanitized_colors() {
+		update_post_meta( $this->event_id, 'wpfa_event_hover_button_color', '#B20D06' );
+
+		$_POST = array(
+			'wpfa_event_meta_nonce'             => wp_create_nonce( 'wpfa_event_meta_nonce' ),
+			'wpfa_event_primary_color'          => 'f97316',
+			'wpfa_event_hover_button_color'     => 'not-a-color',
+			'wpfa_event_theme_success_color'    => 'rgb(47, 143, 91)',
+			'wpfa_event_theme_danger_color'     => '#dc2626',
+			'wpfa_event_theme_background_color' => '#fff7ed',
+		);
+
+		( new Wpfaevent_Admin_Event_Metabox() )->save_event_meta( $this->event_id );
+		$_POST = array();
+
+		$this->assertSame( '#F97316', get_post_meta( $this->event_id, 'wpfa_event_primary_color', true ) );
+		$this->assertSame( '', get_post_meta( $this->event_id, 'wpfa_event_hover_button_color', true ) );
+		$this->assertSame( 'rgb(47, 143, 91)', get_post_meta( $this->event_id, 'wpfa_event_theme_success_color', true ) );
+		$this->assertSame( '#DC2626', get_post_meta( $this->event_id, 'wpfa_event_theme_danger_color', true ) );
+		$this->assertSame( '#FFF7ED', get_post_meta( $this->event_id, 'wpfa_event_theme_background_color', true ) );
+	}
+
+	/**
+	 * The hero background uses the event primary color variable.
+	 */
+	public function test_event_hero_uses_primary_color_variable() {
+		$stylesheet = file_get_contents( dirname( __DIR__, 2 ) . '/public/css/templates/event-base.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a repository fixture in a unit test.
+
+		$this->assertNotFalse( $stylesheet );
+		$this->assertMatchesRegularExpression( '/\.wpfaevent \.wpfa-event-hero \{.*?var\(--event-primary\);/s', $stylesheet );
+		$this->assertStringNotContainsString( 'linear-gradient(135deg, #8f0a05 0%, #D51007 52%, #f15b53 100%)', $stylesheet );
+	}
+}

--- a/tests/unit/EventColorsTest.php
+++ b/tests/unit/EventColorsTest.php
@@ -79,4 +79,28 @@ class EventColorsTest extends WP_UnitTestCase {
 		$this->assertMatchesRegularExpression( '/\.wpfaevent \.wpfa-event-hero \{.*?var\(--event-primary\);/s', $stylesheet );
 		$this->assertStringNotContainsString( 'linear-gradient(135deg, #8f0a05 0%, #D51007 52%, #f15b53 100%)', $stylesheet );
 	}
+
+	/**
+	 * Events without a primary color keep the FOSSASIA red fallback.
+	 */
+	public function test_event_hero_uses_fossasia_red_when_no_custom_color_is_set() {
+		$stylesheet = file_get_contents( dirname( __DIR__, 2 ) . '/public/css/templates/event-base.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a repository fixture in a unit test.
+		$data       = Wpfaevent_Event_Template_Controller::get_event_template_data( $this->event_id );
+
+		$this->assertNotFalse( $stylesheet );
+		$this->assertStringContainsString( '--event-primary: var(--brand, #D51007);', $stylesheet );
+		$this->assertSame( '', $data['event_style_attr'] );
+	}
+
+	/**
+	 * A light primary color receives dark text for accessible hero contrast.
+	 */
+	public function test_light_primary_color_uses_dark_contrast_text() {
+		update_post_meta( $this->event_id, 'wpfa_event_primary_color', '#FDE68A' );
+
+		$data = Wpfaevent_Event_Template_Controller::get_event_template_data( $this->event_id );
+
+		$this->assertSame( '#000000', Wpfaevent_Meta_Event::get_contrast_text_color( '#FDE68A' ) );
+		$this->assertStringContainsString( '--event-primary: #FDE68A; --event-primary-contrast: #000000', $data['event_style_attr'] );
+	}
 }


### PR DESCRIPTION
## Summary
- add event color fields to the event editor
- save colors with the existing sanitizer
- apply the primary color to the event hero
- add focused regression tests

## Tests
- `composer phpcs`
- `composer phpstan`
- `composer test` (71 tests, 238 assertions)

Fixes/Closes #274

## Summary by Sourcery

Allow event-specific colors to be configured and rendered with accessible contrast throughout the event experience.

New Features:
- Add editable per-event color fields to the event administration interface.
- Apply customized event colors to the event hero and related controls.

Bug Fixes:
- Ensure custom colors are sanitized to supported opaque formats and invalid values are removed.
- Provide accessible contrasting text colors for customized event backgrounds.

Tests:
- Add regression coverage for color editing, sanitization, hero styling, fallbacks, and contrast handling.


## Screenshot
<img width="1440" height="760" alt="Screenshot 2026-09-03 at 11 54 31 PM" src="https://github.com/user-attachments/assets/32e7c880-740f-4c1d-9c56-c606a862788f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event color fields to the event editor for customizing primary and hover colors.
  * Event banners now automatically select contrasting text colors for readability.
  * Added a FOSSASIA red fallback when no custom primary color is set.
* **Improvements**
  * Event hero backgrounds now use the configured primary color directly instead of a layered overlay.
* **Bug Fixes**
  * Color values are sanitized and limited to valid, opaque RGB formats when saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->