### PR TITLE
fix: hide empty speaker and schedule sections

### DIFF
--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -167,7 +167,17 @@ class Wpfaevent_Event_Template_Controller {
 				)
 			);
 
-			return $normalize_post_id_list( array_merge( $speaker_ids, $reverse_speaker_ids ) );
+			$linked_speaker_ids = $normalize_post_id_list( array_merge( $speaker_ids, $reverse_speaker_ids ) );
+
+			// The forward meta list is unfiltered, and templates skip anything not publicly viewable.
+			return array_values(
+				array_filter(
+					$linked_speaker_ids,
+					static function ( $speaker_id ) {
+						return 'wpfa_speaker' === get_post_type( $speaker_id ) && 'publish' === get_post_status( $speaker_id );
+					}
+				)
+			);
 		};
 
 		$format_event_date = static function ( $date ) {
@@ -1001,14 +1011,7 @@ class Wpfaevent_Event_Template_Controller {
 			$custom_sections[ $custom_tab['slug'] ] = $custom_tab['title'];
 		}
 
-		// Both speaker sources skip entries they cannot render, so count only those that survive.
-		$renderable_speaker_ids = array_filter(
-			$speaker_ids,
-			static function ( $speaker_id ) {
-				return 'wpfa_speaker' === get_post_type( $speaker_id ) && 'publish' === get_post_status( $speaker_id );
-			}
-		);
-
+		// Dashboard rows without a displayable name render no card, so they are not speakers.
 		$renderable_dashboard_speakers = array_filter(
 			$dashboard_speakers,
 			static function ( $dashboard_speaker ) {
@@ -1021,7 +1024,7 @@ class Wpfaevent_Event_Template_Controller {
 			}
 		);
 
-		$has_speakers = $show_speakers && ( ! empty( $renderable_speaker_ids ) || ! empty( $renderable_dashboard_speakers ) );
+		$has_speakers = $show_speakers && ( ! empty( $speaker_ids ) || ! empty( $renderable_dashboard_speakers ) );
 		$has_schedule = $show_schedule && ! empty( $schedule_items );
 
 		$wpfa_event_nav_context = array(

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -1001,7 +1001,22 @@ class Wpfaevent_Event_Template_Controller {
 			$custom_sections[ $custom_tab['slug'] ] = $custom_tab['title'];
 		}
 
-		$has_speakers = $show_speakers && ( ! empty( $speaker_ids ) || ! empty( $dashboard_speakers ) );
+		// Both speaker sources skip entries they cannot render, so count only those that survive.
+		$renderable_speaker_ids = array_filter(
+			$speaker_ids,
+			static function ( $speaker_id ) {
+				return 'wpfa_speaker' === get_post_type( $speaker_id ) && 'publish' === get_post_status( $speaker_id );
+			}
+		);
+
+		$renderable_dashboard_speakers = array_filter(
+			$dashboard_speakers,
+			static function ( $dashboard_speaker ) {
+				return is_array( $dashboard_speaker ) && ! empty( $dashboard_speaker['name'] );
+			}
+		);
+
+		$has_speakers = $show_speakers && ( ! empty( $renderable_speaker_ids ) || ! empty( $renderable_dashboard_speakers ) );
 		$has_schedule = $show_schedule && ! empty( $schedule_items );
 
 		$wpfa_event_nav_context = array(

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -1012,7 +1012,12 @@ class Wpfaevent_Event_Template_Controller {
 		$renderable_dashboard_speakers = array_filter(
 			$dashboard_speakers,
 			static function ( $dashboard_speaker ) {
-				return is_array( $dashboard_speaker ) && ! empty( $dashboard_speaker['name'] );
+				if ( ! is_array( $dashboard_speaker ) || ! isset( $dashboard_speaker['name'] ) || ! is_scalar( $dashboard_speaker['name'] ) ) {
+					return false;
+				}
+
+				// Match the card partial, which displays the sanitized name.
+				return '' !== sanitize_text_field( (string) $dashboard_speaker['name'] );
 			}
 		);
 

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -169,13 +169,22 @@ class Wpfaevent_Event_Template_Controller {
 
 			$linked_speaker_ids = $normalize_post_id_list( array_merge( $speaker_ids, $reverse_speaker_ids ) );
 
+			if ( empty( $linked_speaker_ids ) ) {
+				return array();
+			}
+
 			// The forward meta list is unfiltered, and templates skip anything not publicly viewable.
-			return array_values(
-				array_filter(
-					$linked_speaker_ids,
-					static function ( $speaker_id ) {
-						return 'wpfa_speaker' === get_post_type( $speaker_id ) && 'publish' === get_post_status( $speaker_id );
-					}
+			return $normalize_post_id_list(
+				get_posts(
+					array(
+						'post_type'      => 'wpfa_speaker',
+						'post_status'    => 'publish',
+						'post__in'       => $linked_speaker_ids,
+						'orderby'        => 'post__in',
+						'posts_per_page' => -1,
+						'fields'         => 'ids',
+						'no_found_rows'  => true,
+					)
 				)
 			);
 		};

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -1001,6 +1001,9 @@ class Wpfaevent_Event_Template_Controller {
 			$custom_sections[ $custom_tab['slug'] ] = $custom_tab['title'];
 		}
 
+		$has_speakers = $show_speakers && ( ! empty( $speaker_ids ) || ! empty( $dashboard_speakers ) );
+		$has_schedule = $show_schedule && ! empty( $schedule_items );
+
 		$wpfa_event_nav_context = array(
 			'show_about'      => $show_about,
 			'show_speakers'   => $show_speakers,
@@ -1009,8 +1012,8 @@ class Wpfaevent_Event_Template_Controller {
 			'show_exhibitors' => $show_exhibitors,
 			'has_about'       => $show_about && '' !== trim( $about_content ),
 			'has_tickets'     => $show_ticket_section,
-			'has_speakers'    => $show_speakers && ( ! empty( $speaker_ids ) || ! empty( $dashboard_speakers ) ),
-			'has_schedule'    => $show_schedule && ! empty( $schedule_items ),
+			'has_speakers'    => $has_speakers,
+			'has_schedule'    => $has_schedule,
 			'has_sponsors'    => $show_sponsors && ! empty( $visible_sponsor_groups ),
 			'has_exhibitors'  => $show_exhibitors && ! empty( $visible_exhibitors ),
 			'has_venue'       => '' !== trim( wp_strip_all_tags( $venue_information ) ),
@@ -1074,6 +1077,8 @@ class Wpfaevent_Event_Template_Controller {
 			'show_schedule'                            => $show_schedule,
 			'show_sponsors'                            => $show_sponsors,
 			'show_exhibitors'                          => $show_exhibitors,
+			'has_speakers'                             => $has_speakers,
+			'has_schedule'                             => $has_schedule,
 			'venue_information'                        => $venue_information,
 			'event_additional_url'                     => $event_additional_url,
 			'custom_tabs'                              => $custom_tabs,
@@ -1167,6 +1172,8 @@ class Wpfaevent_Event_Template_Controller {
 			'show_schedule'                            => false,
 			'show_sponsors'                            => false,
 			'show_exhibitors'                          => false,
+			'has_speakers'                             => false,
+			'has_schedule'                             => false,
 			'venue_information'                        => '',
 			'event_additional_url'                     => '',
 			'custom_tabs'                              => array(),

--- a/public/templates/single-wpfa-event.php
+++ b/public/templates/single-wpfa-event.php
@@ -49,6 +49,8 @@ $show_speakers                            = $event_data['show_speakers'];
 $show_schedule                            = $event_data['show_schedule'];
 $show_sponsors                            = $event_data['show_sponsors'];
 $show_exhibitors                          = $event_data['show_exhibitors'];
+$has_speakers                             = $event_data['has_speakers'];
+$has_schedule                             = $event_data['has_schedule'];
 $venue_information                        = $event_data['venue_information'];
 $event_additional_url                     = $event_data['event_additional_url'];
 $custom_tabs                              = $event_data['custom_tabs'];
@@ -438,7 +440,7 @@ if ( $show_ticket_widget ) {
 			</section>
 		<?php endif; ?>
 
-		<?php if ( $show_speakers ) : ?>
+		<?php if ( $has_speakers ) : ?>
 			<section id="speakers" class="wpfa-event-section wpfa-event-speakers" aria-labelledby="wpfa-event-speakers-title">
 				<div class="container">
 					<div class="wpfa-event-section-head">
@@ -574,14 +576,12 @@ if ( $show_ticket_widget ) {
 								</p>
 							<?php endif; ?>
 						<?php endif; ?>
-					<?php else : ?>
-						<p class="wpfa-empty-state"><?php esc_html_e( 'No speakers have been imported for this event yet.', 'wpfaevent' ); ?></p>
 					<?php endif; ?>
 				</div>
 			</section>
 		<?php endif; ?>
 
-		<?php if ( $show_schedule ) : ?>
+		<?php if ( $has_schedule ) : ?>
 			<section id="schedule-overview" class="wpfa-event-section wpfa-event-schedule" aria-labelledby="wpfa-event-schedule-title">
 				<div class="container">
 					<div class="wpfa-event-section-head">
@@ -907,10 +907,8 @@ if ( $show_ticket_widget ) {
 								?>
 							</p>
 						<?php endif; ?>
-					<?php elseif ( ! empty( $schedule_items ) && $has_schedule_filters && ( $current_day_filter || $current_track_filter || $current_room_filter ) && empty( $filtered_schedule_items ) ) : ?>
+					<?php elseif ( $has_schedule_filters && ( $current_day_filter || $current_track_filter || $current_room_filter ) && empty( $filtered_schedule_items ) ) : ?>
 						<p class="wpfa-empty-state"><?php esc_html_e( 'No sessions match the selected filters.', 'wpfaevent' ); ?></p>
-					<?php else : ?>
-						<p class="wpfa-empty-state"><?php esc_html_e( 'No schedule has been imported for this event yet.', 'wpfaevent' ); ?></p>
 					<?php endif; ?>
 				</div>
 			</section>

--- a/tests/unit/EventSectionVisibilityTest.php
+++ b/tests/unit/EventSectionVisibilityTest.php
@@ -200,6 +200,24 @@ class EventSectionVisibilityTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Published speakers belonging to no event must not leak into an unrelated event.
+	 */
+	public function test_event_page_ignores_speakers_that_are_not_linked_to_the_event() {
+		$this->factory->post->create(
+			array(
+				'post_title'  => 'Unrelated Speaker',
+				'post_type'   => 'wpfa_speaker',
+				'post_status' => 'publish',
+			)
+		);
+
+		$output = $this->render_event_template();
+
+		$this->assertStringNotContainsString( 'id="wpfa-event-speakers-title"', $output );
+		$this->assertStringNotContainsString( 'Unrelated Speaker', $output );
+	}
+
+	/**
 	 * Store a single-session dashboard schedule for the event fixture.
 	 */
 	private function write_schedule_fixture() {

--- a/tests/unit/EventSectionVisibilityTest.php
+++ b/tests/unit/EventSectionVisibilityTest.php
@@ -173,6 +173,33 @@ class EventSectionVisibilityTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An unpublished linked speaker must not shadow renderable dashboard speakers.
+	 */
+	public function test_event_page_renders_dashboard_speakers_despite_unpublished_linked_speaker() {
+		$speaker_id = $this->factory->post->create(
+			array(
+				'post_title'  => 'Draft Speaker',
+				'post_type'   => 'wpfa_speaker',
+				'post_status' => 'draft',
+			)
+		);
+
+		update_post_meta( $this->event_id, 'wpfa_event_speakers', array( $speaker_id ) );
+
+		$this->write_dashboard_json(
+			'speakers',
+			array(
+				array( 'name' => 'Dashboard Speaker' ),
+			)
+		);
+
+		$output = $this->render_event_template();
+
+		$this->assertStringContainsString( 'id="wpfa-event-speakers-title"', $output );
+		$this->assertStringContainsString( 'Dashboard Speaker', $output );
+	}
+
+	/**
 	 * Store a single-session dashboard schedule for the event fixture.
 	 */
 	private function write_schedule_fixture() {

--- a/tests/unit/EventSectionVisibilityTest.php
+++ b/tests/unit/EventSectionVisibilityTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Unit tests for empty event section visibility (Issue #273).
+ *
+ * @package Wpfaevent
+ */
+
+/**
+ * Event section visibility test class.
+ */
+class EventSectionVisibilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Test event ID.
+	 *
+	 * @var int
+	 */
+	private $event_id;
+
+	/**
+	 * Create the event fixture.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->event_id = $this->factory->post->create(
+			array(
+				'post_title'  => 'Test Event',
+				'post_type'   => 'wpfa_event',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Remove dashboard fixture data created by a test.
+	 */
+	public function tearDown(): void {
+		$store = new Wpfaevent_Eventyay_Dashboard_Store();
+
+		foreach ( array( 'speakers', 'schedule' ) as $dataset ) {
+			$path = $store->get_dashboard_json_path( $dataset . '-' . $this->event_id . '.json' );
+
+			if ( $path && file_exists( $path ) ) {
+				wp_delete_file( $path );
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * An event without speakers or schedule renders neither section heading.
+	 */
+	public function test_event_page_hides_speaker_and_schedule_sections_without_data() {
+		$output = $this->render_event_template();
+
+		$this->assertStringNotContainsString( 'id="wpfa-event-speakers-title"', $output );
+		$this->assertStringNotContainsString( 'id="wpfa-event-schedule-title"', $output );
+	}
+
+	/**
+	 * Linked speaker posts bring the speakers section back.
+	 */
+	public function test_event_page_renders_speakers_section_when_speakers_are_linked() {
+		$speaker_id = $this->factory->post->create(
+			array(
+				'post_title'  => 'Speaker 1',
+				'post_type'   => 'wpfa_speaker',
+				'post_status' => 'publish',
+			)
+		);
+
+		update_post_meta( $this->event_id, 'wpfa_event_speakers', array( $speaker_id ) );
+		update_post_meta( $speaker_id, 'wpfa_speaker_events', array( $this->event_id ) );
+
+		$output = $this->render_event_template();
+
+		$this->assertStringContainsString( 'id="wpfa-event-speakers-title"', $output );
+	}
+
+	/**
+	 * Imported dashboard speakers bring the speakers section back.
+	 */
+	public function test_event_page_renders_speakers_section_for_dashboard_speakers() {
+		$this->write_dashboard_json(
+			'speakers',
+			array(
+				array(
+					'name'  => 'Dashboard Speaker',
+					'title' => 'Engineer',
+				),
+			)
+		);
+
+		$output = $this->render_event_template();
+
+		$this->assertStringContainsString( 'id="wpfa-event-speakers-title"', $output );
+	}
+
+	/**
+	 * An imported schedule brings the schedule section back.
+	 */
+	public function test_event_page_renders_schedule_section_when_schedule_is_imported() {
+		$this->write_schedule_fixture();
+
+		$output = $this->render_event_template();
+
+		$this->assertStringContainsString( 'id="wpfa-event-schedule-title"', $output );
+	}
+
+	/**
+	 * A schedule filter that excludes every session keeps the section and explains why.
+	 */
+	public function test_event_page_keeps_schedule_section_when_filters_exclude_every_session() {
+		$this->write_schedule_fixture();
+
+		$output = $this->render_event_template( array( 'day' => 'no-such-day' ) );
+
+		$this->assertStringContainsString( 'id="wpfa-event-schedule-title"', $output );
+		$this->assertStringContainsString( 'No sessions match the selected filters.', $output );
+	}
+
+	/**
+	 * Store a single-session dashboard schedule for the event fixture.
+	 */
+	private function write_schedule_fixture() {
+		$this->write_dashboard_json(
+			'schedule',
+			array(
+				'data'     => array(
+					array( 'Date', 'Time', 'Session', 'Speakers', 'Track', 'Room' ),
+					array( '2026-03-08', '09:00 - 10:00', 'Opening Keynote', 'Speaker 1', 'Main', 'Hall A' ),
+				),
+				'sessions' => array(
+					array(
+						'starts_at' => '2026-03-08T09:00:00+00:00',
+						'ends_at'   => '2026-03-08T10:00:00+00:00',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Store dashboard rows for the event fixture.
+	 *
+	 * @param string $dataset Dashboard dataset name.
+	 * @param array  $data    Dashboard payload.
+	 */
+	private function write_dashboard_json( $dataset, $data ) {
+		$store  = new Wpfaevent_Eventyay_Dashboard_Store();
+		$result = $store->write_dashboard_json_file( $dataset . '-' . $this->event_id . '.json', $data );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Render the single event template for the event fixture.
+	 *
+	 * @param array<string, string> $query_args Optional query string arguments.
+	 * @return string Rendered markup.
+	 */
+	private function render_event_template( $query_args = array() ) {
+		$url = get_permalink( $this->event_id );
+
+		if ( ! empty( $query_args ) ) {
+			$url = add_query_arg( $query_args, $url );
+		}
+
+		$this->go_to( $url );
+
+		$this->assertSame( $this->event_id, get_queried_object_id() );
+
+		ob_start();
+		include WPFAEVENT_PATH . 'public/templates/single-wpfa-event.php';
+
+		return (string) ob_get_clean();
+	}
+}

--- a/tests/unit/EventSectionVisibilityTest.php
+++ b/tests/unit/EventSectionVisibilityTest.php
@@ -122,6 +122,41 @@ class EventSectionVisibilityTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Linked speakers that are no longer published render no cards, so the section stays hidden.
+	 */
+	public function test_event_page_hides_speakers_section_when_linked_speakers_are_unpublished() {
+		$speaker_id = $this->factory->post->create(
+			array(
+				'post_title'  => 'Draft Speaker',
+				'post_type'   => 'wpfa_speaker',
+				'post_status' => 'draft',
+			)
+		);
+
+		update_post_meta( $this->event_id, 'wpfa_event_speakers', array( $speaker_id ) );
+
+		$output = $this->render_event_template();
+
+		$this->assertStringNotContainsString( 'id="wpfa-event-speakers-title"', $output );
+	}
+
+	/**
+	 * Dashboard speaker rows without a name render no cards, so the section stays hidden.
+	 */
+	public function test_event_page_hides_speakers_section_when_dashboard_speakers_have_no_name() {
+		$this->write_dashboard_json(
+			'speakers',
+			array(
+				array( 'position' => 'Engineer' ),
+			)
+		);
+
+		$output = $this->render_event_template();
+
+		$this->assertStringNotContainsString( 'id="wpfa-event-speakers-title"', $output );
+	}
+
+	/**
 	 * Store a single-session dashboard schedule for the event fixture.
 	 */
 	private function write_schedule_fixture() {

--- a/tests/unit/EventSectionVisibilityTest.php
+++ b/tests/unit/EventSectionVisibilityTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit tests for empty event section visibility (Issue #273).
+ * Unit tests for empty event section visibility.
  *
  * @package Wpfaevent
  */

--- a/tests/unit/EventSectionVisibilityTest.php
+++ b/tests/unit/EventSectionVisibilityTest.php
@@ -157,6 +157,22 @@ class EventSectionVisibilityTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A dashboard speaker name that sanitizes away is not a speaker.
+	 */
+	public function test_event_page_hides_speakers_section_when_dashboard_speaker_names_are_blank() {
+		$this->write_dashboard_json(
+			'speakers',
+			array(
+				array( 'name' => '   ' ),
+			)
+		);
+
+		$output = $this->render_event_template();
+
+		$this->assertStringNotContainsString( 'id="wpfa-event-speakers-title"', $output );
+	}
+
+	/**
 	 * Store a single-session dashboard schedule for the event fixture.
 	 */
 	private function write_schedule_fixture() {


### PR DESCRIPTION
## What

Hide the Speakers and Schedule sections on an event page when there is nothing to show,
instead of rendering the heading above an empty-state paragraph.

Closes #273

## Why

Both sections were gated on `$show_speakers` / `$show_schedule`, which encode only the
per-section visibility toggle and default to `true`. They say nothing about whether data
exists, so a new event rendered both headings.

The other sections in the same template already gate on data (`$show_about && '' !== trim(
$about_content )`, and the same shape for sponsors and exhibitors). The section nav was also
already data-aware via `has_speakers` / `has_schedule`, so an empty event omitted the nav
links while still rendering the sections they point at.

## How

The controller already computed the right conditions for the nav; they just never reached the
template. Hoisted them into locals, reused for the nav, and exposed in the template data
(including the invalid-event fallback array).

Speaker availability counts only speakers that will actually render. Linked IDs are now
filtered to published `wpfa_speaker` posts where the list is built, since the template both
branches on that list and skips unpublished entries inside it, so one trashed speaker could
leave an empty heading and hide otherwise renderable dashboard speakers. Dashboard rows are
matched on the sanitized name the card partial displays, so a blank name is not a speaker.

The two "not imported yet" empty states are now unreachable and were removed. The
"No sessions match the selected filters." state is kept, since it is still reachable when a
schedule exists but filters exclude every session.
###  Before: 
<img width="1568" height="860" alt="image" src="https://github.com/user-attachments/assets/3b11a153-f569-4a23-a0a3-4d8642f8574a" />
### After:

[Screencast_20260904_011417.webm](https://github.com/user-attachments/assets/b1e3c1ce-4218-4729-84a5-a6688a5a27f7)


## Testing

`tests/unit/EventSectionVisibilityTest.php` renders the real template through `go_to()` and
asserts on the resulting markup: empty event, linked speakers, dashboard speakers, unpublished
linked speakers, unnamed and blank-named dashboard rows, an unpublished linked speaker
alongside a valid dashboard speaker, unlinked speakers, imported schedule, and filters
excluding everything.

Tests were written before each fix and confirmed failing first. The filter test was checked by
mutation, so it is not a vacuous assertion.

```
$ composer test -- --testsuite Unit
OK (72 tests, 232 assertions)

$ composer phpcs      # exit 0
$ composer phpstan    # [OK] No errors
```

Also checked by hand on a local WordPress install: empty event hides both sections; adding a
speaker or a schedule brings each back; trashing the speaker hides it again; `?day=no-such-day`
keeps the schedule section with the filter message.

## Out of scope

Two pre-existing issues noticed while testing, left alone to keep this focused. Happy to file
either separately.

- An event with regular but no featured speakers renders `<h2>Speakers</h2>` directly above
  `<h3>Speakers</h3>`.
- A dashboard speaker row whose name is blank still renders a nameless card when the event has
  other valid speakers, since `dashboard-speaker-card.php` guards on `empty()` rather than the
  sanitized name.

## Summary by Sourcery

Hide empty speaker and schedule sections on event pages while preserving meaningful filtered-schedule feedback.

Bug Fixes:
- Hide the Speakers and Schedule sections when no renderable content exists, while retaining the schedule section when active filters exclude all sessions.
- Exclude unpublished linked speakers and unnamed dashboard rows from speaker availability checks so empty sections are not displayed and valid dashboard speakers remain visible.

Enhancements:
- Share data-aware section visibility conditions between event navigation and the event template.
- Remove unreachable empty states for missing imported speakers and schedules.

Tests:
- Add template-level coverage for empty events, linked and dashboard speakers, unpublished and invalid speaker data, imported schedules, and filters that exclude all sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Event pages now show Speakers and Schedule sections only when relevant content is available.
  - Unpublished or unusable speaker entries no longer make the Speakers section appear.
  - Empty events no longer display misleading section headings or outdated import messages.
  - Schedule sections remain available when filters exclude all sessions, with a clear no-results message.

- **Tests**
  - Added coverage for section visibility, unpublished speakers, invalid entries, and schedule filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->