### PR TITLE
feat: show progress while importing an Eventyay event

### DIFF
--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -261,7 +261,7 @@ class Wpfaevent_Eventyay_Importer {
 					<?php esc_html_e( 'Use this to import the configured Eventyay event. Use the Update Event menu item when that event changes after the initial import.', 'wpfaevent' ); ?>
 				</p>
 
-				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<form class="wpfaevent-eventyay-import-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 					<input type="hidden" name="action" value="wpfaevent_import_eventyay_events">
 					<input type="hidden" name="wpfaevent_eventyay_return_page" value="wpfaevent-import-events">
 					<?php wp_nonce_field( 'wpfaevent_import_eventyay_events' ); ?>
@@ -279,6 +279,16 @@ class Wpfaevent_Eventyay_Importer {
 						<li><?php esc_html_e( 'Frontend rendering for imported data is handled by the follow-up display PR.', 'wpfaevent' ); ?></li>
 					</ul>
 				</div>
+		</div>
+
+		<div id="wpfaevent-import-progress-overlay" style="display:none;" role="status" aria-live="polite">
+			<div class="wpfaevent-progress-card">
+				<div class="wpfaevent-spinner-container">
+					<div class="wpfaevent-spinner"></div>
+				</div>
+				<h3 id="wpfaevent-progress-title"><?php esc_html_e( 'Importing from Eventyay', 'wpfaevent' ); ?></h3>
+				<p id="wpfaevent-progress-status"><?php esc_html_e( 'This can take a while. Keep this page open until the import finishes.', 'wpfaevent' ); ?></p>
+			</div>
 		</div>
 		<?php
 	}

--- a/admin/css/wpfaevent-admin.css
+++ b/admin/css/wpfaevent-admin.css
@@ -103,7 +103,7 @@
 	border: 1px solid rgba(255, 255, 255, 0.1);
 	border-radius: 20px;
 	padding: 40px;
-	width: 480px;
+	width: min(480px, calc(100vw - 32px));
 	box-sizing: border-box;
 	text-align: center;
 	box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5),
@@ -126,6 +126,7 @@
 	margin-bottom: 24px !important;
 	color: #ffffff !important;
 	font-size: 22px !important;
+	line-height: 1.3 !important;
 	font-weight: 600 !important;
 	letter-spacing: -0.5px !important;
 	background: linear-gradient(135deg, #ffffff 30%, #94a3b8 100%);
@@ -185,6 +186,15 @@
 @keyframes wpfaevent-spin {
 	0% { transform: rotate(0deg); }
 	100% { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#wpfaevent-import-progress-overlay .wpfaevent-progress-card,
+	#wpfaevent-import-progress-overlay .wpfaevent-spinner,
+	#wpfaevent-progress-bar {
+		animation: none;
+		transform: none;
+	}
 }
 
 /* Status & Details styling */

--- a/admin/js/wpfaevent-admin.js
+++ b/admin/js/wpfaevent-admin.js
@@ -122,6 +122,33 @@
 			$container.prepend($notice);
 		}
 
+		// The import posts and reloads, so nothing on the page moved while it ran.
+		// Show the overlay for the duration of that request. The form still posts
+		// normally, so the import itself is unchanged.
+		const $eventyayImportForm = $('.wpfaevent-eventyay-import-form');
+
+		if ($eventyayImportForm.length) {
+			let importRunning = false;
+
+			$eventyayImportForm.on('submit', function (e) {
+				if (importRunning) {
+					e.preventDefault();
+					return;
+				}
+
+				importRunning = true;
+
+				// Left enabled so the button still posts its own value; the styling
+				// and aria state are what stop a second run.
+				$(this)
+					.find('[type="submit"]')
+					.addClass('disabled')
+					.attr('aria-disabled', 'true');
+
+				$('#wpfaevent-import-progress-overlay').css('display', 'flex');
+			});
+		}
+
 		if ($importForm.length || $updateForm.length) {
 			const $form = $importForm.length ? $importForm : $updateForm;
 			const rawReturnPage = $form


### PR DESCRIPTION
## What

The Eventyay import page now shows a loading overlay while an import runs, and the button refuses a second run until it finishes.

## Why

Closes #281.

The import form posts to `admin-post.php` and reloads. Nothing on the page changed while the request was in flight, so the only sign of activity was the browser's own tab spinner.

## How

Show an overlay on submit, reusing the progress card already styled in `admin/css/wpfaevent-admin.css`. The form still posts normally: `preventDefault` is never called, the import path is untouched, and the existing result notice still reports what was imported. Without JavaScript the overlay stays hidden and the page behaves exactly as before.

The overlay is a polite live region so the wait is announced rather than silent, and the submit button is marked `aria-disabled` while a run is in progress.

### Why not the existing AJAX progress overlay

There is already a full AJAX progress implementation in `admin/js/wpfaevent-admin.js`, with registered `wpfaevent_import_*` handlers and a progress bar. It never runs, because it binds to `#wpfaevent-import-events-form` and only `admin/partials/eventyay-import-settings.php` renders that id, while nothing instantiates `Wpfaevent_Admin_Settings_Renderer`.

Adding that id looks like the obvious one-line fix. It is not safe, because the two paths write the same files in different orders:

```
POST : upsert -> sync_speakers_for_event -> dashboard -> partners -> import_eventyay_event_program
AJAX : upsert -> dashboard -> partners -> import_eventyay_event_program -> sync_speakers_for_event
```

`import_eventyay_event_program` builds `speakers-{id}.json` and `schedule-{id}.json` from `/submissions/`, `/speakers/` and `/slots/` merged, while `sync_speakers_for_event` rebuilds them from `/speakers/` alone, and `merge_dashboard_speaker_state` keeps only what the last writer produced. With identical mocked upstream responses the POST path yielded 2 speakers and 1 schedule row; the AJAX path yielded 1 speaker and a header-only schedule. Since #277 hides empty schedule sections, that loss would be silent on the front end.

So this PR deliberately leaves that path dormant. Wiring it up needs its ordering fixed first, which is a separate change.

## Testing

There is no JS test suite in `package.json`, so this is verified in a browser against a local WordPress instance with the importer configured.

Before: with the import request held in flight, the page showed no spinner, no disabled control and no status.

After:

- the overlay appears on submit, titled "Importing from Eventyay", with `role="status"` and `aria-live="polite"`
- the request is still a single POST to `admin-post.php` with no AJAX calls, and the usual notice reports the outcome
- a second submit is refused while one is running
- the card fits a 360px viewport (previously 60px was cut off each side, with no scroll to recover it)
- under `prefers-reduced-motion: reduce` the spinner, card and bar animations resolve to `none`
- with JavaScript disabled the overlay stays hidden and the form posts as before

`npm run lint`, `prettier --check` and `phpcs` exit 0. `phpstan` is unchanged by this PR: the file it touches reports 192 errors both on `main` and here, part of the 617 pre-existing level 6 errors tracked in #279, which is why that check is red.

https://github.com/user-attachments/assets/974f24c9-d84a-4da7-acd1-eb91fd5a06fe


## Notes

The Update Event page has the same missing feedback and would take the same treatment; left out to keep this to the reported issue.

`admin/partials/eventyay-import-settings.php` and `eventyay-update-events.php` are unreachable, since nothing instantiates their renderer. Happy to open a separate issue for those and for the import ordering above.

## Summary by Sourcery

Add accessible in-page progress feedback and duplicate-submit protection to the Eventyay import form without changing its existing server-side import flow.

New Features:
- Show an accessible loading overlay while Eventyay event imports are in progress.
- Prevent duplicate import submissions until the current import completes.

Enhancements:
- Refine the import progress card for responsive layouts, WordPress styling, and reduced-motion preferences.
- Preserve the existing standard POST import flow and behavior when JavaScript is unavailable.

Chores:
- Add missing void return annotations to admin methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an import progress overlay with a spinner, title, and status message while importing from Eventyay.
  - Prevented duplicate import submissions while an import is in progress.

- **Accessibility**
  - Added reduced-motion support for progress animations.
  - Added an accessibility state indicator while importing.

- **Style**
  - Updated the progress display with a compact, light-themed design.
  - Improved progress visibility with a fade-in transition and clearer status styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->