### PR TITLE
refactor: resolve the PHPStan level 6 type errors

### DIFF
--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -104,6 +104,7 @@ class Wpfaevent_Admin {
 	 * Register the stylesheets for the admin area.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function enqueue_styles() {
 
@@ -131,6 +132,7 @@ class Wpfaevent_Admin {
 	 * Register the JavaScript for the admin area.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function enqueue_scripts() {
 
@@ -155,6 +157,8 @@ class Wpfaevent_Admin {
 	 * @since    1.0.0
 	 * @param    array $links Existing plugin action links.
 	 * @return   array Modified plugin action links.
+	 * @phpstan-param array<string, string> $links
+	 * @phpstan-return array<array-key, string>
 	 */
 	public function add_settings_link( $links ) {
 		$settings_link = sprintf(
@@ -177,6 +181,7 @@ class Wpfaevent_Admin {
 	 * Register the settings page in WordPress admin.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function register_settings_page() {
 		add_menu_page(
@@ -221,6 +226,7 @@ class Wpfaevent_Admin {
 	 * Remove taxonomy submenu items from the Events admin menu.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function remove_event_taxonomy_submenus() {
 		remove_submenu_page( 'edit.php?post_type=wpfa_event', 'edit-tags.php?taxonomy=wpfa_event_track&post_type=wpfa_event' );
@@ -235,6 +241,7 @@ class Wpfaevent_Admin {
 	 * Render the settings page placeholder.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function render_settings_page() {
 		// Check user capabilities.
@@ -314,6 +321,7 @@ class Wpfaevent_Admin {
 	 * Register plugin settings stored under WPFAEvent -> Settings.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function register_plugin_settings() {
 		register_setting(
@@ -331,6 +339,7 @@ class Wpfaevent_Admin {
 	 * Render the per-user plugin access assignment table.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	private function render_user_access_settings_fields() {
 		$access_labels   = Wpfaevent_Roles::get_access_level_labels();
@@ -405,6 +414,7 @@ class Wpfaevent_Admin {
 	 * Render the access-level reference guide shown above the assignment table.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	private function render_user_access_level_guide() {
 		?>
@@ -442,6 +452,7 @@ class Wpfaevent_Admin {
 	 * Register Eventyay import options.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function register_eventyay_import_settings() {
 		register_setting(
@@ -463,6 +474,7 @@ class Wpfaevent_Admin {
 	 *
 	 * @param mixed $input Raw option input.
 	 * @return array Sanitized settings.
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function sanitize_eventyay_import_settings( $input ) {
 		return $this->get_eventyay_importer()->sanitize_eventyay_import_settings( $input );
@@ -472,6 +484,7 @@ class Wpfaevent_Admin {
 	 * Render the Eventyay import page.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function render_eventyay_import_page() {
 		$this->get_eventyay_importer()->render_settings_page();
@@ -481,6 +494,7 @@ class Wpfaevent_Admin {
 	 * Render the Eventyay update page.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function render_eventyay_update_page() {
 		$this->get_eventyay_importer()->render_update_events_page();
@@ -500,6 +514,7 @@ class Wpfaevent_Admin {
 	 * Handle Eventyay import form submissions.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function handle_eventyay_events_import() {
 		$this->get_eventyay_importer()->handle_eventyay_events_import();
@@ -511,6 +526,7 @@ class Wpfaevent_Admin {
 	 * @since 1.0.0
 	 *
 	 * @param string $post_type Current admin list post type.
+	 * @return void
 	 */
 	public function render_speaker_event_filter( $post_type = '' ) {
 		if ( 'wpfa_speaker' !== $post_type ) {
@@ -555,6 +571,7 @@ class Wpfaevent_Admin {
 	 * @since 1.0.0
 	 *
 	 * @param WP_Query $query Admin posts query.
+	 * @return void
 	 */
 	public function filter_speaker_admin_list( $query ) {
 		if ( ! $query instanceof WP_Query || ! $this->is_speaker_admin_list_query( $query ) ) {
@@ -601,6 +618,8 @@ class Wpfaevent_Admin {
 	 *
 	 * @param array $views Existing list table views.
 	 * @return array
+	 * @phpstan-param array<string, string> $views
+	 * @phpstan-return array<string, string>
 	 */
 	public function filter_speaker_admin_views( $views ) {
 		unset( $views );
@@ -636,6 +655,7 @@ class Wpfaevent_Admin {
 	 * Intercept the Speakers admin list screen to render our custom dashboard layout.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function intercept_speaker_list_screen() {
 		$screen = get_current_screen();
@@ -744,6 +764,7 @@ class Wpfaevent_Admin {
 	 * Render the opening of the dashboard layout wrapper on the classic list table screen.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function begin_speaker_table_layout() {
 		$screen = get_current_screen();
@@ -789,6 +810,7 @@ class Wpfaevent_Admin {
 	 * Render the closing of the dashboard layout wrapper on the classic list table screen.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function end_speaker_table_layout() {
 		$screen = get_current_screen();
@@ -887,6 +909,7 @@ class Wpfaevent_Admin {
 	 * Render a "Back to Event Dashboard" button on standard admin list pages.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function render_back_to_dashboard_button() {
 		$screen = get_current_screen();

--- a/admin/class-wpfaevent-admin.php
+++ b/admin/class-wpfaevent-admin.php
@@ -157,7 +157,7 @@ class Wpfaevent_Admin {
 	 * @since    1.0.0
 	 * @param    array $links Existing plugin action links.
 	 * @return   array Modified plugin action links.
-	 * @phpstan-param array<string, string> $links
+	 * @phpstan-param array<array-key, string> $links
 	 * @phpstan-return array<array-key, string>
 	 */
 	public function add_settings_link( $links ) {

--- a/admin/class-wpfaevent-event-dashboard-data.php
+++ b/admin/class-wpfaevent-event-dashboard-data.php
@@ -475,7 +475,7 @@ class Wpfaevent_Event_Dashboard_Data {
 	 * @param int   $event_id  Event post ID.
 	 * @param array $sessions  Normalized schedule sessions.
 	 * @return array<int, string>
-	 * @phpstan-param array<int, array<string, string>> $sessions
+	 * @phpstan-param array<int, array<string, mixed>> $sessions
 	 */
 	private function get_track_names( $event_id, $sessions ) {
 		$tracks = $this->get_term_names( $event_id, 'wpfa_event_track' );

--- a/admin/class-wpfaevent-event-dashboard-data.php
+++ b/admin/class-wpfaevent-event-dashboard-data.php
@@ -367,6 +367,7 @@ class Wpfaevent_Event_Dashboard_Data {
 	 *
 	 * @param array $schedule Schedule payload.
 	 * @return array<int, array<string, string>>
+	 * @phpstan-param array<string, mixed> $schedule
 	 */
 	private function get_schedule_sessions( $schedule ) {
 		if ( ! is_array( $schedule ) ) {
@@ -420,6 +421,7 @@ class Wpfaevent_Event_Dashboard_Data {
 	 *
 	 * @param array $speakers Raw speakers payload.
 	 * @return array<int, array<string, mixed>>
+	 * @phpstan-param array<array-key, mixed> $speakers
 	 */
 	private function get_dashboard_speakers( $speakers ) {
 		if ( ! is_array( $speakers ) ) {
@@ -473,6 +475,7 @@ class Wpfaevent_Event_Dashboard_Data {
 	 * @param int   $event_id  Event post ID.
 	 * @param array $sessions  Normalized schedule sessions.
 	 * @return array<int, string>
+	 * @phpstan-param array<int, array<string, string>> $sessions
 	 */
 	private function get_track_names( $event_id, $sessions ) {
 		$tracks = $this->get_term_names( $event_id, 'wpfa_event_track' );
@@ -496,6 +499,7 @@ class Wpfaevent_Event_Dashboard_Data {
 	 * @param array  $site_settings Site settings JSON.
 	 * @param string $site_logo_url Global site logo URL.
 	 * @return array<int, array<string, string>>
+	 * @phpstan-param array<string, mixed> $site_settings
 	 */
 	private function get_event_assets( $event_id, $site_settings, $site_logo_url ) {
 		$featured_image_url = get_the_post_thumbnail_url( $event_id, 'large' );

--- a/admin/class-wpfaevent-event-dashboard-sync-service.php
+++ b/admin/class-wpfaevent-event-dashboard-sync-service.php
@@ -132,7 +132,7 @@ class Wpfaevent_Event_Dashboard_Sync_Service {
 	 * @param array $settings       Eventyay import settings.
 	 * @param bool  $overwrite_logo Whether to overwrite the saved event logo.
 	 * @return array<string, bool>|WP_Error
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function update_dashboard_media_settings( $event_id, $event, $settings, $overwrite_logo ) {
@@ -178,7 +178,7 @@ class Wpfaevent_Event_Dashboard_Sync_Service {
 	 * @param array $event    Eventyay event resource.
 	 * @param array $settings Eventyay import settings.
 	 * @return array<string, string>
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function extract_event_media_urls( $event, $settings ) {
@@ -233,7 +233,7 @@ class Wpfaevent_Event_Dashboard_Sync_Service {
 	 * @param array $data Source array.
 	 * @param array $keys Candidate keys.
 	 * @return mixed
-	 * @phpstan-param array<string, mixed> $data
+	 * @phpstan-param array<array-key, mixed> $data
 	 * @phpstan-param list<string> $keys
 	 */
 	private function first_present_value( $data, $keys ) {

--- a/admin/class-wpfaevent-event-dashboard-sync-service.php
+++ b/admin/class-wpfaevent-event-dashboard-sync-service.php
@@ -132,6 +132,8 @@ class Wpfaevent_Event_Dashboard_Sync_Service {
 	 * @param array $settings       Eventyay import settings.
 	 * @param bool  $overwrite_logo Whether to overwrite the saved event logo.
 	 * @return array<string, bool>|WP_Error
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function update_dashboard_media_settings( $event_id, $event, $settings, $overwrite_logo ) {
 		$settings_file      = 'site-settings-' . absint( $event_id ) . '.json';
@@ -176,6 +178,8 @@ class Wpfaevent_Event_Dashboard_Sync_Service {
 	 * @param array $event    Eventyay event resource.
 	 * @param array $settings Eventyay import settings.
 	 * @return array<string, string>
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function extract_event_media_urls( $event, $settings ) {
 		$logo = $this->parser->eventyay_url_value(
@@ -229,6 +233,8 @@ class Wpfaevent_Event_Dashboard_Sync_Service {
 	 * @param array $data Source array.
 	 * @param array $keys Candidate keys.
 	 * @return mixed
+	 * @phpstan-param array<string, mixed> $data
+	 * @phpstan-param list<string> $keys
 	 */
 	private function first_present_value( $data, $keys ) {
 		if ( ! is_array( $data ) ) {

--- a/admin/class-wpfaevent-eventyay-ajax-sync.php
+++ b/admin/class-wpfaevent-eventyay-ajax-sync.php
@@ -45,6 +45,7 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 * Handle Eventyay JSON:API speaker sync for the admin dashboard.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function ajax_sync_eventyay() {
 		if ( ! check_ajax_referer( 'fossasia_admin_nonce', 'nonce', false ) ) {
@@ -317,6 +318,7 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 * @param string $api_url   Eventyay API URL.
 	 * @param string $api_token Optional API token for Authorization header.
 	 * @return array|WP_Error
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function fetch_eventyay_json( $api_url, $api_token = '' ) {
 		if ( '' === trim( (string) $api_token ) ) {
@@ -358,6 +360,9 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 * @param array $imported Imported Eventyay speakers.
 	 * @param array $existing Existing dashboard speakers.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $imported
+	 * @phpstan-param list<array<string, mixed>> $existing
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function merge_dashboard_speaker_state( $imported, $existing ) {
 		if ( ! is_array( $existing ) ) {
@@ -415,6 +420,8 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 *
 	 * @param array $speaker Speaker data.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-return list<string>
 	 */
 	private function get_dashboard_speaker_state_keys( $speaker ) {
 		$keys = array();
@@ -441,6 +448,7 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 *
 	 * @param array $speaker Speaker data.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $speaker
 	 */
 	private function is_eventyay_dashboard_speaker( $speaker ) {
 		if ( isset( $speaker['source'] ) && 'eventyay' === $speaker['source'] ) {
@@ -588,6 +596,8 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 * @param array $speakers Imported speakers.
 	 * @param int   $event_id Event post ID.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $speakers
+	 * @phpstan-return array{created: int, updated: int, ids: list<int>, featured_ids: list<int>}
 	 */
 	private function sync_eventyay_speaker_posts( $speakers, $event_id ) {
 		$result         = array(
@@ -693,6 +703,8 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 * @param array  $speaker     Speaker data.
 	 * @param string $post_status WordPress post status for the speaker.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-return array{id: int, created: bool}|WP_Error
 	 */
 	private function upsert_eventyay_speaker_post( $speaker, $post_status = 'draft' ) {
 		if ( empty( $speaker['eventyay_speaker_id'] ) || empty( $speaker['name'] ) ) {
@@ -1041,6 +1053,8 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 * @param string $event_slug Eventyay event slug.
 	 * @param array  $settings   Import settings.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{speakers: int, created_speakers: int, updated_speakers: int, sessions: int, schedule_rows: int}|WP_Error
 	 */
 	public function sync_speakers_for_event( $event_id, $event_slug, $settings ) {
 		$event_id  = absint( $event_id );
@@ -1117,6 +1131,8 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 * @param array  $settings   Import settings.
 	 * @param string $api_url    Primary speakers API URL.
 	 * @return array|WP_Error Normalized import payload.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function fetch_speakers_with_fallback( $event_id, $event_slug, $settings, $api_url ) {
 		$api_token = ! empty( $settings['api_token'] ) ? $settings['api_token'] : '';
@@ -1233,6 +1249,7 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 * @param int   $event_id Imported WordPress event post ID.
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return int|WP_Error Number of imported schedule data rows.
+	 * @phpstan-param list<array<string, mixed>> $sessions
 	 */
 	private function write_eventyay_schedule_table( $event_id, $sessions ) {
 		$event_id = absint( $event_id );
@@ -1268,6 +1285,8 @@ class Wpfaevent_Eventyay_Ajax_Sync {
 	 *
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $sessions
+	 * @phpstan-return array{name: string, rows: int, cols: int, data: list<list<string>>, sessions: list<array<string, string>>, source: string}
 	 */
 	private function build_eventyay_schedule_table( $sessions ) {
 		usort(

--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -656,7 +656,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array<string, mixed>|WP_Error
+	 * @phpstan-return array<array-key, mixed>|WP_Error
 	 */
 	public function fetch_single_eventyay_event_from_settings( $settings ) {
 		$settings = wp_parse_args( is_array( $settings ) ? $settings : array(), $this->get_eventyay_import_default_settings() );
@@ -693,9 +693,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $events   Fetched Eventyay event resources.
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error
-	 * @phpstan-param list<array<string, mixed>> $events
+	 * @phpstan-param list<array<array-key, mixed>> $events
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array<string, mixed>|WP_Error
+	 * @phpstan-return array<array-key, mixed>|WP_Error
 	 */
 	private function match_configured_eventyay_event( $events, $settings ) {
 		$event_slug = isset( $settings['event_slug'] ) ? $this->sanitize_eventyay_path_segment( $settings['event_slug'] ) : '';
@@ -758,7 +758,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $settings       Import settings.
 	 * @param int   $target_post_id Optional target event post ID to update in place.
 	 * @return array|WP_Error
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
@@ -820,7 +820,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error Event resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{events: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
+	 * @phpstan-return array{events: list<array<array-key, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	private function fetch_eventyay_event_resources( $settings ) {
 		$endpoints = $this->build_eventyay_event_endpoint_candidates( $settings );
@@ -862,7 +862,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Event resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{events: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
+	 * @phpstan-return array{events: list<array<array-key, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	private function fetch_eventyay_event_resources_from_endpoint( $endpoint, $settings ) {
 		if ( empty( $endpoint ) || ! wp_http_validate_url( $endpoint ) ) {
@@ -1179,9 +1179,9 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array $settings     Import settings.
 		 * @param bool  $fetch_detail Whether to fetch the detail endpoint if the list item is sparse.
 		 * @return array
-		 * @phpstan-param array<string, mixed> $event
+		 * @phpstan-param array<array-key, mixed> $event
 		 * @phpstan-param array<string, mixed> $settings
-		 * @phpstan-return array<string, mixed>
+		 * @phpstan-return array<array-key, mixed>
 		 */
 	private function hydrate_eventyay_event_resource( $event, $settings, $fetch_detail ) {
 		$event      = $this->normalize_eventyay_event_resource( $event );
@@ -1220,8 +1220,8 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $payload API payload.
 		 * @return array
-		 * @phpstan-param array<string, mixed> $payload
-		 * @phpstan-return list<array<string, mixed>>
+		 * @phpstan-param array<array-key, mixed> $payload
+		 * @phpstan-return list<array<array-key, mixed>>
 		 */
 	private function extract_eventyay_event_resources( $payload ) {
 		$resources = array();
@@ -1264,8 +1264,8 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Eventyay event resource.
 		 * @return array
-		 * @phpstan-param array<string, mixed> $event
-		 * @phpstan-return array<string, mixed>
+		 * @phpstan-param array<array-key, mixed> $event
+		 * @phpstan-return array<array-key, mixed>
 		 */
 	private function normalize_eventyay_event_resource( $event ) {
 		if ( ! is_array( $event ) ) {
@@ -1300,7 +1300,7 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Normalized Eventyay event resource.
 		 * @return bool
-		 * @phpstan-param array<string, mixed> $event
+		 * @phpstan-param array<array-key, mixed> $event
 		 */
 	private function eventyay_event_resource_needs_detail( $event ) {
 		$has_start    = '' !== trim( $this->eventyay_event_datetime( $event, 'start' ) );
@@ -1317,9 +1317,9 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array $base   Existing event fields.
 		 * @param array $detail Detail event fields.
 		 * @return array
-		 * @phpstan-param array<string, mixed> $base
-		 * @phpstan-param array<string, mixed> $detail
-		 * @phpstan-return array<string, mixed>
+		 * @phpstan-param array<array-key, mixed> $base
+		 * @phpstan-param array<array-key, mixed> $detail
+		 * @phpstan-return array<array-key, mixed>
 		 */
 	private function merge_eventyay_event_resource( $base, $detail ) {
 		$base   = $this->normalize_eventyay_event_resource( $base );
@@ -1348,7 +1348,7 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param string $event_slug Eventyay event slug.
 		 * @return array|WP_Error
 		 * @phpstan-param array<string, mixed> $settings
-		 * @phpstan-return array<string, mixed>|WP_Error
+		 * @phpstan-return array<array-key, mixed>|WP_Error
 		 */
 	private function fetch_eventyay_event_settings_resource( $settings, $event_slug ) {
 		$settings_endpoint = $this->build_eventyay_event_settings_endpoint( $settings, $event_slug );
@@ -1480,7 +1480,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $resource_type Partner resource type. Accepts sponsors or exhibitors.
 	 * @return array Endpoint URLs.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-return list<string>
 	 */
 	private function build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type ) {
@@ -1564,7 +1564,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $resource_type Partner resource type.
 	 * @return array Endpoint URLs.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-return list<string>
 	 */
 	private function build_eventyay_legacy_partner_endpoints( $settings, $event, $event_slug, $resource_type ) {
@@ -1630,7 +1630,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Import result.
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, int>|WP_Error
 	 */
@@ -1686,8 +1686,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $resource_type Partner resource type.
 	 * @return array|WP_Error Partner resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-param array<string, mixed> $event
-	 * @phpstan-return array{resources: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
+	 * @phpstan-param array<array-key, mixed> $event
+	 * @phpstan-return array{resources: list<array<array-key, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	private function fetch_eventyay_partner_collection( $settings, $event, $event_slug, $resource_type ) {
 		$endpoints = $this->build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type );
@@ -1744,7 +1744,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $resource_type Partner resource type.
 	 * @return array|WP_Error Partner resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{resources: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
+	 * @phpstan-return array{resources: list<array<array-key, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	private function fetch_eventyay_partner_resources( $endpoint, $settings, $resource_type ) {
 		$resources = array();
@@ -1828,7 +1828,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $resources Eventyay sponsor resources.
 	 * @param array $settings  Import settings.
 	 * @return array
-	 * @phpstan-param list<array<string, mixed>> $resources
+	 * @phpstan-param list<array<array-key, mixed>> $resources
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return list<array<string, mixed>>
 	 */
@@ -1875,7 +1875,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $sponsor_resource Eventyay sponsor resource.
 	 * @param array $settings Import settings.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $sponsor_resource
+	 * @phpstan-param array<array-key, mixed> $sponsor_resource
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -1917,7 +1917,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $sponsor_resource Eventyay sponsor resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $sponsor_resource
+	 * @phpstan-param array<array-key, mixed> $sponsor_resource
 	 */
 	private function eventyay_sponsor_group_name( $sponsor_resource ) {
 		$type = $this->eventyay_first_present_text(
@@ -2123,7 +2123,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $resources Eventyay exhibitor resources.
 	 * @param array $settings  Import settings.
 	 * @return array
-	 * @phpstan-param list<array<string, mixed>> $resources
+	 * @phpstan-param list<array<array-key, mixed>> $resources
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return list<array<string, mixed>>
 	 */
@@ -2170,7 +2170,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $exhibitor_resource Eventyay exhibitor resource.
 	 * @param array $settings Import settings.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $exhibitor_resource
+	 * @phpstan-param array<array-key, mixed> $exhibitor_resource
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -2493,7 +2493,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Submission resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{submissions: list<array<string, mixed>>, pages: int}|WP_Error
+	 * @phpstan-return array{submissions: list<array<array-key, mixed>>, pages: int}|WP_Error
 	 */
 	private function fetch_eventyay_program_resources( $endpoint, $settings ) {
 		$submissions = array();
@@ -2603,7 +2603,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Slot resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{slots: list<array<string, mixed>>, pages: int}|WP_Error
+	 * @phpstan-return array{slots: list<array<array-key, mixed>>, pages: int}|WP_Error
 	 */
 	private function fetch_eventyay_slot_resources( $endpoint, $settings ) {
 		$slots     = array();
@@ -3097,7 +3097,7 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Eventyay event resource.
 		 * @return string
-		 * @phpstan-param array<string, mixed> $event
+		 * @phpstan-param array<array-key, mixed> $event
 		 */
 	private function eventyay_event_slug( $event ) {
 		$slug = $this->eventyay_first_present_text( $event, array( 'slug', 'identifier', 'code' ) );
@@ -3125,7 +3125,7 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Eventyay event resource.
 		 * @return string
-		 * @phpstan-param array<string, mixed> $event
+		 * @phpstan-param array<array-key, mixed> $event
 		 */
 	private function eventyay_event_title( $event ) {
 		return $this->eventyay_first_present_text( $event, array( 'name', 'title', 'label' ) );
@@ -3139,7 +3139,7 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array  $event Eventyay event resource.
 		 * @param string $type  Date type. Accepts start or end.
 		 * @return string
-		 * @phpstan-param array<string, mixed> $event
+		 * @phpstan-param array<array-key, mixed> $event
 		 */
 	private function eventyay_event_datetime( $event, $type ) {
 		$keys = ( 'end' === $type )
@@ -3156,7 +3156,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	private function eventyay_event_timezone( $event ) {
 		return Wpfaevent_Meta_Event::sanitize_timezone(
@@ -3175,7 +3175,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	private function eventyay_event_location( $event ) {
 		$location = $this->eventyay_event_first_present_raw(
@@ -3204,7 +3204,7 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Eventyay event resource.
 		 * @return array<string>
-		 * @phpstan-param array<string, mixed> $event
+		 * @phpstan-param array<array-key, mixed> $event
 		 */
 	private function eventyay_event_languages( $event ) {
 		$languages = $this->eventyay_event_first_present_raw(
@@ -3238,7 +3238,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return array<string, string>
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	private function eventyay_event_colors( $event ) {
 		$color_fields = array(
@@ -3272,7 +3272,7 @@ class Wpfaevent_Eventyay_Importer {
 			 * @param array $settings          Import settings.
 			 * @param int   $preferred_post_id Optional preferred WordPress event post ID.
 			 * @return array|WP_Error Upsert result.
-			 * @phpstan-param array<string, mixed> $event
+			 * @phpstan-param array<array-key, mixed> $event
 			 * @phpstan-param array<string, mixed> $settings
 			 * @phpstan-return array{id: int, created: bool, event_slug: string}|WP_Error
 			 */
@@ -3389,7 +3389,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Dashboard sync result.
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array{about_updated: int}|WP_Error
 	 */
@@ -3488,7 +3488,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings    Import settings.
 	 * @param string $event_slug  Eventyay event slug.
 	 * @return array
-	 * @phpstan-param list<array<string, mixed>> $submissions
+	 * @phpstan-param list<array<array-key, mixed>> $submissions
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -3557,7 +3557,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings       Import settings.
 	 * @param string $event_slug     Eventyay event slug.
 	 * @return array
-	 * @phpstan-param list<array<string, mixed>> $slot_resources
+	 * @phpstan-param list<array<array-key, mixed>> $slot_resources
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -3700,7 +3700,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-param array<array-key, mixed> $submission
 	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_submission_session( $submission ) {
@@ -3747,8 +3747,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $slot       Eventyay slot resource.
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $slot
-	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-param array<array-key, mixed> $slot
+	 * @phpstan-param array<array-key, mixed> $submission
 	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_slot_session( $slot, $submission ) {
@@ -3812,7 +3812,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $slot Eventyay slot resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $slot
+	 * @phpstan-param array<array-key, mixed> $slot
 	 */
 	private function eventyay_slot_room_name( $slot ) {
 		$slot = $this->normalize_eventyay_api_resource( $slot );
@@ -3842,7 +3842,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings         Import settings.
 	 * @param string $event_slug       Eventyay event slug.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -3903,7 +3903,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 */
 	private function eventyay_speaker_is_featured( $speaker_resource ) {
 		$featured = $this->eventyay_first_present_raw(
@@ -3935,7 +3935,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return int
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 */
 	private function eventyay_speaker_featured_order( $speaker_resource ) {
 		$order = $this->eventyay_first_present_raw(
@@ -3998,7 +3998,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-param array<array-key, mixed> $submission
 	 */
 	private function eventyay_submission_abstract( $submission ) {
 		return $this->eventyay_first_present_rich_text(
@@ -4019,8 +4019,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $submission
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $submission
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	private function eventyay_first_slot( $submission ) {
 		if ( ! empty( $submission['slot'] ) && is_array( $submission['slot'] ) ) {
@@ -4045,8 +4045,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $eventyay_resource
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	private function normalize_eventyay_api_resource( $eventyay_resource ) {
 		if ( ! is_array( $eventyay_resource ) ) {
@@ -4172,7 +4172,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 */
 	private function eventyay_resource_identifier( $eventyay_resource ) {
 		foreach ( array( '_eventyay_source_id', 'code', 'id', 'slug' ) as $key ) {
@@ -4192,7 +4192,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	private function eventyay_first_present_text( $eventyay_resource, $keys ) {
@@ -4209,7 +4209,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	private function eventyay_first_present_rich_text( $eventyay_resource, $keys ) {
@@ -4226,7 +4226,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return mixed
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	private function eventyay_first_present_raw( $eventyay_resource, $keys ) {
@@ -4337,7 +4337,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	private function eventyay_event_has_settings_payload( $event ) {
 		foreach ( array( '_eventyay_settings', 'settings' ) as $settings_key ) {
@@ -4358,7 +4358,7 @@ class Wpfaevent_Eventyay_Importer {
 			 * @param array $keys             Candidate keys.
 			 * @param bool  $include_settings Whether to check Eventyay settings payloads.
 			 * @return mixed
-			 * @phpstan-param array<string, mixed> $event
+			 * @phpstan-param array<array-key, mixed> $event
 			 * @phpstan-param list<string> $keys
 			 */
 	private function eventyay_event_first_present_raw( $event, $keys, $include_settings = false ) {
@@ -4545,7 +4545,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	private function eventyay_event_description( $event ) {
 		$value = $this->eventyay_event_first_present_raw(
@@ -4598,7 +4598,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function eventyay_public_event_url( $event, $settings, $event_slug ) {
@@ -5067,7 +5067,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $payload JSON:API document.
 	 * @return array|WP_Error
-	 * @phpstan-param array<string, mixed> $payload
+	 * @phpstan-param array<array-key, mixed> $payload
 	 * @phpstan-return array{speakers: list<array<string, mixed>>, session_count: int}|WP_Error
 	 */
 	private function normalize_eventyay_payload( $payload ) {
@@ -5157,7 +5157,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $session_resource Session resource.
 	 * @param array $included         Indexed included resources.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $session_resource
+	 * @phpstan-param array<array-key, mixed> $session_resource
 	 * @phpstan-param array<string, mixed> $included
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -5197,7 +5197,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $speaker_resource Speaker resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_speaker_resource( $speaker_resource ) {
@@ -5881,8 +5881,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $jsonapi_resource JSON:API resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $jsonapi_resource
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $jsonapi_resource
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	private function get_jsonapi_attributes( $jsonapi_resource ) {
 		return isset( $jsonapi_resource['attributes'] ) && is_array( $jsonapi_resource['attributes'] ) ? $jsonapi_resource['attributes'] : array();
@@ -5896,7 +5896,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $attributes Attribute map.
 	 * @param array $keys       Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $attributes
+	 * @phpstan-param array<array-key, mixed> $attributes
 	 * @phpstan-param list<string> $keys
 	 */
 	private function attribute_value( $attributes, $keys ) {
@@ -5946,9 +5946,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $resource_identifier JSON:API resource identifier.
 	 * @param array $included            Indexed included resources.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $resource_identifier
+	 * @phpstan-param array<array-key, mixed> $resource_identifier
 	 * @phpstan-param array<string, mixed> $included
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	private function resolve_jsonapi_resource( $resource_identifier, $included ) {
 		if ( ! $this->is_jsonapi_resource( $resource_identifier ) ) {
@@ -5987,7 +5987,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $jsonapi_resource JSON:API resource.
 	 * @param string $name             Relationship name.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-param array<array-key, mixed> $jsonapi_resource
 	 * @phpstan-return array<int|string, mixed>
 	 */
 	private function get_jsonapi_relationship_resources( $jsonapi_resource, $name ) {
@@ -6027,7 +6027,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $jsonapi_resource JSON:API resource.
 	 * @param string $type             Expected singular type.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-param array<array-key, mixed> $jsonapi_resource
 	 */
 	private function jsonapi_type_is( $jsonapi_resource, $type ) {
 		if ( empty( $jsonapi_resource['type'] ) ) {

--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -2818,7 +2818,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $api_url   API endpoint URL.
 	 * @param string $api_token Optional API token.
 	 * @return array|WP_Error
-	 * @phpstan-return array<string, mixed>|WP_Error
+	 * @phpstan-return array<array-key, mixed>|WP_Error
 	 */
 	private function fetch_eventyay_rest_json( $api_url, $api_token = '' ) {
 		if ( empty( $api_url ) || ! wp_http_validate_url( $api_url ) ) {
@@ -2912,7 +2912,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $api_url  API endpoint URL.
 	 * @return array|WP_Error
 	 * @phpstan-param array<string, mixed> $response
-	 * @phpstan-return array<string, mixed>|WP_Error
+	 * @phpstan-return array<array-key, mixed>|WP_Error
 	 */
 	private function decode_eventyay_rest_response( $response, $api_url ) {
 		$status = absint( wp_remote_retrieve_response_code( $response ) );
@@ -5048,7 +5048,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param string $body Response body.
 	 * @return array|string
-	 * @phpstan-return array<string, mixed>|string
+	 * @phpstan-return array<array-key, mixed>|string
 	 */
 	private function decode_eventyay_error_body( $body ) {
 		$decoded = json_decode( $body, true );

--- a/admin/class-wpfaevent-eventyay-importer.php
+++ b/admin/class-wpfaevent-eventyay-importer.php
@@ -53,6 +53,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param mixed $input Raw option input.
 	 * @return array Sanitized settings.
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function sanitize_eventyay_import_settings( $input ) {
 		$input    = is_array( $input ) ? $input : array();
@@ -147,6 +148,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * Render the settings page.
 	 *
 	 * @since    1.0.0
+	 * @return void
 	 */
 	public function render_settings_page() {
 		// Check user capabilities.
@@ -287,6 +289,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * Render the Eventyay update page.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function render_update_events_page() {
 		if ( ! Wpfaevent_Roles::current_user_can_import_eventyay() ) {
@@ -366,6 +369,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * Import Eventyay events using the saved newer REST API settings.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function handle_eventyay_events_import() {
 		if ( ! Wpfaevent_Roles::current_user_can_import_eventyay() ) {
@@ -439,6 +443,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @since 1.0.0
 	 *
 	 * @return array
+	 * @phpstan-return array<string, string>
 	 */
 	public function get_eventyay_import_default_settings() {
 		return array(
@@ -471,6 +476,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @since 1.0.0
 	 *
 	 * @return array
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function get_eventyay_import_settings() {
 		$settings = get_option( 'wpfaevent_eventyay_import_settings', array() );
@@ -543,6 +549,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @since 1.0.0
 	 *
 	 * @return array|WP_Error Import result.
+	 * @phpstan-return array<string, int>|WP_Error
 	 */
 	public function import_eventyay_events_from_settings() {
 		$settings = $this->get_eventyay_import_settings();
@@ -648,6 +655,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function fetch_single_eventyay_event_from_settings( $settings ) {
 		$settings = wp_parse_args( is_array( $settings ) ? $settings : array(), $this->get_eventyay_import_default_settings() );
@@ -684,6 +693,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $events   Fetched Eventyay event resources.
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error
+	 * @phpstan-param list<array<string, mixed>> $events
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function match_configured_eventyay_event( $events, $settings ) {
 		$event_slug = isset( $settings['event_slug'] ) ? $this->sanitize_eventyay_path_segment( $settings['event_slug'] ) : '';
@@ -721,6 +733,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $settings Import settings.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function get_eventyay_public_event_url_from_settings( $settings ) {
 		$settings = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -745,6 +758,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $settings       Import settings.
 	 * @param int   $target_post_id Optional target event post ID to update in place.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function import_single_eventyay_event( $event, $settings, $target_post_id = 0 ) {
 		$event          = is_array( $event ) ? $event : array();
@@ -803,6 +819,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error Event resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{events: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	private function fetch_eventyay_event_resources( $settings ) {
 		$endpoints = $this->build_eventyay_event_endpoint_candidates( $settings );
@@ -843,6 +861,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $endpoint Event endpoint URL.
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Event resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{events: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	private function fetch_eventyay_event_resources_from_endpoint( $endpoint, $settings ) {
 		if ( empty( $endpoint ) || ! wp_http_validate_url( $endpoint ) ) {
@@ -920,6 +940,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error Endpoint URLs.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<string>|WP_Error
 	 */
 	private function build_eventyay_event_endpoint_candidates( $settings ) {
 		$primary_endpoint = $this->build_eventyay_events_endpoint( $settings );
@@ -946,6 +968,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $settings Import settings.
 	 * @return array Endpoint URLs.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<string>
 	 */
 	private function build_eventyay_legacy_event_endpoint_candidates( $settings ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1017,6 +1041,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $endpoints        Endpoint URLs that were tried.
 	 * @param array $not_found_errors 404 errors returned by the endpoints.
 	 * @return WP_Error
+	 * @phpstan-param list<string> $endpoints
+	 * @phpstan-param list<WP_Error> $not_found_errors
 	 */
 	private function eventyay_event_not_found_error( $endpoints, $not_found_errors ) {
 		$tried_endpoints = implode( ', ', array_map( 'esc_url_raw', $endpoints ) );
@@ -1048,6 +1074,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $settings Import settings.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function build_eventyay_events_endpoint( $settings ) {
 		$settings = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1096,6 +1123,7 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array  $settings   Import settings.
 		 * @param string $event_slug Eventyay event slug.
 		 * @return string|WP_Error Endpoint URL.
+		 * @phpstan-param array<string, mixed> $settings
 		 */
 	private function build_eventyay_event_endpoint( $settings, $event_slug ) {
 		$settings               = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1112,6 +1140,7 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array  $settings   Import settings.
 		 * @param string $event_slug Eventyay event slug.
 		 * @return string|WP_Error Endpoint URL.
+		 * @phpstan-param array<string, mixed> $settings
 		 */
 	private function build_eventyay_event_settings_endpoint( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1150,6 +1179,9 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array $settings     Import settings.
 		 * @param bool  $fetch_detail Whether to fetch the detail endpoint if the list item is sparse.
 		 * @return array
+		 * @phpstan-param array<string, mixed> $event
+		 * @phpstan-param array<string, mixed> $settings
+		 * @phpstan-return array<string, mixed>
 		 */
 	private function hydrate_eventyay_event_resource( $event, $settings, $fetch_detail ) {
 		$event      = $this->normalize_eventyay_event_resource( $event );
@@ -1188,6 +1220,8 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $payload API payload.
 		 * @return array
+		 * @phpstan-param array<string, mixed> $payload
+		 * @phpstan-return list<array<string, mixed>>
 		 */
 	private function extract_eventyay_event_resources( $payload ) {
 		$resources = array();
@@ -1230,6 +1264,8 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Eventyay event resource.
 		 * @return array
+		 * @phpstan-param array<string, mixed> $event
+		 * @phpstan-return array<string, mixed>
 		 */
 	private function normalize_eventyay_event_resource( $event ) {
 		if ( ! is_array( $event ) ) {
@@ -1264,6 +1300,7 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Normalized Eventyay event resource.
 		 * @return bool
+		 * @phpstan-param array<string, mixed> $event
 		 */
 	private function eventyay_event_resource_needs_detail( $event ) {
 		$has_start    = '' !== trim( $this->eventyay_event_datetime( $event, 'start' ) );
@@ -1280,6 +1317,9 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array $base   Existing event fields.
 		 * @param array $detail Detail event fields.
 		 * @return array
+		 * @phpstan-param array<string, mixed> $base
+		 * @phpstan-param array<string, mixed> $detail
+		 * @phpstan-return array<string, mixed>
 		 */
 	private function merge_eventyay_event_resource( $base, $detail ) {
 		$base   = $this->normalize_eventyay_event_resource( $base );
@@ -1307,6 +1347,8 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array  $settings   Import settings.
 		 * @param string $event_slug Eventyay event slug.
 		 * @return array|WP_Error
+		 * @phpstan-param array<string, mixed> $settings
+		 * @phpstan-return array<string, mixed>|WP_Error
 		 */
 	private function fetch_eventyay_event_settings_resource( $settings, $event_slug ) {
 		$settings_endpoint = $this->build_eventyay_event_settings_endpoint( $settings, $event_slug );
@@ -1341,6 +1383,7 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array  $settings   Import settings.
 		 * @param string $event_slug Eventyay event slug.
 		 * @return string|WP_Error Endpoint URL.
+		 * @phpstan-param array<string, mixed> $settings
 		 */
 	private function build_eventyay_submissions_endpoint( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1387,6 +1430,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function build_eventyay_slots_endpoint( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1435,6 +1479,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $event_slug    Eventyay event slug.
 	 * @param string $resource_type Partner resource type. Accepts sponsors or exhibitors.
 	 * @return array Endpoint URLs.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-return list<string>
 	 */
 	private function build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type ) {
 		$resource_type = sanitize_key( $resource_type );
@@ -1465,6 +1512,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $event_slug    Eventyay event slug.
 	 * @param string $resource_type Partner resource type.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function build_eventyay_modern_partner_endpoint( $settings, $event_slug, $resource_type ) {
 		$settings      = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1515,6 +1563,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $event_slug    Eventyay event slug.
 	 * @param string $resource_type Partner resource type.
 	 * @return array Endpoint URLs.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-return list<string>
 	 */
 	private function build_eventyay_legacy_partner_endpoints( $settings, $event, $event_slug, $resource_type ) {
 		$settings      = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1579,6 +1630,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Import result.
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, int>|WP_Error
 	 */
 	private function import_eventyay_event_partner_data( $event_id, $event, $settings, $event_slug ) {
 		$result   = array(
@@ -1631,6 +1685,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $event_slug    Eventyay event slug.
 	 * @param string $resource_type Partner resource type.
 	 * @return array|WP_Error Partner resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-return array{resources: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	private function fetch_eventyay_partner_collection( $settings, $event, $event_slug, $resource_type ) {
 		$endpoints = $this->build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type );
@@ -1686,6 +1743,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings      Import settings.
 	 * @param string $resource_type Partner resource type.
 	 * @return array|WP_Error Partner resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{resources: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	private function fetch_eventyay_partner_resources( $endpoint, $settings, $resource_type ) {
 		$resources = array();
@@ -1769,6 +1828,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $resources Eventyay sponsor resources.
 	 * @param array $settings  Import settings.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $resources
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function normalize_eventyay_sponsor_resources( $resources, $settings ) {
 		$sponsors = array();
@@ -1813,6 +1875,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $sponsor_resource Eventyay sponsor resource.
 	 * @param array $settings Import settings.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $sponsor_resource
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_sponsor_resource( $sponsor_resource, $settings ) {
 		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
@@ -1852,6 +1917,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $sponsor_resource Eventyay sponsor resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $sponsor_resource
 	 */
 	private function eventyay_sponsor_group_name( $sponsor_resource ) {
 		$type = $this->eventyay_first_present_text(
@@ -1896,6 +1962,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $imported Imported sponsors.
 	 * @param array $existing Existing dashboard sponsor groups.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $imported
+	 * @phpstan-param array<int|string, mixed> $existing
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function merge_eventyay_sponsor_groups( $imported, $existing ) {
 		$existing        = is_array( $existing ) ? $existing : array();
@@ -1981,6 +2050,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $sponsors Imported sponsors.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $sponsors
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function group_eventyay_sponsors( $sponsors ) {
 		$groups = array();
@@ -2024,6 +2095,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $group Sponsor group.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $group
 	 */
 	private function is_eventyay_sponsor_group( $group ) {
 		if ( ! empty( $group['source'] ) && 'eventyay' === $group['source'] ) {
@@ -2051,6 +2123,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $resources Eventyay exhibitor resources.
 	 * @param array $settings  Import settings.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $resources
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function normalize_eventyay_exhibitor_resources( $resources, $settings ) {
 		$exhibitors = array();
@@ -2095,6 +2170,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $exhibitor_resource Eventyay exhibitor resource.
 	 * @param array $settings Import settings.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $exhibitor_resource
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_exhibitor_resource( $exhibitor_resource, $settings ) {
 		$exhibitor_resource = $this->normalize_eventyay_api_resource( $exhibitor_resource );
@@ -2138,6 +2216,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $imported Imported records.
 	 * @param array $existing Existing records.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $imported
+	 * @phpstan-param array<int|string, mixed> $existing
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function merge_eventyay_flat_records( $imported, $existing ) {
 		$existing = is_array( $existing ) ? $existing : array();
@@ -2167,6 +2248,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Import result.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function import_eventyay_event_program( $event_id, $settings, $event_slug ) {
 		$endpoint = $this->build_eventyay_submissions_endpoint( $settings, $event_slug );
@@ -2250,6 +2333,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param int   $event_id Imported WordPress event post ID.
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return int|WP_Error Number of imported schedule data rows.
+	 * @phpstan-param list<array<string, mixed>> $sessions
 	 */
 	private function write_eventyay_schedule_table( $event_id, $sessions ) {
 		$event_id = absint( $event_id );
@@ -2286,6 +2370,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param int   $event_id Imported WordPress event post ID.
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return int
+	 * @phpstan-param list<array<string, mixed>> $sessions
 	 */
 	private function sync_eventyay_event_tracks( $event_id, $sessions ) {
 		$event_id = absint( $event_id );
@@ -2318,6 +2403,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $sessions
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function build_eventyay_schedule_table( $sessions ) {
 		usort(
@@ -2405,6 +2492,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $endpoint Submission endpoint.
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Submission resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{submissions: list<array<string, mixed>>, pages: int}|WP_Error
 	 */
 	private function fetch_eventyay_program_resources( $endpoint, $settings ) {
 		$submissions = array();
@@ -2473,6 +2562,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Normalized speaker program payload.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function fetch_eventyay_event_speaker_program( $settings, $event_slug ) {
 		return $this->get_client()->fetch_eventyay_event_speaker_program( $settings, $event_slug );
@@ -2486,6 +2577,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Normalized slot program payload.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function fetch_eventyay_event_slot_program( $settings, $event_slug ) {
 		$endpoint = $this->build_eventyay_slots_endpoint( $settings, $event_slug );
@@ -2509,6 +2602,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $endpoint Slot endpoint.
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Slot resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{slots: list<array<string, mixed>>, pages: int}|WP_Error
 	 */
 	private function fetch_eventyay_slot_resources( $endpoint, $settings ) {
 		$slots     = array();
@@ -2723,6 +2818,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param string $api_url   API endpoint URL.
 	 * @param string $api_token Optional API token.
 	 * @return array|WP_Error
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function fetch_eventyay_rest_json( $api_url, $api_token = '' ) {
 		if ( empty( $api_url ) || ! wp_http_validate_url( $api_url ) ) {
@@ -2815,6 +2911,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $response WordPress HTTP response.
 	 * @param string $api_url  API endpoint URL.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $response
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function decode_eventyay_rest_response( $response, $api_url ) {
 		$status = absint( wp_remote_retrieve_response_code( $response ) );
@@ -2999,6 +3097,7 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Eventyay event resource.
 		 * @return string
+		 * @phpstan-param array<string, mixed> $event
 		 */
 	private function eventyay_event_slug( $event ) {
 		$slug = $this->eventyay_first_present_text( $event, array( 'slug', 'identifier', 'code' ) );
@@ -3026,6 +3125,7 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Eventyay event resource.
 		 * @return string
+		 * @phpstan-param array<string, mixed> $event
 		 */
 	private function eventyay_event_title( $event ) {
 		return $this->eventyay_first_present_text( $event, array( 'name', 'title', 'label' ) );
@@ -3039,6 +3139,7 @@ class Wpfaevent_Eventyay_Importer {
 		 * @param array  $event Eventyay event resource.
 		 * @param string $type  Date type. Accepts start or end.
 		 * @return string
+		 * @phpstan-param array<string, mixed> $event
 		 */
 	private function eventyay_event_datetime( $event, $type ) {
 		$keys = ( 'end' === $type )
@@ -3055,6 +3156,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	private function eventyay_event_timezone( $event ) {
 		return Wpfaevent_Meta_Event::sanitize_timezone(
@@ -3073,6 +3175,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	private function eventyay_event_location( $event ) {
 		$location = $this->eventyay_event_first_present_raw(
@@ -3101,6 +3204,7 @@ class Wpfaevent_Eventyay_Importer {
 		 *
 		 * @param array $event Eventyay event resource.
 		 * @return array<string>
+		 * @phpstan-param array<string, mixed> $event
 		 */
 	private function eventyay_event_languages( $event ) {
 		$languages = $this->eventyay_event_first_present_raw(
@@ -3134,6 +3238,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return array<string, string>
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	private function eventyay_event_colors( $event ) {
 		$color_fields = array(
@@ -3167,6 +3272,9 @@ class Wpfaevent_Eventyay_Importer {
 			 * @param array $settings          Import settings.
 			 * @param int   $preferred_post_id Optional preferred WordPress event post ID.
 			 * @return array|WP_Error Upsert result.
+			 * @phpstan-param array<string, mixed> $event
+			 * @phpstan-param array<string, mixed> $settings
+			 * @phpstan-return array{id: int, created: bool, event_slug: string}|WP_Error
 			 */
 	private function upsert_eventyay_event_post( $event, $settings, $preferred_post_id = 0 ) {
 		$event      = $this->normalize_eventyay_event_resource( $event );
@@ -3281,6 +3389,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Dashboard sync result.
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{about_updated: int}|WP_Error
 	 */
 	private function sync_eventyay_event_dashboard_data( $event_id, $event, $settings, $event_slug ) {
 		$event_id = absint( $event_id );
@@ -3377,6 +3488,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings    Import settings.
 	 * @param string $event_slug  Eventyay event slug.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $submissions
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_submissions_payload( $submissions, $settings, $event_slug ) {
 		$speakers      = array();
@@ -3443,6 +3557,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings       Import settings.
 	 * @param string $event_slug     Eventyay event slug.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $slot_resources
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_slots_payload( $slot_resources, $settings, $event_slug ) {
 		$speakers = array();
@@ -3507,6 +3624,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $base  Base program payload.
 	 * @param array $extra Extra program payload.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $base
+	 * @phpstan-param array<string, mixed> $extra
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function merge_eventyay_program_payloads( $base, $extra ) {
 		$base  = is_array( $base ) ? $base : array();
@@ -3550,6 +3670,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $sessions Session list.
 	 * @param array $session  Session payload.
 	 * @return array
+	 * @phpstan-param array<string, array<string, mixed>> $sessions
+	 * @phpstan-param array<string, mixed> $session
+	 * @phpstan-return array<string, array<string, mixed>>
 	 */
 	private function merge_eventyay_session_payload( $sessions, $session ) {
 		if ( ! $this->eventyay_session_has_content( $session ) ) {
@@ -3577,6 +3700,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_submission_session( $submission ) {
 		$submission = $this->normalize_eventyay_api_resource( $submission );
@@ -3622,6 +3747,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $slot       Eventyay slot resource.
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $slot
+	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_slot_session( $slot, $submission ) {
 		$slot       = $this->normalize_eventyay_api_resource( $slot );
@@ -3665,6 +3793,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $session Normalized session.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $session
 	 */
 	private function eventyay_session_has_content( $session ) {
 		foreach ( array( 'title', 'date', 'time', 'end_time', 'abstract', 'track', 'room' ) as $key ) {
@@ -3683,6 +3812,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $slot Eventyay slot resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $slot
 	 */
 	private function eventyay_slot_room_name( $slot ) {
 		$slot = $this->normalize_eventyay_api_resource( $slot );
@@ -3712,6 +3842,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings         Import settings.
 	 * @param string $event_slug       Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_submission_speaker( $speaker_resource, $settings, $event_slug ) {
 		$speaker_resource = $this->normalize_eventyay_api_resource( $speaker_resource );
@@ -3770,6 +3903,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $speaker_resource
 	 */
 	private function eventyay_speaker_is_featured( $speaker_resource ) {
 		$featured = $this->eventyay_first_present_raw(
@@ -3801,6 +3935,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return int
+	 * @phpstan-param array<string, mixed> $speaker_resource
 	 */
 	private function eventyay_speaker_featured_order( $speaker_resource ) {
 		$order = $this->eventyay_first_present_raw(
@@ -3863,6 +3998,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $submission
 	 */
 	private function eventyay_submission_abstract( $submission ) {
 		return $this->eventyay_first_present_rich_text(
@@ -3883,6 +4019,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function eventyay_first_slot( $submission ) {
 		if ( ! empty( $submission['slot'] ) && is_array( $submission['slot'] ) ) {
@@ -3907,6 +4045,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_api_resource( $eventyay_resource ) {
 		if ( ! is_array( $eventyay_resource ) ) {
@@ -3990,6 +4130,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param mixed $value Raw value.
 	 * @return array
+	 * @phpstan-return array<int|string, mixed>
 	 */
 	private function eventyay_list_value( $value ) {
 		if ( ! is_array( $value ) ) {
@@ -4031,6 +4172,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
 	 */
 	private function eventyay_resource_identifier( $eventyay_resource ) {
 		foreach ( array( '_eventyay_source_id', 'code', 'id', 'slug' ) as $key ) {
@@ -4050,6 +4192,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	private function eventyay_first_present_text( $eventyay_resource, $keys ) {
 		$value = $this->eventyay_first_present_raw( $eventyay_resource, $keys );
@@ -4065,6 +4209,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	private function eventyay_first_present_rich_text( $eventyay_resource, $keys ) {
 		$value = $this->eventyay_first_present_raw( $eventyay_resource, $keys );
@@ -4080,6 +4226,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return mixed
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	private function eventyay_first_present_raw( $eventyay_resource, $keys ) {
 		foreach ( $keys as $key ) {
@@ -4189,6 +4337,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	private function eventyay_event_has_settings_payload( $event ) {
 		foreach ( array( '_eventyay_settings', 'settings' ) as $settings_key ) {
@@ -4209,6 +4358,8 @@ class Wpfaevent_Eventyay_Importer {
 			 * @param array $keys             Candidate keys.
 			 * @param bool  $include_settings Whether to check Eventyay settings payloads.
 			 * @return mixed
+			 * @phpstan-param array<string, mixed> $event
+			 * @phpstan-param list<string> $keys
 			 */
 	private function eventyay_event_first_present_raw( $event, $keys, $include_settings = false ) {
 		$value = $this->eventyay_first_present_raw( $event, $keys );
@@ -4394,6 +4545,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	private function eventyay_event_description( $event ) {
 		$value = $this->eventyay_event_first_present_raw(
@@ -4446,6 +4598,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	private function eventyay_public_event_url( $event, $settings, $event_slug ) {
 		$url = $this->eventyay_url_value(
@@ -4492,6 +4646,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * Handle Eventyay JSON:API speaker sync for the admin dashboard.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function ajax_sync_eventyay() {
 		if ( ! check_ajax_referer( 'fossasia_admin_nonce', 'nonce', false ) ) {
@@ -4724,6 +4879,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param string $api_url Eventyay API URL.
 	 * @return array|WP_Error
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	private function fetch_eventyay_json( $api_url ) {
 		$headers = array(
@@ -4892,6 +5048,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param string $body Response body.
 	 * @return array|string
+	 * @phpstan-return array<string, mixed>|string
 	 */
 	private function decode_eventyay_error_body( $body ) {
 		$decoded = json_decode( $body, true );
@@ -4910,6 +5067,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $payload JSON:API document.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $payload
+	 * @phpstan-return array{speakers: list<array<string, mixed>>, session_count: int}|WP_Error
 	 */
 	private function normalize_eventyay_payload( $payload ) {
 		$data = isset( $payload['data'] ) ? $payload['data'] : array();
@@ -4998,6 +5157,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $session_resource Session resource.
 	 * @param array $included         Indexed included resources.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $session_resource
+	 * @phpstan-param array<string, mixed> $included
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_session_resource( $session_resource, $included ) {
 		$attributes = $this->get_jsonapi_attributes( $session_resource );
@@ -5035,6 +5197,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $speaker_resource Speaker resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function normalize_eventyay_speaker_resource( $speaker_resource ) {
 		$attributes = $this->get_jsonapi_attributes( $speaker_resource );
@@ -5096,6 +5260,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $speaker  Speaker data.
 	 * @param array $session  Session data.
 	 * @return void
+	 * @phpstan-param array<string, array<string, mixed>> $speakers
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-param array<string, mixed> $session
 	 */
 	private function merge_eventyay_speaker( &$speakers, $speaker, $session ) {
 		$key = ! empty( $speaker['eventyay_speaker_id'] ) ? 'eventyay:' . $speaker['eventyay_speaker_id'] : 'name:' . sanitize_title( $speaker['name'] );
@@ -5150,6 +5317,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $imported Imported Eventyay speakers.
 	 * @param array $existing Existing dashboard speakers.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $imported
+	 * @phpstan-param array<int|string, mixed> $existing
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function merge_dashboard_speaker_state( $imported, $existing ) {
 		if ( ! is_array( $existing ) ) {
@@ -5210,6 +5380,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $speaker Speaker data.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-return list<string>
 	 */
 	private function get_dashboard_speaker_state_keys( $speaker ) {
 		$keys = array();
@@ -5236,6 +5408,7 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $speaker Speaker data.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $speaker
 	 */
 	private function is_eventyay_dashboard_speaker( $speaker ) {
 		if ( isset( $speaker['source'] ) && 'eventyay' === $speaker['source'] ) {
@@ -5253,6 +5426,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $speakers Imported speakers.
 	 * @param int   $event_id Event post ID.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $speakers
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function sync_eventyay_speaker_posts( $speakers, $event_id ) {
 		$result         = array(
@@ -5512,6 +5687,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $speaker     Speaker data.
 	 * @param string $post_status Optional. Post status. Default 'draft'.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-return array{id: int, created: bool}|WP_Error
 	 */
 	private function upsert_eventyay_speaker_post( $speaker, $post_status = 'draft' ) {
 		if ( empty( $speaker['eventyay_speaker_id'] ) || empty( $speaker['name'] ) ) {
@@ -5704,6 +5881,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $jsonapi_resource JSON:API resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function get_jsonapi_attributes( $jsonapi_resource ) {
 		return isset( $jsonapi_resource['attributes'] ) && is_array( $jsonapi_resource['attributes'] ) ? $jsonapi_resource['attributes'] : array();
@@ -5717,6 +5896,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $attributes Attribute map.
 	 * @param array $keys       Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $attributes
+	 * @phpstan-param list<string> $keys
 	 */
 	private function attribute_value( $attributes, $keys ) {
 		foreach ( $keys as $key ) {
@@ -5735,6 +5916,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param array $resources Included resources.
 	 * @return array
+	 * @phpstan-param array<int|string, mixed> $resources
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function index_jsonapi_resources( $resources ) {
 		$index = array();
@@ -5763,6 +5946,9 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array $resource_identifier JSON:API resource identifier.
 	 * @param array $included            Indexed included resources.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $resource_identifier
+	 * @phpstan-param array<string, mixed> $included
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function resolve_jsonapi_resource( $resource_identifier, $included ) {
 		if ( ! $this->is_jsonapi_resource( $resource_identifier ) ) {
@@ -5801,6 +5987,8 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $jsonapi_resource JSON:API resource.
 	 * @param string $name             Relationship name.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-return array<int|string, mixed>
 	 */
 	private function get_jsonapi_relationship_resources( $jsonapi_resource, $name ) {
 		if ( empty( $jsonapi_resource['relationships'][ $name ] ) || ! is_array( $jsonapi_resource['relationships'][ $name ] ) ) {
@@ -5839,6 +6027,7 @@ class Wpfaevent_Eventyay_Importer {
 	 * @param array  $jsonapi_resource JSON:API resource.
 	 * @param string $type             Expected singular type.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $jsonapi_resource
 	 */
 	private function jsonapi_type_is( $jsonapi_resource, $type ) {
 		if ( empty( $jsonapi_resource['type'] ) ) {
@@ -6135,6 +6324,8 @@ class Wpfaevent_Eventyay_Importer {
 	 *
 	 * @param string $message Log message.
 	 * @param array  $context Additional context data.
+	 * @return void
+	 * @phpstan-param array<string, mixed> $context
 	 */
 	private function safe_debug_log( $message, $context = array() ) {
 		if ( ! ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) ) {

--- a/admin/class-wpfaevent-eventyay-schedule-sync.php
+++ b/admin/class-wpfaevent-eventyay-schedule-sync.php
@@ -37,6 +37,7 @@ class Wpfaevent_Eventyay_Schedule_Sync {
 	 * @param int   $event_id Imported WordPress event post ID.
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return int|WP_Error Number of imported schedule data rows.
+	 * @phpstan-param list<array<string, mixed>> $sessions
 	 */
 	public function write_eventyay_schedule_table( $event_id, $sessions ) {
 		$event_id = absint( $event_id );
@@ -70,6 +71,8 @@ class Wpfaevent_Eventyay_Schedule_Sync {
 	 *
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $sessions
+	 * @phpstan-return array{name: string, rows: int, cols: int, data: list<list<string>>, sessions: list<array<string, string>>, source: string}
 	 */
 	private function build_eventyay_schedule_table( $sessions ) {
 		usort(

--- a/admin/class-wpfaevent-partner-dashboard-controller.php
+++ b/admin/class-wpfaevent-partner-dashboard-controller.php
@@ -47,6 +47,8 @@ class Wpfaevent_Partner_Dashboard_Controller {
 
 	/**
 	 * POST Handler to Save Sponsor/Exhibitor.
+	 *
+	 * @return void
 	 */
 	public function handle_save_partner() {
 		if ( ! current_user_can( 'edit_events' ) ) {
@@ -204,6 +206,8 @@ class Wpfaevent_Partner_Dashboard_Controller {
 
 	/**
 	 * GET Handler to Delete Sponsor/Exhibitor.
+	 *
+	 * @return void
 	 */
 	public function handle_delete_partner() {
 		if ( ! current_user_can( 'edit_events' ) ) {
@@ -258,6 +262,8 @@ class Wpfaevent_Partner_Dashboard_Controller {
 	 * @param string $id           Requested partner ID.
 	 * @param int    $record_index Requested record index.
 	 * @return array
+	 * @phpstan-param array<array-key, mixed> $records
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	private function remove_partner_record( $records, $id, $record_index ) {
 		$id = sanitize_key( $id );
@@ -279,6 +285,9 @@ class Wpfaevent_Partner_Dashboard_Controller {
 	 * @param array $records         Flat sponsor records.
 	 * @param array $existing_groups Existing sponsor groups.
 	 * @return array
+	 * @phpstan-param array<array-key, mixed> $records
+	 * @phpstan-param array<array-key, mixed> $existing_groups
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function build_sponsor_groups_from_records( $records, $existing_groups ) {
 		$existing_groups = is_array( $existing_groups ) ? $existing_groups : array();
@@ -362,6 +371,9 @@ class Wpfaevent_Partner_Dashboard_Controller {
 	 * @param array $groups      Existing groups.
 	 * @param array $group_order Submitted order.
 	 * @return array
+	 * @phpstan-param array<array-key, mixed> $groups
+	 * @phpstan-param list<string> $group_order
+	 * @phpstan-return list<array<array-key, mixed>>
 	 */
 	private function reorder_sponsor_groups( $groups, $group_order ) {
 		$groups      = is_array( $groups ) ? $groups : array();
@@ -402,6 +414,7 @@ class Wpfaevent_Partner_Dashboard_Controller {
 	 * @param int   $event_id   Event ID.
 	 * @param array $group_keys Submitted group keys.
 	 * @return array<string, mixed>
+	 * @phpstan-param list<string> $group_keys
 	 */
 	private function process_reorder_sponsor_groups( $event_id, $group_keys ) {
 		$existing_groups = $this->store->read_dashboard_json_file( 'sponsors-' . $event_id . '.json', array() );

--- a/admin/class-wpfaevent-partner-dashboard-hooks.php
+++ b/admin/class-wpfaevent-partner-dashboard-hooks.php
@@ -31,6 +31,8 @@ class Wpfaevent_Partner_Dashboard_Hooks {
 
 	/**
 	 * Register the submenu pages for Sponsors and Exhibitors.
+	 *
+	 * @return void
 	 */
 	public function register_menu_pages() {
 		add_submenu_page(

--- a/admin/class-wpfaevent-partner-dashboard-renderer.php
+++ b/admin/class-wpfaevent-partner-dashboard-renderer.php
@@ -57,6 +57,8 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 
 	/**
 	 * Render Sponsors Management Page callback.
+	 *
+	 * @return void
 	 */
 	public function render_sponsors_page() {
 		$this->render_dashboard_page( 'sponsor' );
@@ -64,6 +66,8 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 
 	/**
 	 * Render Exhibitors Management Page callback.
+	 *
+	 * @return void
 	 */
 	public function render_exhibitors_page() {
 		$this->render_dashboard_page( 'exhibitor' );
@@ -73,6 +77,7 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 	 * Unified layout generator for both Sponsors and Exhibitors dashboards.
 	 *
 	 * @param string $type Accepts 'sponsor' or 'exhibitor'.
+	 * @return void
 	 */
 	public function render_dashboard_page( $type ) {
 		if ( ! current_user_can( 'edit_events' ) ) {
@@ -583,6 +588,8 @@ class Wpfaevent_Partner_Dashboard_Renderer {
 	 * @param string $type     Accepts 'sponsor' or 'exhibitor'.
 	 * @param int    $event_id Event ID.
 	 * @param array  $item     Existing item for editing, or empty for creation.
+	 * @return void
+	 * @phpstan-param array<string, mixed> $item
 	 */
 	public function render_form( $type, $event_id, $item = array() ) {
 		$is_edit           = ! empty( $item );

--- a/admin/class-wpfaevent-partner-dashboard-statistics.php
+++ b/admin/class-wpfaevent-partner-dashboard-statistics.php
@@ -59,6 +59,7 @@ class Wpfaevent_Partner_Dashboard_Statistics {
 	 * @param string $type     Accepts 'sponsor' or 'exhibitor'.
 	 * @param int    $event_id Event ID.
 	 * @return array
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function load_records( $type, $event_id ) {
 		if ( ! $event_id ) {
@@ -97,6 +98,7 @@ class Wpfaevent_Partner_Dashboard_Statistics {
 	 *
 	 * @param int $event_id Event ID.
 	 * @return array
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function load_sponsor_groups( $event_id ) {
 		if ( ! $event_id ) {
@@ -113,6 +115,7 @@ class Wpfaevent_Partner_Dashboard_Statistics {
 	 *
 	 * @param array $records Records list.
 	 * @return array<string, int> Map of count types to count values.
+	 * @phpstan-param array<array-key, mixed> $records
 	 */
 	public function get_active_inactive_stats( $records ) {
 		$active_count   = 0;
@@ -143,6 +146,8 @@ class Wpfaevent_Partner_Dashboard_Statistics {
 	 * @param string $orderby       Field to order by.
 	 * @param string $order         Asc or desc order.
 	 * @return array Filtered and sorted records.
+	 * @phpstan-param array<array-key, mixed> $records
+	 * @phpstan-return list<mixed>
 	 */
 	public function filter_and_sort_records( $records, $type, $search_query, $status_filter, $cat_filter, $orderby, $order ) {
 		$filtered_records = array();

--- a/admin/class-wpfaevent-partner-dashboard.php
+++ b/admin/class-wpfaevent-partner-dashboard.php
@@ -39,6 +39,8 @@ class Wpfaevent_Partner_Dashboard {
 
 	/**
 	 * Register the submenu pages for Sponsors and Exhibitors.
+	 *
+	 * @return void
 	 */
 	public function register_menu_pages() {
 		$this->hooks->register_menu_pages();
@@ -46,6 +48,8 @@ class Wpfaevent_Partner_Dashboard {
 
 	/**
 	 * POST Handler to Save Sponsor/Exhibitor.
+	 *
+	 * @return void
 	 */
 	public function handle_save_partner() {
 		$this->controller->handle_save_partner();
@@ -53,6 +57,8 @@ class Wpfaevent_Partner_Dashboard {
 
 	/**
 	 * GET Handler to Delete Sponsor/Exhibitor.
+	 *
+	 * @return void
 	 */
 	public function handle_delete_partner() {
 		$this->controller->handle_delete_partner();
@@ -60,6 +66,8 @@ class Wpfaevent_Partner_Dashboard {
 
 	/**
 	 * POST Handler to save sponsor group order.
+	 *
+	 * @return void
 	 */
 	public function handle_reorder_sponsor_groups() {
 		$this->controller->handle_reorder_sponsor_groups();

--- a/admin/partials/ajax-handlers/class-wpfaevent-event-handler.php
+++ b/admin/partials/ajax-handlers/class-wpfaevent-event-handler.php
@@ -412,7 +412,10 @@ class Wpfaevent_Event_Handler {
 			$this->update_or_delete_post_meta( $event_id, 'wpfa_event_timezone', $timezone );
 		}
 
-		$all_day = isset( $request['all_day'] ) && rest_sanitize_boolean( wp_unslash( $request['all_day'] ) );
+		$posted_all_day = isset( $request['all_day'] ) ? wp_unslash( $request['all_day'] ) : false;
+		$all_day        = is_bool( $posted_all_day ) || is_string( $posted_all_day ) || is_int( $posted_all_day )
+			? rest_sanitize_boolean( $posted_all_day )
+			: (bool) $posted_all_day;
 		update_post_meta( $event_id, 'wpfa_event_all_day', $all_day ? '1' : '0' );
 
 		$posted_start_time = isset( $request['start_time'] ) ? sanitize_text_field( wp_unslash( $request['start_time'] ) ) : '';

--- a/admin/partials/ajax-handlers/class-wpfaevent-event-handler.php
+++ b/admin/partials/ajax-handlers/class-wpfaevent-event-handler.php
@@ -30,6 +30,7 @@ class Wpfaevent_Event_Handler {
 	 * Handle AJAX request to get event data.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_get_event() {
 		// Verify nonce. Third param 'false' ensures we can handle the error response manually via JSON.
@@ -94,6 +95,7 @@ class Wpfaevent_Event_Handler {
 	 * Handle AJAX request to add a new event.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_add_event() {
 		// Verify nonce. Third param 'false' ensures we can handle the error response manually via JSON.
@@ -235,6 +237,7 @@ class Wpfaevent_Event_Handler {
 	 * Handle AJAX request to update an event.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_update_event() {
 		// Verify nonce. Third param 'false' ensures we can handle the error response manually via JSON.
@@ -382,6 +385,7 @@ class Wpfaevent_Event_Handler {
 	 * @param int   $event_id Event post ID.
 	 * @param array $request  Request data.
 	 * @return void
+	 * @phpstan-param array<string, mixed> $request
 	 */
 	private function save_event_timing_meta( $event_id, $request ) {
 		$event_id = absint( $event_id );
@@ -499,6 +503,7 @@ class Wpfaevent_Event_Handler {
 	 * Handle AJAX request to delete an event.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_delete_event() {
 		// Verify nonce. Third param 'false' ensures we can handle the error response manually via JSON.

--- a/admin/partials/ajax-handlers/class-wpfaevent-speakers-handler.php
+++ b/admin/partials/ajax-handlers/class-wpfaevent-speakers-handler.php
@@ -30,6 +30,7 @@ class Wpfaevent_Speakers_Handler {
 	 * Handle AJAX request to get speaker data.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_get_speaker() {
 		// Verify nonce.
@@ -98,6 +99,7 @@ class Wpfaevent_Speakers_Handler {
 	 * Handle AJAX request to add a new speaker.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_add_speaker() {
 		// Verify nonce.
@@ -263,6 +265,7 @@ class Wpfaevent_Speakers_Handler {
 	 * Handle AJAX request to update a speaker.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_update_speaker() {
 		// Verify nonce.
@@ -433,6 +436,7 @@ class Wpfaevent_Speakers_Handler {
 	 * Handle AJAX request to delete a speaker.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_delete_speaker() {
 		// Verify nonce.

--- a/admin/partials/meta-boxes/class-wpfaevent-admin-event-metabox.php
+++ b/admin/partials/meta-boxes/class-wpfaevent-admin-event-metabox.php
@@ -30,6 +30,7 @@ class Wpfaevent_Admin_Event_Metabox {
 	 * Register meta boxes for the Event CPT.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function register_meta_boxes() {
 		add_meta_box(
@@ -93,6 +94,7 @@ class Wpfaevent_Admin_Event_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @param WP_Post $post The post object.
+	 * @return void
 	 */
 	public function render_event_meta_box( $post ) {
 		wp_nonce_field( 'wpfa_event_meta_nonce', 'wpfa_event_meta_nonce' );
@@ -239,6 +241,7 @@ class Wpfaevent_Admin_Event_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @param WP_Post $post The post object.
+	 * @return void
 	 */
 	public function render_eventyay_sync_meta_box( $post ) {
 		$eventyay_id = get_post_meta( $post->ID, '_eventyay_event_slug', true );
@@ -319,6 +322,7 @@ class Wpfaevent_Admin_Event_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @param WP_Post $post The post object.
+	 * @return void
 	 */
 	public function render_event_schedule_meta_box( $post ) {
 		$sessions = array();
@@ -457,6 +461,7 @@ class Wpfaevent_Admin_Event_Metabox {
 	 *
 	 * @since 1.0.1
 	 * @param WP_Post $post The post object.
+	 * @return void
 	 */
 	public function render_event_sponsors_meta_box( $post ) {
 		$sponsors = array();
@@ -589,6 +594,7 @@ class Wpfaevent_Admin_Event_Metabox {
 	 *
 	 * @since 1.0.1
 	 * @param WP_Post $post The post object.
+	 * @return void
 	 */
 	public function render_event_exhibitors_meta_box( $post ) {
 		$exhibitors = array();
@@ -711,6 +717,7 @@ class Wpfaevent_Admin_Event_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @param int $post_id The post ID.
+	 * @return void
 	 */
 	public function save_event_meta( $post_id ) {
 		$event_nonce = isset( $_POST['wpfa_event_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_event_meta_nonce'] ) ) : '';

--- a/admin/partials/meta-boxes/class-wpfaevent-admin-speaker-metabox.php
+++ b/admin/partials/meta-boxes/class-wpfaevent-admin-speaker-metabox.php
@@ -22,6 +22,7 @@ class Wpfaevent_Admin_Speaker_Metabox {
 	 * Register meta boxes for the Speaker CPT.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function register_meta_boxes() {
 		add_meta_box(
@@ -43,6 +44,7 @@ class Wpfaevent_Admin_Speaker_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @param WP_Post $post The post object.
+	 * @return void
 	 */
 	public function render_speaker_meta_box( $post ) {
 		wp_nonce_field( 'wpfa_speaker_meta_nonce', 'wpfa_speaker_meta_nonce' );
@@ -144,6 +146,7 @@ class Wpfaevent_Admin_Speaker_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @param int $post_id The post ID.
+	 * @return void
 	 */
 	public function save_speaker_meta( $post_id ) {
 		$speaker_nonce = isset( $_POST['wpfa_speaker_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_speaker_meta_nonce'] ) ) : '';

--- a/includes/cache/class-wpfaevent-cache.php
+++ b/includes/cache/class-wpfaevent-cache.php
@@ -61,6 +61,7 @@ class Wpfaevent_Cache {
 	 *
 	 * @since    1.0.0
 	 * @param    int $post_id    The post ID being saved/deleted.
+	 * @return   void
 	 */
 	public static function clear_page_cache( $post_id ) {
 		// Only clear for pages (not posts, CPTs, etc.).

--- a/includes/class-wpfaevent-activator.php
+++ b/includes/class-wpfaevent-activator.php
@@ -25,6 +25,7 @@ class Wpfaevent_Activator {
 	 * Activate the plugin.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public static function activate() {
 		// Load CPT classes to register them before flushing.
@@ -59,6 +60,7 @@ class Wpfaevent_Activator {
 	 * Grant custom capabilities to administrator role.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	private static function add_capabilities() {
 		$role = get_role( 'administrator' );

--- a/includes/class-wpfaevent-calendar.php
+++ b/includes/class-wpfaevent-calendar.php
@@ -26,6 +26,7 @@ class Wpfaevent_Calendar {
 	 * Register calendar REST routes.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function register_rest_routes() {
 		register_rest_route(
@@ -92,6 +93,7 @@ class Wpfaevent_Calendar {
 	 *
 	 * @param array $event Normalized event calendar data.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public static function build_google_calendar_url( $event ) {
 		$dates = self::format_google_calendar_dates( $event );
@@ -232,6 +234,7 @@ class Wpfaevent_Calendar {
 	 *
 	 * @param array $event Normalized event calendar data.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public static function build_event_ics_content( $event ) {
 		$dtstamp = isset( $event['dtstamp'] ) && $event['dtstamp'] instanceof DateTimeInterface
@@ -303,6 +306,7 @@ class Wpfaevent_Calendar {
 	 *
 	 * @param int $event_id Event post ID.
 	 * @return array|WP_Error
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public static function get_event_calendar_data( $event_id ) {
 		$event_id = absint( $event_id );
@@ -503,6 +507,7 @@ class Wpfaevent_Calendar {
 	 *
 	 * @param array $event Normalized event calendar data.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public static function format_google_calendar_dates( $event ) {
 		if ( ! empty( $event['all_day'] ) ) {
@@ -550,6 +555,7 @@ class Wpfaevent_Calendar {
 	 *
 	 * @param array $lines Lines.
 	 * @return string
+	 * @phpstan-param list<string> $lines
 	 */
 	private static function render_ics_lines( $lines ) {
 		$lines = array_filter(

--- a/includes/class-wpfaevent-cron-scheduler.php
+++ b/includes/class-wpfaevent-cron-scheduler.php
@@ -36,6 +36,7 @@ class Wpfaevent_Cron_Scheduler {
 	 *
 	 * @param array $settings Saved Eventyay import settings (plain-text, not encrypted).
 	 * @return void
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public static function schedule( array $settings ) {
 		self::clear();

--- a/includes/class-wpfaevent-deactivator.php
+++ b/includes/class-wpfaevent-deactivator.php
@@ -25,6 +25,7 @@ class Wpfaevent_Deactivator {
 	 * Deactivate the plugin.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public static function deactivate() {
 		require_once plugin_dir_path( __FILE__ ) . 'class-wpfaevent-cron-scheduler.php';

--- a/includes/class-wpfaevent-event-speaker-relation-manager.php
+++ b/includes/class-wpfaevent-event-speaker-relation-manager.php
@@ -172,7 +172,7 @@ class Wpfaevent_Event_Speaker_Relation_Manager {
 	 * @param array<int>        $speaker_ids        Linked speaker post IDs.
 	 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
 	 * @return array<int>
-	 * @phpstan-param array<int, array<string, mixed>> $dashboard_speakers
+	 * @phpstan-param array<array-key, mixed> $dashboard_speakers
 	 */
 	public static function resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers = array() ) {
 		$event_id    = absint( $event_id );

--- a/includes/class-wpfaevent-event-speaker-relation-manager.php
+++ b/includes/class-wpfaevent-event-speaker-relation-manager.php
@@ -172,6 +172,7 @@ class Wpfaevent_Event_Speaker_Relation_Manager {
 	 * @param array<int>        $speaker_ids        Linked speaker post IDs.
 	 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
 	 * @return array<int>
+	 * @phpstan-param array<int, array<string, mixed>> $dashboard_speakers
 	 */
 	public static function resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers = array() ) {
 		$event_id    = absint( $event_id );
@@ -500,6 +501,7 @@ class Wpfaevent_Event_Speaker_Relation_Manager {
 	 * @param int          $speaker_id  Speaker post ID.
 	 * @param string|array $post_status Event post status filter.
 	 * @return array<int>
+	 * @phpstan-param string|array<int, string> $post_status
 	 */
 	public static function get_events_referencing_speaker( $speaker_id, $post_status = 'any' ) {
 		$speaker_id = absint( $speaker_id );
@@ -548,6 +550,7 @@ class Wpfaevent_Event_Speaker_Relation_Manager {
 	 * @param int          $speaker_id  Speaker post ID.
 	 * @param string|array $post_status Event post status filter.
 	 * @return array<int>
+	 * @phpstan-param string|array<int, string> $post_status
 	 */
 	public static function get_events_linked_to_speaker( $speaker_id, $post_status = 'publish' ) {
 		$speaker_id = absint( $speaker_id );
@@ -604,6 +607,7 @@ class Wpfaevent_Event_Speaker_Relation_Manager {
 	 * @param int  $speaker_id       Speaker post ID.
 	 * @param int  $event_id         Event post ID.
 	 * @param bool $check_capability Whether to require edit access to the speaker.
+	 * @return void
 	 */
 	public static function add_event_to_speaker( $speaker_id, $event_id, $check_capability = true ) {
 		$speaker_id = absint( $speaker_id );
@@ -631,6 +635,7 @@ class Wpfaevent_Event_Speaker_Relation_Manager {
 	 * @param int  $speaker_id       Speaker post ID.
 	 * @param int  $event_id         Event post ID.
 	 * @param bool $check_capability Whether to require edit access to the speaker.
+	 * @return void
 	 */
 	public static function remove_event_from_speaker( $speaker_id, $event_id, $check_capability = true ) {
 		$speaker_id = absint( $speaker_id );
@@ -676,6 +681,7 @@ class Wpfaevent_Event_Speaker_Relation_Manager {
 	 * @param int        $event_id          Event post ID.
 	 * @param array<int> $previous_speakers Speaker IDs before save.
 	 * @param array<int> $current_speakers  Speaker IDs after save.
+	 * @return void
 	 */
 	public static function sync_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers ) {
 		$event_id          = absint( $event_id );

--- a/includes/class-wpfaevent-i18n.php
+++ b/includes/class-wpfaevent-i18n.php
@@ -22,6 +22,7 @@ class Wpfaevent_I18n {
 	 * Load the plugin text domain for translation.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function load_plugin_textdomain() {
 		load_plugin_textdomain(

--- a/includes/class-wpfaevent-loader.php
+++ b/includes/class-wpfaevent-loader.php
@@ -28,6 +28,7 @@ class Wpfaevent_Loader {
 	 * @since    1.0.0
 	 * @access   protected
 	 * @var      array    $actions    The actions registered with WordPress to fire when the plugin loads.
+	 * @phpstan-var array<int, array{hook: string, component: object|string, callback: string, priority: int, accepted_args: int}>
 	 */
 	protected $actions;
 
@@ -37,6 +38,7 @@ class Wpfaevent_Loader {
 	 * @since    1.0.0
 	 * @access   protected
 	 * @var      array    $filters    The filters registered with WordPress to fire when the plugin loads.
+	 * @phpstan-var array<int, array{hook: string, component: object|string, callback: string, priority: int, accepted_args: int}>
 	 */
 	protected $filters;
 
@@ -60,6 +62,7 @@ class Wpfaevent_Loader {
 	 * @param    string $callback         The name of the function definition on the $component.
 	 * @param    int    $priority         Optional. The priority at which the function should be fired. Default is 10.
 	 * @param    int    $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1.
+	 * @return   void
 	 * @phpstan-param object|string $component
 	 */
 	public function add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
@@ -75,6 +78,7 @@ class Wpfaevent_Loader {
 	 * @param    string $callback         The name of the function definition on the $component.
 	 * @param    int    $priority         Optional. The priority at which the function should be fired. Default is 10.
 	 * @param    int    $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1.
+	 * @return   void
 	 * @phpstan-param object|string $component
 	 */
 	public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
@@ -95,6 +99,8 @@ class Wpfaevent_Loader {
 	 * @param    int    $accepted_args    The number of arguments that should be passed to the $callback.
 	 * @return   array                                  The collection of actions and filters registered with WordPress.
 	 * @phpstan-param object|string $component
+	 * @phpstan-param array<int, array{hook: string, component: object|string, callback: string, priority: int, accepted_args: int}> $hooks
+	 * @phpstan-return array<int, array{hook: string, component: object|string, callback: string, priority: int, accepted_args: int}>
 	 */
 	private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
 
@@ -113,6 +119,7 @@ class Wpfaevent_Loader {
 	 * Register the filters and actions with WordPress.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function run() {
 

--- a/includes/class-wpfaevent.php
+++ b/includes/class-wpfaevent.php
@@ -104,6 +104,7 @@ class Wpfaevent {
 	 *
 	 * @since    1.0.0
 	 * @access   private
+	 * @return   void
 	 */
 	private function load_dependencies() {
 		// Loader.
@@ -186,6 +187,7 @@ class Wpfaevent {
 	 *
 	 * @since    1.0.0
 	 * @access   private
+	 * @return   void
 	 */
 	private function define_cpt_hooks() {
 		// Register Event CPT (static method call).
@@ -200,6 +202,7 @@ class Wpfaevent {
 	 *
 	 * @since    1.0.0
 	 * @access   private
+	 * @return   void
 	 */
 	private function define_taxonomy_hooks() {
 		// Register Event and Speaker taxonomies.
@@ -212,6 +215,7 @@ class Wpfaevent {
 	 *
 	 * @since    1.0.0
 	 * @access   private
+	 * @return   void
 	 */
 	private function define_meta_hooks() {
 		// Register Event meta fields.
@@ -226,6 +230,7 @@ class Wpfaevent {
 	 *
 	 * @since    1.0.0
 	 * @access   private
+	 * @return   void
 	 */
 	private function define_page_hooks() {
 		$this->loader->add_action( 'init', 'Wpfaevent_Additional_Information_Helper', 'ensure_additional_information_page', 21 );
@@ -238,6 +243,7 @@ class Wpfaevent {
 	 *
 	 * @since    1.0.0
 	 * @access   private
+	 * @return   void
 	 */
 	private function define_admin_hooks() {
 		// Instantiate the admin class.
@@ -331,6 +337,7 @@ class Wpfaevent {
 	 *
 	 * @since    1.0.0
 	 * @access   private
+	 * @return   void
 	 */
 	private function define_public_hooks() {
 		// Instantiate the public class.
@@ -360,6 +367,7 @@ class Wpfaevent {
 	 * Run the loader to execute all of the hooks with WordPress.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function run() {
 		$this->loader->run();

--- a/includes/cli/class-wpfa-cli.php
+++ b/includes/cli/class-wpfa-cli.php
@@ -37,6 +37,9 @@ class WPFA_CLI {
 	 *
 	 * @param array $args Positional command arguments.
 	 * @param array $assoc_args Associative command arguments.
+	 * @return void
+	 * @phpstan-param list<string> $args
+	 * @phpstan-param array<string, string|bool> $assoc_args
 	 */
 	public static function seed( $args, $assoc_args ) {
 		if ( isset( $assoc_args['from-json'] ) ) {
@@ -54,6 +57,8 @@ class WPFA_CLI {
 
 	/**
 	 * Minimal hardcoded seed (2 speakers, 1 event).
+	 *
+	 * @return void
 	 */
 	private static function seed_minimal() {
 		$placeholder = 'https://via.placeholder.com/300x300.png?text=Speaker';
@@ -137,6 +142,7 @@ class WPFA_CLI {
 	 * }
 	 *
 	 * @param string $path Path to the JSON seed file.
+	 * @return void
 	 */
 	private static function seed_from_json( $path ) {
 		if ( ! file_exists( $path ) ) {
@@ -236,6 +242,8 @@ class WPFA_CLI {
 	 * @param array  $postarr Post arguments passed to WordPress.
 	 * @param array  $meta Meta fields to store on the post.
 	 * @return int post ID
+	 * @phpstan-param array<string, mixed> $postarr
+	 * @phpstan-param array<string, mixed> $meta
 	 */
 	private static function upsert_post_by_slug( $post_type, $slug, $postarr, $meta ) {
 		$existing = get_page_by_path( $slug, OBJECT, $post_type );
@@ -270,6 +278,7 @@ class WPFA_CLI {
 	 * @param int   $event_id Event post ID.
 	 * @param array $speaker_ids Related speaker post IDs.
 	 * @return void
+	 * @phpstan-param list<int> $speaker_ids
 	 */
 	private static function sync_relationships( $event_id, $speaker_ids ) {
 		$event_id    = absint( $event_id );
@@ -305,6 +314,8 @@ class WPFA_CLI {
 	 * @param array $args Positional command arguments.
 	 * @param array $assoc_args Associative command arguments.
 	 * @return void
+	 * @phpstan-param list<string> $args
+	 * @phpstan-param array<string, string|bool> $assoc_args
 	 */
 	public static function import( $args, $assoc_args ) {
 		unset( $args, $assoc_args );

--- a/includes/cpt/class-wpfaevent-cpt-event.php
+++ b/includes/cpt/class-wpfaevent-cpt-event.php
@@ -29,6 +29,7 @@ class Wpfaevent_CPT_Event {
 	 * Registers the custom post type.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function register() {
 

--- a/includes/cpt/class-wpfaevent-cpt-speaker.php
+++ b/includes/cpt/class-wpfaevent-cpt-speaker.php
@@ -29,6 +29,7 @@ class Wpfaevent_CPT_Speaker {
 	 * Registers the custom post type.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function register() {
 

--- a/includes/eventyay-importer/class-wpfaevent-admin-settings-renderer.php
+++ b/includes/eventyay-importer/class-wpfaevent-admin-settings-renderer.php
@@ -35,6 +35,7 @@ class Wpfaevent_Admin_Settings_Renderer {
 	 * Render the settings configuration and import page.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function render_settings_page() {
 		if ( ! Wpfaevent_Roles::current_user_can_import_eventyay() ) {
@@ -57,6 +58,7 @@ class Wpfaevent_Admin_Settings_Renderer {
 	 * Render the update events dashboard module.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function render_update_events_page() {
 		if ( ! Wpfaevent_Roles::current_user_can_import_eventyay() ) {

--- a/includes/eventyay-importer/class-wpfaevent-ajax-controller.php
+++ b/includes/eventyay-importer/class-wpfaevent-ajax-controller.php
@@ -65,6 +65,7 @@ class Wpfaevent_AJAX_Controller {
 	 * Handle Eventyay JSON:API speaker sync for the admin dashboard.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function ajax_sync_eventyay() {
 		if ( ! check_ajax_referer( 'fossasia_admin_nonce', 'nonce', false ) ) {
@@ -155,6 +156,7 @@ class Wpfaevent_AJAX_Controller {
 	 * Get all events for chunked imports.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function ajax_import_get_events() {
 		if ( ! check_ajax_referer( 'wpfaevent_import_eventyay_events', 'nonce', false ) ) {
@@ -217,6 +219,7 @@ class Wpfaevent_AJAX_Controller {
 	 * Import a single event for chunked imports.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function ajax_import_single_event() {
 		if ( ! check_ajax_referer( 'wpfaevent_import_eventyay_events', 'nonce', false ) ) {
@@ -280,6 +283,7 @@ class Wpfaevent_AJAX_Controller {
 	 * Save the final import summary transient for notices.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public function ajax_import_save_summary() {
 		if ( ! check_ajax_referer( 'wpfaevent_import_eventyay_events', 'nonce', false ) ) {

--- a/includes/eventyay-importer/class-wpfaevent-event-repository.php
+++ b/includes/eventyay-importer/class-wpfaevent-event-repository.php
@@ -45,6 +45,9 @@ class Wpfaevent_Event_Repository {
 	 * @param array $event    Eventyay event resource.
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error Upsert result.
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{id: int, created: bool, event_slug: string}|WP_Error
 	 */
 	public function upsert_eventyay_event_post( $event, $settings ) {
 		$event      = $this->parser->normalize_eventyay_event_resource( $event );
@@ -329,6 +332,7 @@ class Wpfaevent_Event_Repository {
 	 * @param int   $event_id Imported WordPress event post ID.
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return int|WP_Error Number of imported schedule data rows.
+	 * @phpstan-param list<array<string, mixed>> $sessions
 	 */
 	public function write_eventyay_schedule_table( $event_id, $sessions ) {
 		$event_id = absint( $event_id );
@@ -364,6 +368,8 @@ class Wpfaevent_Event_Repository {
 	 *
 	 * @param array $sessions Normalized Eventyay sessions.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $sessions
+	 * @phpstan-return array{name: string, rows: int, cols: int, data: list<list<string>>, sessions: list<array<string, string>>, source: string}
 	 */
 	public function build_eventyay_schedule_table( $sessions ) {
 		usort(

--- a/includes/eventyay-importer/class-wpfaevent-event-repository.php
+++ b/includes/eventyay-importer/class-wpfaevent-event-repository.php
@@ -45,7 +45,7 @@ class Wpfaevent_Event_Repository {
 	 * @param array $event    Eventyay event resource.
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error Upsert result.
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array{id: int, created: bool, event_slug: string}|WP_Error
 	 */

--- a/includes/eventyay-importer/class-wpfaevent-eventyay-api-client.php
+++ b/includes/eventyay-importer/class-wpfaevent-eventyay-api-client.php
@@ -1591,7 +1591,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $api_url   API endpoint URL.
 	 * @param string $api_token Optional API token.
 	 * @return array|WP_Error
-	 * @phpstan-return array<string, mixed>|WP_Error
+	 * @phpstan-return array<array-key, mixed>|WP_Error
 	 */
 	public function fetch_eventyay_rest_json( $api_url, $api_token = '' ) {
 		if ( empty( $api_url ) || ! wp_http_validate_url( $api_url ) ) {
@@ -1685,7 +1685,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $api_url  API endpoint URL.
 	 * @return array|WP_Error
 	 * @phpstan-param array<string, mixed> $response
-	 * @phpstan-return array<string, mixed>|WP_Error
+	 * @phpstan-return array<array-key, mixed>|WP_Error
 	 */
 	public function decode_eventyay_rest_response( $response, $api_url ) {
 		$status = absint( wp_remote_retrieve_response_code( $response ) );
@@ -1870,7 +1870,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 *
 	 * @param string $body Response body.
 	 * @return array|string
-	 * @phpstan-return array<string, mixed>|string
+	 * @phpstan-return array<array-key, mixed>|string
 	 */
 	public function decode_eventyay_error_body( $body ) {
 		$decoded = json_decode( $body, true );

--- a/includes/eventyay-importer/class-wpfaevent-eventyay-api-client.php
+++ b/includes/eventyay-importer/class-wpfaevent-eventyay-api-client.php
@@ -37,7 +37,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error Event resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{events: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
+	 * @phpstan-return array{events: list<array<array-key, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	public function fetch_eventyay_event_resources( $settings ) {
 		$endpoints = $this->build_eventyay_event_endpoint_candidates( $settings );
@@ -79,7 +79,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Event resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{events: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
+	 * @phpstan-return array{events: list<array<array-key, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	public function fetch_eventyay_event_resources_from_endpoint( $endpoint, $settings ) {
 		if ( empty( $endpoint ) || ! wp_http_validate_url( $endpoint ) ) {
@@ -396,7 +396,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array<string, mixed>|WP_Error
+	 * @phpstan-return array<array-key, mixed>|WP_Error
 	 */
 	public function fetch_eventyay_event_settings_resource( $settings, $event_slug ) {
 		$settings_endpoint = $this->build_eventyay_event_settings_endpoint( $settings, $event_slug );
@@ -559,7 +559,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $resource_type Partner resource type. Accepts sponsors or exhibitors.
 	 * @return array Endpoint URLs.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-return list<string>
 	 */
 	public function build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type ) {
@@ -643,7 +643,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $resource_type Partner resource type.
 	 * @return array Endpoint URLs.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-return list<string>
 	 */
 	public function build_eventyay_legacy_partner_endpoints( $settings, $event, $event_slug, $resource_type ) {
@@ -710,8 +710,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $resource_type Partner resource type.
 	 * @return array|WP_Error Partner resources.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-param array<string, mixed> $event
-	 * @phpstan-return array{resources: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
+	 * @phpstan-param array<array-key, mixed> $event
+	 * @phpstan-return array{resources: list<array<array-key, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	public function fetch_eventyay_partner_collection( $settings, $event, $event_slug, $resource_type ) {
 		$endpoints = $this->build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type );
@@ -768,7 +768,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $resource_type Partner resource type.
 	 * @return array|WP_Error Partner resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{resources: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
+	 * @phpstan-return array{resources: list<array<array-key, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	public function fetch_eventyay_partner_resources( $endpoint, $settings, $resource_type ) {
 		$resources = array();
@@ -853,7 +853,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Submission resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{submissions: list<array<string, mixed>>, pages: int}|WP_Error
+	 * @phpstan-return array{submissions: list<array<array-key, mixed>>, pages: int}|WP_Error
 	 */
 	public function fetch_eventyay_program_resources( $endpoint, $settings ) {
 		$submissions = array();
@@ -1267,7 +1267,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Speaker resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{speakers: list<array<string, mixed>>, pages: int}|WP_Error
+	 * @phpstan-return array{speakers: list<array<array-key, mixed>>, pages: int}|WP_Error
 	 */
 	public function fetch_eventyay_speaker_resources( $endpoint, $settings ) {
 		$speakers  = array();
@@ -1376,7 +1376,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Slot resources and metadata.
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array{slots: list<array<string, mixed>>, pages: int}|WP_Error
+	 * @phpstan-return array{slots: list<array<array-key, mixed>>, pages: int}|WP_Error
 	 */
 	public function fetch_eventyay_slot_resources( $endpoint, $settings ) {
 		$slots     = array();
@@ -2099,9 +2099,9 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array $settings     Import settings.
 	 * @param bool  $fetch_detail Whether to fetch the detail endpoint if the list item is sparse.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function hydrate_eventyay_event_resource( $event, $settings, $fetch_detail ) {
 		$event      = $this->parser->normalize_eventyay_event_resource( $event );

--- a/includes/eventyay-importer/class-wpfaevent-eventyay-api-client.php
+++ b/includes/eventyay-importer/class-wpfaevent-eventyay-api-client.php
@@ -36,6 +36,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 *
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error Event resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{events: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	public function fetch_eventyay_event_resources( $settings ) {
 		$endpoints = $this->build_eventyay_event_endpoint_candidates( $settings );
@@ -76,6 +78,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $endpoint Event endpoint URL.
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Event resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{events: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	public function fetch_eventyay_event_resources_from_endpoint( $endpoint, $settings ) {
 		if ( empty( $endpoint ) || ! wp_http_validate_url( $endpoint ) ) {
@@ -153,6 +157,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 *
 	 * @param array $settings Import settings.
 	 * @return array|WP_Error Endpoint URLs.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<string>|WP_Error
 	 */
 	public function build_eventyay_event_endpoint_candidates( $settings ) {
 		$primary_endpoint = $this->build_eventyay_events_endpoint( $settings );
@@ -179,6 +185,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 *
 	 * @param array $settings Import settings.
 	 * @return array Endpoint URLs.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<string>
 	 */
 	public function build_eventyay_legacy_event_endpoint_candidates( $settings ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -250,6 +258,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array $endpoints        Endpoint URLs that were tried.
 	 * @param array $not_found_errors 404 errors returned by the endpoints.
 	 * @return WP_Error
+	 * @phpstan-param list<string> $endpoints
+	 * @phpstan-param list<WP_Error> $not_found_errors
 	 */
 	public function eventyay_event_not_found_error( $endpoints, $not_found_errors ) {
 		$tried_endpoints = implode( ', ', array_map( 'esc_url_raw', $endpoints ) );
@@ -281,6 +291,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 *
 	 * @param array $settings Import settings.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_events_endpoint( $settings ) {
 		$settings = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -329,6 +340,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_event_endpoint( $settings, $event_slug ) {
 		$settings               = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -345,6 +357,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_event_settings_endpoint( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -382,6 +395,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function fetch_eventyay_event_settings_resource( $settings, $event_slug ) {
 		$settings_endpoint = $this->build_eventyay_event_settings_endpoint( $settings, $event_slug );
@@ -400,6 +415,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_submissions_endpoint( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -446,6 +462,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_speakers_endpoint( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -492,6 +509,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_slots_endpoint( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -540,6 +558,9 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $event_slug    Eventyay event slug.
 	 * @param string $resource_type Partner resource type. Accepts sponsors or exhibitors.
 	 * @return array Endpoint URLs.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-return list<string>
 	 */
 	public function build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type ) {
 		$resource_type = sanitize_key( $resource_type );
@@ -570,6 +591,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $event_slug    Eventyay event slug.
 	 * @param string $resource_type Partner resource type.
 	 * @return string|WP_Error Endpoint URL.
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_modern_partner_endpoint( $settings, $event_slug, $resource_type ) {
 		$settings      = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -620,6 +642,9 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $event_slug    Eventyay event slug.
 	 * @param string $resource_type Partner resource type.
 	 * @return array Endpoint URLs.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-return list<string>
 	 */
 	public function build_eventyay_legacy_partner_endpoints( $settings, $event, $event_slug, $resource_type ) {
 		$settings      = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -684,6 +709,9 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $event_slug    Eventyay event slug.
 	 * @param string $resource_type Partner resource type.
 	 * @return array|WP_Error Partner resources.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-return array{resources: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	public function fetch_eventyay_partner_collection( $settings, $event, $event_slug, $resource_type ) {
 		$endpoints = $this->build_eventyay_partner_endpoint_candidates( $settings, $event, $event_slug, $resource_type );
@@ -739,6 +767,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings      Import settings.
 	 * @param string $resource_type Partner resource type.
 	 * @return array|WP_Error Partner resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{resources: list<array<string, mixed>>, pages: int, endpoint: string}|WP_Error
 	 */
 	public function fetch_eventyay_partner_resources( $endpoint, $settings, $resource_type ) {
 		$resources = array();
@@ -822,6 +852,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $endpoint Submission endpoint.
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Submission resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{submissions: list<array<string, mixed>>, pages: int}|WP_Error
 	 */
 	public function fetch_eventyay_program_resources( $endpoint, $settings ) {
 		$submissions = array();
@@ -890,6 +922,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Normalized speaker program payload.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function fetch_eventyay_event_speaker_program( $settings, $event_slug ) {
 		$endpoint = $this->build_eventyay_speakers_endpoint( $settings, $event_slug );
@@ -928,6 +962,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, array<string, mixed>>|WP_Error
 	 */
 	public function fetch_eventyay_public_speaker_featured_map( $settings, $event_slug ) {
 		$page_url = $this->build_eventyay_public_speakers_page_url( $settings, $event_slug );
@@ -976,6 +1012,9 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $import
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function enrich_legacy_eventyay_speakers_with_featured_state( $import, $settings, $event_slug ) {
 		if ( ! is_array( $import ) || empty( $import['speakers'] ) || empty( $settings['organizer_slug'] ) ) {
@@ -1000,6 +1039,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function fetch_eventyay_featured_speakers( $settings, $event_slug ) {
 		$endpoints = $this->build_eventyay_featured_speaker_endpoint_candidates( $settings, $event_slug );
@@ -1022,6 +1063,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, array<string, mixed>>|WP_Error
 	 */
 	public function fetch_eventyay_public_event_featured_map_fallback( $settings, $event_slug ) {
 		$page_url = $this->build_eventyay_public_event_url( $settings, $event_slug );
@@ -1067,6 +1110,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<string>
 	 */
 	private function build_eventyay_featured_speaker_endpoint_candidates( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1105,6 +1150,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string|WP_Error
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_public_event_url( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1133,6 +1179,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string|WP_Error
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function build_eventyay_public_speakers_page_url( $settings, $event_slug ) {
 		$settings   = wp_parse_args( $settings, $this->get_eventyay_import_default_settings() );
@@ -1162,6 +1209,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	private function fetch_eventyay_featured_speakers_from_endpoint( $endpoint, $settings, $event_slug ) {
 		if ( empty( $endpoint ) || ! wp_http_validate_url( $endpoint ) ) {
@@ -1217,6 +1266,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $endpoint Speaker endpoint.
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Speaker resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{speakers: list<array<string, mixed>>, pages: int}|WP_Error
 	 */
 	public function fetch_eventyay_speaker_resources( $endpoint, $settings ) {
 		$speakers  = array();
@@ -1299,6 +1350,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error Normalized slot program payload.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function fetch_eventyay_event_slot_program( $settings, $event_slug ) {
 		$endpoint = $this->build_eventyay_slots_endpoint( $settings, $event_slug );
@@ -1322,6 +1375,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $endpoint Slot endpoint.
 	 * @param array  $settings Import settings.
 	 * @return array|WP_Error Slot resources and metadata.
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array{slots: list<array<string, mixed>>, pages: int}|WP_Error
 	 */
 	public function fetch_eventyay_slot_resources( $endpoint, $settings ) {
 		$slots     = array();
@@ -1536,6 +1591,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param string $api_url   API endpoint URL.
 	 * @param string $api_token Optional API token.
 	 * @return array|WP_Error
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function fetch_eventyay_rest_json( $api_url, $api_token = '' ) {
 		if ( empty( $api_url ) || ! wp_http_validate_url( $api_url ) ) {
@@ -1628,6 +1684,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array  $response WordPress HTTP response.
 	 * @param string $api_url  API endpoint URL.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $response
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function decode_eventyay_rest_response( $response, $api_url ) {
 		$status = absint( wp_remote_retrieve_response_code( $response ) );
@@ -1812,6 +1870,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 *
 	 * @param string $body Response body.
 	 * @return array|string
+	 * @phpstan-return array<string, mixed>|string
 	 */
 	public function decode_eventyay_error_body( $body ) {
 		$decoded = json_decode( $body, true );
@@ -1830,6 +1889,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 *
 	 * @param string $api_url Eventyay API URL.
 	 * @return array|WP_Error
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function fetch_eventyay_json( $api_url ) {
 		$headers = array(
@@ -2039,6 +2099,9 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @param array $settings     Import settings.
 	 * @param bool  $fetch_detail Whether to fetch the detail endpoint if the list item is sparse.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function hydrate_eventyay_event_resource( $event, $settings, $fetch_detail ) {
 		$event      = $this->parser->normalize_eventyay_event_resource( $event );
@@ -2076,6 +2139,7 @@ class Wpfaevent_Eventyay_API_Client {
 	 * @since 1.0.0
 	 *
 	 * @return array
+	 * @phpstan-return array{base_url: string, organizer_slug: string, event_slug: string, api_token: string, post_status: string}
 	 */
 	public function get_eventyay_import_default_settings() {
 		return array(
@@ -2108,6 +2172,8 @@ class Wpfaevent_Eventyay_API_Client {
 	 *
 	 * @param string $message Log message.
 	 * @param array  $context Additional context data.
+	 * @return void
+	 * @phpstan-param array<string, mixed> $context
 	 */
 	private function safe_debug_log( $message, $context = array() ) {
 		if ( ! ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) ) {

--- a/includes/eventyay-importer/class-wpfaevent-eventyay-post-manager.php
+++ b/includes/eventyay-importer/class-wpfaevent-eventyay-post-manager.php
@@ -26,6 +26,7 @@ class Wpfaevent_Eventyay_Post_Manager {
 	 * @param array $post_data Arguments passed to wp_insert_post/wp_update_post.
 	 * @param int   $post_id   Existing post ID to update, or 0 to insert.
 	 * @return int|WP_Error New or updated post ID, or WP_Error on database error.
+	 * @phpstan-param array<string, mixed> $post_data
 	 */
 	public function save_event_post( $post_data, $post_id = 0 ) {
 		if ( $post_id ) {
@@ -48,6 +49,7 @@ class Wpfaevent_Eventyay_Post_Manager {
 	 * @param int   $post_id  Target post ID.
 	 * @param array $metadata Key-value pairs of metadata fields.
 	 * @return void
+	 * @phpstan-param array<string, mixed> $metadata
 	 */
 	public function sync_event_metadata( $post_id, $metadata ) {
 		$post_id = absint( $post_id );

--- a/includes/eventyay-importer/class-wpfaevent-jsonapi-parser.php
+++ b/includes/eventyay-importer/class-wpfaevent-jsonapi-parser.php
@@ -36,8 +36,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $event
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $event
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function normalize_eventyay_event_resource( $event ) {
 		if ( ! is_array( $event ) ) {
@@ -72,8 +72,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $payload API payload.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $payload
-	 * @phpstan-return list<array<string, mixed>>
+	 * @phpstan-param array<array-key, mixed> $payload
+	 * @phpstan-return list<array<array-key, mixed>>
 	 */
 	public function extract_eventyay_event_resources( $payload ) {
 		$resources = array();
@@ -116,7 +116,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Normalized Eventyay event resource.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_resource_needs_detail( $event ) {
 		$has_start    = '' !== trim( $this->eventyay_event_datetime( $event, 'start' ) );
@@ -133,9 +133,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $base   Existing event fields.
 	 * @param array $detail Detail event fields.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $base
-	 * @phpstan-param array<string, mixed> $detail
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $base
+	 * @phpstan-param array<array-key, mixed> $detail
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function merge_eventyay_event_resource( $base, $detail ) {
 		$base   = $this->normalize_eventyay_event_resource( $base );
@@ -179,7 +179,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $resources Eventyay sponsor resources.
 	 * @param array $settings  Import settings.
 	 * @return array
-	 * @phpstan-param list<array<string, mixed>> $resources
+	 * @phpstan-param list<array<array-key, mixed>> $resources
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return list<array<string, mixed>>
 	 */
@@ -226,7 +226,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $sponsor_resource Eventyay sponsor resource.
 	 * @param array $settings Import settings.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $sponsor_resource
+	 * @phpstan-param array<array-key, mixed> $sponsor_resource
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -257,7 +257,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $sponsor_resource Eventyay sponsor resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $sponsor_resource
+	 * @phpstan-param array<array-key, mixed> $sponsor_resource
 	 */
 	public function eventyay_sponsor_group_name( $sponsor_resource ) {
 		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
@@ -291,7 +291,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $resources Eventyay exhibitor resources.
 	 * @param array $settings  Import settings.
 	 * @return array
-	 * @phpstan-param list<array<string, mixed>> $resources
+	 * @phpstan-param list<array<array-key, mixed>> $resources
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return list<array<string, mixed>>
 	 */
@@ -338,7 +338,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $exhibitor_resource Eventyay exhibitor resource.
 	 * @param array $settings Import settings.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $exhibitor_resource
+	 * @phpstan-param array<array-key, mixed> $exhibitor_resource
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -648,8 +648,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $submission
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $submission
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function normalize_eventyay_submission_session( $submission ) {
 		$submission = $this->normalize_eventyay_api_resource( $submission );
@@ -695,8 +695,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $slot       Eventyay slot resource.
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $slot
-	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-param array<array-key, mixed> $slot
+	 * @phpstan-param array<array-key, mixed> $submission
 	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_slot_session( $slot, $submission ) {
@@ -760,7 +760,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $slot Eventyay slot resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $slot
+	 * @phpstan-param array<array-key, mixed> $slot
 	 */
 	public function eventyay_slot_room_name( $slot ) {
 		$slot = $this->normalize_eventyay_api_resource( $slot );
@@ -790,7 +790,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings         Import settings.
 	 * @param string $event_slug       Eventyay event slug.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -851,7 +851,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 */
 	public function eventyay_speaker_is_featured( $speaker_resource ) {
 		$featured = $this->eventyay_first_present_raw(
@@ -883,7 +883,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return int
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 */
 	public function eventyay_speaker_featured_order( $speaker_resource ) {
 		$order = $this->eventyay_first_present_raw(
@@ -912,7 +912,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 */
 	public function eventyay_speaker_featured_state_known( $speaker_resource ) {
 		return $this->eventyay_has_present_key(
@@ -943,7 +943,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $speaker_resource Eventyay resource array.
 	 * @param array $keys             Candidate keys.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_has_present_key( $speaker_resource, $keys ) {
@@ -1001,7 +1001,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-param array<array-key, mixed> $submission
 	 */
 	public function eventyay_submission_abstract( $submission ) {
 		return $this->eventyay_first_present_rich_text(
@@ -1022,8 +1022,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $submission
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $submission
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function eventyay_first_slot( $submission ) {
 		if ( ! empty( $submission['slot'] ) && is_array( $submission['slot'] ) ) {
@@ -1048,8 +1048,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $eventyay_resource
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function normalize_eventyay_api_resource( $eventyay_resource ) {
 		if ( ! is_array( $eventyay_resource ) ) {
@@ -1175,7 +1175,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 */
 	public function eventyay_resource_identifier( $eventyay_resource ) {
 		foreach ( array( '_eventyay_source_id', 'code', 'id', 'slug' ) as $key ) {
@@ -1195,7 +1195,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_text( $eventyay_resource, $keys ) {
@@ -1212,7 +1212,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_rich_text( $eventyay_resource, $keys ) {
@@ -1229,7 +1229,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return mixed
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_raw( $eventyay_resource, $keys ) {
@@ -1362,7 +1362,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_has_settings_payload( $event ) {
 		foreach ( array( '_eventyay_settings', 'settings' ) as $settings_key ) {
@@ -1383,7 +1383,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $keys             Candidate keys.
 	 * @param bool  $include_settings Whether to check Eventyay settings payloads.
 	 * @return mixed
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_event_first_present_raw( $event, $keys, $include_settings = false ) {
@@ -1527,7 +1527,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_description( $event ) {
 		$value = $this->eventyay_event_first_present_raw(
@@ -1563,7 +1563,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function eventyay_public_event_url( $event, $settings, $event_slug ) {
@@ -1615,7 +1615,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error
-	 * @phpstan-param array<string, mixed> $payload
+	 * @phpstan-param array<array-key, mixed> $payload
 	 * @phpstan-param array<string, mixed> $settings
 	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
@@ -1865,7 +1865,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $session_resource Session resource.
 	 * @param array $included         Indexed included resources.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $session_resource
+	 * @phpstan-param array<array-key, mixed> $session_resource
 	 * @phpstan-param array<string, mixed> $included
 	 * @phpstan-return array<string, mixed>
 	 */
@@ -1905,7 +1905,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker_resource Speaker resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<array-key, mixed> $speaker_resource
 	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_speaker_resource( $speaker_resource ) {
@@ -1967,8 +1967,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $jsonapi_resource JSON:API resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $jsonapi_resource
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $jsonapi_resource
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function get_jsonapi_attributes( $jsonapi_resource ) {
 		return isset( $jsonapi_resource['attributes'] ) && is_array( $jsonapi_resource['attributes'] ) ? $jsonapi_resource['attributes'] : array();
@@ -1982,7 +1982,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $attributes Attribute map.
 	 * @param array $keys       Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $attributes
+	 * @phpstan-param array<array-key, mixed> $attributes
 	 * @phpstan-param list<string> $keys
 	 */
 	public function attribute_value( $attributes, $keys ) {
@@ -2032,9 +2032,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $resource_identifier JSON:API resource identifier.
 	 * @param array $included            Indexed included resources.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $resource_identifier
+	 * @phpstan-param array<array-key, mixed> $resource_identifier
 	 * @phpstan-param array<string, mixed> $included
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function resolve_jsonapi_resource( $resource_identifier, $included ) {
 		if ( ! $this->is_jsonapi_resource( $resource_identifier ) ) {
@@ -2073,7 +2073,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $jsonapi_resource JSON:API resource.
 	 * @param string $name             Relationship name.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-param array<array-key, mixed> $jsonapi_resource
 	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function get_jsonapi_relationship_resources( $jsonapi_resource, $name ) {
@@ -2113,7 +2113,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $jsonapi_resource JSON:API resource.
 	 * @param string $type             Expected singular type.
 	 * @return bool
-	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-param array<array-key, mixed> $jsonapi_resource
 	 */
 	public function jsonapi_type_is( $jsonapi_resource, $type ) {
 		if ( empty( $jsonapi_resource['type'] ) ) {
@@ -2280,7 +2280,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_slug( $event ) {
 		$slug = $this->eventyay_first_present_text( $event, array( 'slug', 'identifier', 'code' ) );
@@ -2308,7 +2308,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_title( $event ) {
 		return $this->eventyay_first_present_text( $event, array( 'name', 'title', 'label' ) );
@@ -2322,7 +2322,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $event Eventyay event resource.
 	 * @param string $type  Date type. Accepts start or end.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_datetime( $event, $type ) {
 		$keys = ( 'end' === $type )
@@ -2339,7 +2339,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_timezone( $event ) {
 		return Wpfaevent_Meta_Event::sanitize_timezone(
@@ -2358,7 +2358,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_location( $event ) {
 		$location = $this->eventyay_event_first_present_raw(
@@ -2387,7 +2387,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return array<string>
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_languages( $event ) {
 		$languages = $this->eventyay_event_first_present_raw(
@@ -2421,7 +2421,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return array<string, string>
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 */
 	public function eventyay_event_colors( $event ) {
 		$color_fields = array(
@@ -2454,7 +2454,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $event    Eventyay event resource.
 	 * @param array $settings Import settings.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function eventyay_event_header_image_url( $event, $settings ) {
@@ -2511,7 +2511,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $event    Eventyay event resource.
 	 * @param array $settings Import settings.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function eventyay_event_logo_url( $event, $settings ) {
@@ -2549,7 +2549,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<array-key, mixed> $event
 	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function eventyay_ticket_widget_url( $event, $settings, $event_slug ) {

--- a/includes/eventyay-importer/class-wpfaevent-jsonapi-parser.php
+++ b/includes/eventyay-importer/class-wpfaevent-jsonapi-parser.php
@@ -36,6 +36,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_event_resource( $event ) {
 		if ( ! is_array( $event ) ) {
@@ -70,6 +72,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $payload API payload.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $payload
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	public function extract_eventyay_event_resources( $payload ) {
 		$resources = array();
@@ -112,6 +116,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Normalized Eventyay event resource.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_resource_needs_detail( $event ) {
 		$has_start    = '' !== trim( $this->eventyay_event_datetime( $event, 'start' ) );
@@ -128,6 +133,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $base   Existing event fields.
 	 * @param array $detail Detail event fields.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $base
+	 * @phpstan-param array<string, mixed> $detail
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function merge_eventyay_event_resource( $base, $detail ) {
 		$base   = $this->normalize_eventyay_event_resource( $base );
@@ -171,6 +179,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $resources Eventyay sponsor resources.
 	 * @param array $settings  Import settings.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $resources
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	public function normalize_eventyay_sponsor_resources( $resources, $settings ) {
 		$sponsors = array();
@@ -215,6 +226,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $sponsor_resource Eventyay sponsor resource.
 	 * @param array $settings Import settings.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $sponsor_resource
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_sponsor_resource( $sponsor_resource, $settings ) {
 		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
@@ -243,6 +257,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $sponsor_resource Eventyay sponsor resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $sponsor_resource
 	 */
 	public function eventyay_sponsor_group_name( $sponsor_resource ) {
 		$sponsor_resource = $this->normalize_eventyay_api_resource( $sponsor_resource );
@@ -276,6 +291,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $resources Eventyay exhibitor resources.
 	 * @param array $settings  Import settings.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $resources
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	public function normalize_eventyay_exhibitor_resources( $resources, $settings ) {
 		$exhibitors = array();
@@ -320,6 +338,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $exhibitor_resource Eventyay exhibitor resource.
 	 * @param array $settings Import settings.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $exhibitor_resource
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_exhibitor_resource( $exhibitor_resource, $settings ) {
 		$exhibitor_resource = $this->normalize_eventyay_api_resource( $exhibitor_resource );
@@ -353,6 +374,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings    Import settings.
 	 * @param string $event_slug  Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<int, mixed> $submissions
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_submissions_payload( $submissions, $settings, $event_slug ) {
 		$speakers      = array();
@@ -419,6 +443,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings          Import settings.
 	 * @param string $event_slug        Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<int, mixed> $speaker_resources
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_speakers_payload( $speaker_resources, $settings, $event_slug ) {
 		$speakers = array();
@@ -478,6 +505,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings       Import settings.
 	 * @param string $event_slug     Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<int, mixed> $slot_resources
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_slots_payload( $slot_resources, $settings, $event_slug ) {
 		$speakers = array();
@@ -542,6 +572,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $base  Base program payload.
 	 * @param array $extra Extra program payload.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $base
+	 * @phpstan-param array<string, mixed> $extra
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function merge_eventyay_program_payloads( $base, $extra ) {
 		$base  = is_array( $base ) ? $base : array();
@@ -585,6 +618,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $sessions Session list.
 	 * @param array $session  Session payload.
 	 * @return array
+	 * @phpstan-param array<string, array<string, mixed>> $sessions
+	 * @phpstan-param array<string, mixed> $session
+	 * @phpstan-return array<string, array<string, mixed>>
 	 */
 	public function merge_eventyay_session_payload( $sessions, $session ) {
 		if ( ! $this->eventyay_session_has_content( $session ) ) {
@@ -612,6 +648,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_submission_session( $submission ) {
 		$submission = $this->normalize_eventyay_api_resource( $submission );
@@ -657,6 +695,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $slot       Eventyay slot resource.
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $slot
+	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_slot_session( $slot, $submission ) {
 		$slot       = $this->normalize_eventyay_api_resource( $slot );
@@ -700,6 +741,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $session Normalized session.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $session
 	 */
 	public function eventyay_session_has_content( $session ) {
 		foreach ( array( 'title', 'date', 'time', 'end_time', 'abstract', 'track', 'room' ) as $key ) {
@@ -718,6 +760,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $slot Eventyay slot resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $slot
 	 */
 	public function eventyay_slot_room_name( $slot ) {
 		$slot = $this->normalize_eventyay_api_resource( $slot );
@@ -747,6 +790,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings         Import settings.
 	 * @param string $event_slug       Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_submission_speaker( $speaker_resource, $settings, $event_slug ) {
 		$speaker_resource = $this->normalize_eventyay_api_resource( $speaker_resource );
@@ -805,6 +851,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $speaker_resource
 	 */
 	public function eventyay_speaker_is_featured( $speaker_resource ) {
 		$featured = $this->eventyay_first_present_raw(
@@ -836,6 +883,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return int
+	 * @phpstan-param array<string, mixed> $speaker_resource
 	 */
 	public function eventyay_speaker_featured_order( $speaker_resource ) {
 		$order = $this->eventyay_first_present_raw(
@@ -864,6 +912,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker_resource Normalized Eventyay speaker resource.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $speaker_resource
 	 */
 	public function eventyay_speaker_featured_state_known( $speaker_resource ) {
 		return $this->eventyay_has_present_key(
@@ -894,6 +943,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $speaker_resource Eventyay resource array.
 	 * @param array $keys             Candidate keys.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_has_present_key( $speaker_resource, $keys ) {
 		if ( ! is_array( $speaker_resource ) ) {
@@ -950,6 +1001,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $submission
 	 */
 	public function eventyay_submission_abstract( $submission ) {
 		return $this->eventyay_first_present_rich_text(
@@ -970,6 +1022,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $submission Eventyay submission resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $submission
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function eventyay_first_slot( $submission ) {
 		if ( ! empty( $submission['slot'] ) && is_array( $submission['slot'] ) ) {
@@ -994,6 +1048,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_api_resource( $eventyay_resource ) {
 		if ( ! is_array( $eventyay_resource ) ) {
@@ -1077,6 +1133,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param mixed $value Raw value.
 	 * @return array
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function eventyay_list_value( $value ) {
 		if ( ! is_array( $value ) ) {
@@ -1118,6 +1175,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
 	 */
 	public function eventyay_resource_identifier( $eventyay_resource ) {
 		foreach ( array( '_eventyay_source_id', 'code', 'id', 'slug' ) as $key ) {
@@ -1137,6 +1195,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_text( $eventyay_resource, $keys ) {
 		$value = $this->eventyay_first_present_raw( $eventyay_resource, $keys );
@@ -1152,6 +1212,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_rich_text( $eventyay_resource, $keys ) {
 		$value = $this->eventyay_first_present_raw( $eventyay_resource, $keys );
@@ -1167,6 +1229,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys              Candidate keys.
 	 * @return mixed
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_raw( $eventyay_resource, $keys ) {
 		foreach ( $keys as $key ) {
@@ -1298,6 +1362,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_has_settings_payload( $event ) {
 		foreach ( array( '_eventyay_settings', 'settings' ) as $settings_key ) {
@@ -1318,6 +1383,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $keys             Candidate keys.
 	 * @param bool  $include_settings Whether to check Eventyay settings payloads.
 	 * @return mixed
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_event_first_present_raw( $event, $keys, $include_settings = false ) {
 		$value = $this->eventyay_first_present_raw( $event, $keys );
@@ -1460,6 +1527,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_description( $event ) {
 		$value = $this->eventyay_event_first_present_raw(
@@ -1495,6 +1563,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function eventyay_public_event_url( $event, $settings, $event_slug ) {
 		$url = $this->eventyay_url_value(
@@ -1545,6 +1615,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $payload
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>|WP_Error
 	 */
 	public function normalize_eventyay_payload( $payload, $settings = array(), $event_slug = '' ) {
 		if ( ! array_key_exists( 'data', $payload ) && array_key_exists( 'results', $payload ) && is_array( $payload['results'] ) ) {
@@ -1638,6 +1711,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return array
+	 * @phpstan-param array<int, mixed> $results
+	 * @phpstan-param array<string, mixed> $settings
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_rest_speakers_payload( $results, $settings = array(), $event_slug = '' ) {
 		$speakers = array();
@@ -1702,6 +1778,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $slots Raw slots array from the Eventyay slots API.
 	 * @return array
+	 * @phpstan-param array<int, mixed> $slots
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function transform_slots_to_speakers_payload( $slots ) {
 		$speakers_map = array();
@@ -1787,6 +1865,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $session_resource Session resource.
 	 * @param array $included         Indexed included resources.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $session_resource
+	 * @phpstan-param array<string, mixed> $included
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_session_resource( $session_resource, $included ) {
 		$attributes = $this->get_jsonapi_attributes( $session_resource );
@@ -1824,6 +1905,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker_resource Speaker resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $speaker_resource
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_speaker_resource( $speaker_resource ) {
 		$attributes = $this->get_jsonapi_attributes( $speaker_resource );
@@ -1884,6 +1967,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $jsonapi_resource JSON:API resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function get_jsonapi_attributes( $jsonapi_resource ) {
 		return isset( $jsonapi_resource['attributes'] ) && is_array( $jsonapi_resource['attributes'] ) ? $jsonapi_resource['attributes'] : array();
@@ -1897,6 +1982,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $attributes Attribute map.
 	 * @param array $keys       Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $attributes
+	 * @phpstan-param list<string> $keys
 	 */
 	public function attribute_value( $attributes, $keys ) {
 		foreach ( $keys as $key ) {
@@ -1915,6 +2002,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $resources Included resources.
 	 * @return array
+	 * @phpstan-param array<int, mixed> $resources
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function index_jsonapi_resources( $resources ) {
 		$index = array();
@@ -1943,6 +2032,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $resource_identifier JSON:API resource identifier.
 	 * @param array $included            Indexed included resources.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $resource_identifier
+	 * @phpstan-param array<string, mixed> $included
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function resolve_jsonapi_resource( $resource_identifier, $included ) {
 		if ( ! $this->is_jsonapi_resource( $resource_identifier ) ) {
@@ -1981,6 +2073,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $jsonapi_resource JSON:API resource.
 	 * @param string $name             Relationship name.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function get_jsonapi_relationship_resources( $jsonapi_resource, $name ) {
 		if ( empty( $jsonapi_resource['relationships'][ $name ] ) || ! is_array( $jsonapi_resource['relationships'][ $name ] ) ) {
@@ -2019,6 +2113,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $jsonapi_resource JSON:API resource.
 	 * @param string $type             Expected singular type.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $jsonapi_resource
 	 */
 	public function jsonapi_type_is( $jsonapi_resource, $type ) {
 		if ( empty( $jsonapi_resource['type'] ) ) {
@@ -2185,6 +2280,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_slug( $event ) {
 		$slug = $this->eventyay_first_present_text( $event, array( 'slug', 'identifier', 'code' ) );
@@ -2212,6 +2308,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_title( $event ) {
 		return $this->eventyay_first_present_text( $event, array( 'name', 'title', 'label' ) );
@@ -2225,6 +2322,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $event Eventyay event resource.
 	 * @param string $type  Date type. Accepts start or end.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_datetime( $event, $type ) {
 		$keys = ( 'end' === $type )
@@ -2241,6 +2339,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_timezone( $event ) {
 		return Wpfaevent_Meta_Event::sanitize_timezone(
@@ -2259,6 +2358,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_location( $event ) {
 		$location = $this->eventyay_event_first_present_raw(
@@ -2287,6 +2387,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return array<string>
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_languages( $event ) {
 		$languages = $this->eventyay_event_first_present_raw(
@@ -2320,6 +2421,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $event Eventyay event resource.
 	 * @return array<string, string>
+	 * @phpstan-param array<string, mixed> $event
 	 */
 	public function eventyay_event_colors( $event ) {
 		$color_fields = array(
@@ -2352,6 +2454,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $event    Eventyay event resource.
 	 * @param array $settings Import settings.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function eventyay_event_header_image_url( $event, $settings ) {
 		$value = $this->eventyay_event_first_present_raw(
@@ -2407,6 +2511,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $event    Eventyay event resource.
 	 * @param array $settings Import settings.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function eventyay_event_logo_url( $event, $settings ) {
 		$value = $this->eventyay_event_first_present_raw(
@@ -2443,6 +2549,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array  $settings   Import settings.
 	 * @param string $event_slug Eventyay event slug.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $event
+	 * @phpstan-param array<string, mixed> $settings
 	 */
 	public function eventyay_ticket_widget_url( $event, $settings, $event_slug ) {
 		$url = $this->eventyay_url_value(
@@ -2482,6 +2590,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $sponsors Imported sponsors.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $sponsors
+	 * @phpstan-return array<string, array<string, mixed>>
 	 */
 	public function group_eventyay_sponsors( $sponsors ) {
 		$groups = array();
@@ -2525,6 +2635,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $group Sponsor group.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $group
 	 */
 	public function is_eventyay_sponsor_group( $group ) {
 		if ( ! empty( $group['source'] ) && 'eventyay' === $group['source'] ) {
@@ -2552,6 +2663,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $imported Imported sponsors.
 	 * @param array $existing Existing dashboard sponsor groups.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $imported
+	 * @phpstan-param array<int, mixed> $existing
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	public function merge_eventyay_sponsor_groups( $imported, $existing ) {
 		$existing        = is_array( $existing ) ? $existing : array();
@@ -2638,6 +2752,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $imported Imported records.
 	 * @param array $existing Existing records.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $imported
+	 * @phpstan-param array<int, mixed> $existing
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	public function merge_eventyay_flat_records( $imported, $existing ) {
 		$existing = is_array( $existing ) ? $existing : array();
@@ -2666,6 +2783,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $imported Imported Eventyay speakers.
 	 * @param array $existing Existing dashboard speakers.
 	 * @return array
+	 * @phpstan-param array<int, array<string, mixed>> $imported
+	 * @phpstan-param array<int, mixed> $existing
+	 * @phpstan-return list<array<string, mixed>>
 	 */
 	public function merge_dashboard_speaker_state( $imported, $existing ) {
 		if ( ! is_array( $existing ) ) {
@@ -2731,6 +2851,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $speakers              Imported speaker records to enrich.
 	 * @param array $supplemental_speakers Supplemental normalized speaker records.
 	 * @return array
+	 * @phpstan-param array<int, array<string, mixed>> $speakers
+	 * @phpstan-param array<int, array<string, mixed>> $supplemental_speakers
+	 * @phpstan-return array<int, array<string, mixed>>
 	 */
 	public function merge_supplemental_speakers( $speakers, $supplemental_speakers ) {
 		if ( ! is_array( $speakers ) || empty( $speakers ) || ! is_array( $supplemental_speakers ) || empty( $supplemental_speakers ) ) {
@@ -2803,6 +2926,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $speaker    Imported speaker record.
 	 * @param array $candidates Supplemental speaker candidates with the same name key.
 	 * @return int|null
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-param list<array<string, mixed>> $candidates
 	 */
 	private function match_supplemental_speaker_candidate_index( $speaker, $candidates ) {
 		if ( 1 === count( $candidates ) ) {
@@ -2859,6 +2984,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array    $candidates Candidate speaker records.
 	 * @param callable $matcher    Match callback.
 	 * @return int|null
+	 * @phpstan-param list<array<string, mixed>> $candidates
 	 */
 	private function find_unique_candidate_index( $candidates, $matcher ) {
 		$matched_index = null;
@@ -2886,6 +3012,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $speaker      Imported speaker record.
 	 * @param array $supplemental Supplemental speaker record.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-param array<string, mixed> $supplemental
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function merge_eventyay_supplemental_speaker_record( $speaker, $supplemental ) {
 		foreach ( array( 'title', 'position', 'organization', 'category', 'image', 'bio' ) as $field ) {
@@ -2924,6 +3053,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param string $html Public speakers page HTML.
 	 * @return array<string, array>
+	 * @phpstan-return array<string, array<string, mixed>>
 	 */
 	public function extract_eventyay_public_speaker_featured_map( $html ) {
 		if ( ! is_string( $html ) || '' === trim( $html ) ) {
@@ -2974,6 +3104,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array<int, array>    $speakers     Normalized speakers.
 	 * @param array<string, array> $featured_map Public featured speaker map keyed by Eventyay speaker code.
 	 * @return array<int, array>
+	 * @phpstan-param array<int, array<string, mixed>> $speakers
+	 * @phpstan-param array<string, array<string, mixed>> $featured_map
+	 * @phpstan-return array<int, array<string, mixed>>
 	 */
 	public function apply_eventyay_public_speaker_featured_map( $speakers, $featured_map ) {
 		if ( ! is_array( $speakers ) || empty( $featured_map ) ) {
@@ -3019,6 +3152,8 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker Speaker data.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-return list<string>
 	 */
 	public function get_dashboard_speaker_state_keys( $speaker ) {
 		$keys = array();
@@ -3045,6 +3180,7 @@ class Wpfaevent_JSONAPI_Parser {
 	 *
 	 * @param array $speaker Speaker data.
 	 * @return bool
+	 * @phpstan-param array<string, mixed> $speaker
 	 */
 	public function is_eventyay_dashboard_speaker( $speaker ) {
 		if ( isset( $speaker['source'] ) && 'eventyay' === $speaker['source'] ) {
@@ -3063,6 +3199,9 @@ class Wpfaevent_JSONAPI_Parser {
 	 * @param array $speaker  Speaker data.
 	 * @param array $session  Session data.
 	 * @return void
+	 * @phpstan-param array<string, array<string, mixed>> $speakers
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-param array<string, mixed> $session
 	 */
 	public function merge_eventyay_speaker( &$speakers, $speaker, $session ) {
 		$key = ! empty( $speaker['eventyay_speaker_id'] ) ? 'eventyay:' . $speaker['eventyay_speaker_id'] : 'name:' . sanitize_title( $speaker['name'] );

--- a/includes/eventyay-importer/class-wpfaevent-jsonapi-resource-utils.php
+++ b/includes/eventyay-importer/class-wpfaevent-jsonapi-resource-utils.php
@@ -30,7 +30,7 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param array $payload JSON:API document payload.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $payload
+	 * @phpstan-param array<array-key, mixed> $payload
 	 * @phpstan-return array<array-key, array<array-key, mixed>>
 	 */
 	public function extract_eventyay_event_resources( $payload ) {
@@ -58,8 +58,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $eventyay_resource
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function normalize_eventyay_api_resource( $eventyay_resource ) {
 		if ( ! is_array( $eventyay_resource ) ) {
@@ -165,7 +165,7 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 */
 	public function eventyay_resource_identifier( $eventyay_resource ) {
 		foreach ( array( '_eventyay_source_id', 'code', 'id', 'slug' ) as $key ) {
@@ -184,7 +184,7 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 * @param array $keys Candidate keys.
 	 * @param bool  $include_settings Unused parameter to maintain signature compat.
 	 * @return mixed
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_raw( $eventyay_resource, $keys, $include_settings = false ) {
@@ -215,7 +215,7 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_text( $eventyay_resource, $keys ) {
@@ -228,7 +228,7 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param array<array-key, mixed> $eventyay_resource
 	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_rich_text( $eventyay_resource, $keys ) {
@@ -415,8 +415,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param array $jsonapi_resource JSON:API resource.
 	 * @return array
-	 * @phpstan-param array<string, mixed> $jsonapi_resource
-	 * @phpstan-return array<string, mixed>
+	 * @phpstan-param array<array-key, mixed> $jsonapi_resource
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function get_jsonapi_attributes( $jsonapi_resource ) {
 		return isset( $jsonapi_resource['attributes'] ) && is_array( $jsonapi_resource['attributes'] ) ? $jsonapi_resource['attributes'] : array();
@@ -428,7 +428,7 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 * @param array $attributes Attribute map.
 	 * @param array $keys Candidate keys.
 	 * @return string
-	 * @phpstan-param array<string, mixed> $attributes
+	 * @phpstan-param array<array-key, mixed> $attributes
 	 * @phpstan-param list<string> $keys
 	 */
 	public function attribute_value( $attributes, $keys ) {

--- a/includes/eventyay-importer/class-wpfaevent-jsonapi-resource-utils.php
+++ b/includes/eventyay-importer/class-wpfaevent-jsonapi-resource-utils.php
@@ -30,6 +30,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param array $payload JSON:API document payload.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $payload
+	 * @phpstan-return array<array-key, array<array-key, mixed>>
 	 */
 	public function extract_eventyay_event_resources( $payload ) {
 		if ( ! is_array( $payload ) || empty( $payload ) ) {
@@ -56,6 +58,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function normalize_eventyay_api_resource( $eventyay_resource ) {
 		if ( ! is_array( $eventyay_resource ) ) {
@@ -121,6 +125,7 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param mixed $value Raw value.
 	 * @return array
+	 * @phpstan-return array<array-key, mixed>
 	 */
 	public function eventyay_list_value( $value ) {
 		if ( ! is_array( $value ) ) {
@@ -160,6 +165,7 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
 	 */
 	public function eventyay_resource_identifier( $eventyay_resource ) {
 		foreach ( array( '_eventyay_source_id', 'code', 'id', 'slug' ) as $key ) {
@@ -178,6 +184,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 * @param array $keys Candidate keys.
 	 * @param bool  $include_settings Unused parameter to maintain signature compat.
 	 * @return mixed
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_raw( $eventyay_resource, $keys, $include_settings = false ) {
 		foreach ( $keys as $key ) {
@@ -207,6 +215,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_text( $eventyay_resource, $keys ) {
 		return $this->eventyay_text_value( $this->eventyay_first_present_raw( $eventyay_resource, $keys ) );
@@ -218,6 +228,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 * @param array $eventyay_resource Eventyay resource.
 	 * @param array $keys Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $eventyay_resource
+	 * @phpstan-param list<string> $keys
 	 */
 	public function eventyay_first_present_rich_text( $eventyay_resource, $keys ) {
 		return $this->eventyay_rich_text_value( $this->eventyay_first_present_raw( $eventyay_resource, $keys ) );
@@ -403,6 +415,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 *
 	 * @param array $jsonapi_resource JSON:API resource.
 	 * @return array
+	 * @phpstan-param array<string, mixed> $jsonapi_resource
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function get_jsonapi_attributes( $jsonapi_resource ) {
 		return isset( $jsonapi_resource['attributes'] ) && is_array( $jsonapi_resource['attributes'] ) ? $jsonapi_resource['attributes'] : array();
@@ -414,6 +428,8 @@ class Wpfaevent_JSONAPI_Resource_Utils {
 	 * @param array $attributes Attribute map.
 	 * @param array $keys Candidate keys.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $attributes
+	 * @phpstan-param list<string> $keys
 	 */
 	public function attribute_value( $attributes, $keys ) {
 		foreach ( $keys as $key ) {

--- a/includes/eventyay-importer/class-wpfaevent-speaker-repository.php
+++ b/includes/eventyay-importer/class-wpfaevent-speaker-repository.php
@@ -28,6 +28,8 @@ class Wpfaevent_Speaker_Repository {
 	 * @param array $speakers Imported speakers.
 	 * @param int   $event_id Event post ID.
 	 * @return array
+	 * @phpstan-param list<array<string, mixed>> $speakers
+	 * @phpstan-return array{created: int, updated: int, ids: list<int>, featured_ids: list<int>}
 	 */
 	public function sync_eventyay_speaker_posts( $speakers, $event_id ) {
 		$result         = array(
@@ -287,6 +289,8 @@ class Wpfaevent_Speaker_Repository {
 	 * @param array  $speaker     Speaker data.
 	 * @param string $post_status Optional. Post status. Default 'draft'.
 	 * @return array|WP_Error
+	 * @phpstan-param array<string, mixed> $speaker
+	 * @phpstan-return array{id: int, created: bool}|WP_Error
 	 */
 	public function upsert_eventyay_speaker_post( $speaker, $post_status = 'draft' ) {
 		if ( empty( $speaker['eventyay_speaker_id'] ) || empty( $speaker['name'] ) ) {

--- a/includes/helpers/class-wpfaevent-event-navigation-helper.php
+++ b/includes/helpers/class-wpfaevent-event-navigation-helper.php
@@ -114,6 +114,7 @@ class Wpfaevent_Event_Navigation_Helper {
 	 * @param array<string, mixed>   $context           Section availability context.
 	 * @param array<int, array>|null $navigation_items  Optional preloaded navigation items.
 	 * @return array<int, array<string, mixed>>
+	 * @phpstan-param array<int, array<string, mixed>>|null $navigation_items
 	 */
 	public static function build_nav_items( $context, $navigation_items = null ) {
 		if ( null === $navigation_items ) {

--- a/includes/helpers/class-wpfaevent-event-template-controller.php
+++ b/includes/helpers/class-wpfaevent-event-template-controller.php
@@ -61,6 +61,7 @@ class Wpfaevent_Event_Template_Controller {
 	 * @param string $type     Partner type.
 	 * @param array  $partner  Partner array.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $partner
 	 */
 	private static function get_partner_detail_url( $event_id, $type, $partner ) {
 		if ( is_callable( self::$partner_helper_provider ) ) {
@@ -77,6 +78,7 @@ class Wpfaevent_Event_Template_Controller {
 	 * @since 1.0.0
 	 * @param int $event_id Event ID.
 	 * @return array
+	 * @phpstan-return array<string, string>
 	 */
 	private static function get_event_colors( $event_id ) {
 		if ( is_callable( self::$meta_event_provider ) ) {

--- a/includes/helpers/class-wpfaevent-news-functions.php
+++ b/includes/helpers/class-wpfaevent-news-functions.php
@@ -196,6 +196,7 @@ function wpfa_clear_news_cache() {
  * @type bool   $success Whether the feed was fetched successfully.
  * @type string $message Human-readable status message.
  * }
+ * @phpstan-return array{success: bool, message: string}
  */
 function wpfa_test_news_feed() {
 	wpfa_ensure_feed_loaded();

--- a/includes/helpers/class-wpfaevent-partner-helper.php
+++ b/includes/helpers/class-wpfaevent-partner-helper.php
@@ -133,6 +133,7 @@ class Wpfaevent_Partner_Helper {
 	 *
 	 * @param array $partner Partner record.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $partner
 	 */
 	public static function get_partner_key( $partner ) {
 		if ( ! is_array( $partner ) ) {
@@ -169,6 +170,7 @@ class Wpfaevent_Partner_Helper {
 	 *
 	 * @param array $group Sponsor group.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $group
 	 */
 	public static function get_sponsor_group_key( $group ) {
 		if ( ! is_array( $group ) ) {
@@ -195,6 +197,7 @@ class Wpfaevent_Partner_Helper {
 	 * @param string $type     Partner type. Accepts exhibitor or sponsor.
 	 * @param array  $partner  Partner record.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $partner
 	 */
 	public static function get_partner_detail_url( $event_id, $type, $partner ) {
 		$event_id = absint( $event_id );
@@ -371,6 +374,7 @@ class Wpfaevent_Partner_Helper {
 	 * @param int    $event_id    Event post ID.
 	 * @param string $partner_key Partner key.
 	 * @return array
+	 * @phpstan-return array<string, mixed>
 	 */
 	private static function find_exhibitor_by_key( $event_id, $partner_key ) {
 		$exhibitors = self::read_dashboard_json_file( 'exhibitors-' . absint( $event_id ) . '.json', array() );

--- a/includes/helpers/class-wpfaevent-schedule-helper.php
+++ b/includes/helpers/class-wpfaevent-schedule-helper.php
@@ -742,6 +742,7 @@ class Wpfaevent_Schedule_Helper {
 	 * @param array        $item           Schedule item.
 	 * @param DateTimeZone $event_timezone Event timezone.
 	 * @return string
+	 * @phpstan-param array<string, mixed> $item
 	 */
 	private static function build_schedule_session_calendar_url( $event_id, $item, $event_timezone ) {
 		if ( ! class_exists( 'Wpfaevent_Calendar' ) ) {

--- a/includes/helpers/wpfaevent-pagination-helper.php
+++ b/includes/helpers/wpfaevent-pagination-helper.php
@@ -32,6 +32,7 @@ if ( ! function_exists( 'wpfa_render_pagination' ) ) {
 	 *                             Default empty array.
 	 *
 	 * @return void Outputs HTML directly.
+	 * @phpstan-param array<string, mixed> $query_args
 	 */
 	function wpfa_render_pagination( $total_pages, $current_page, $aria_label = 'Pagination', $query_args = array() ) {
 		// Bail if there is only one page.

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -744,7 +744,7 @@ class Wpfaevent_Meta_Event {
 	 * @param array<int>        $speaker_ids        Linked speaker post IDs.
 	 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
 	 * @return array<int, int> Dashboard row index to speaker post ID.
-	 * @phpstan-param array<int, array<string, mixed>> $dashboard_speakers
+	 * @phpstan-param array<array-key, mixed> $dashboard_speakers
 	 */
 	public static function map_dashboard_speakers_to_post_ids( $speaker_ids, $dashboard_speakers ) {
 		$speaker_ids = self::sanitize_post_id_list( $speaker_ids );
@@ -807,7 +807,7 @@ class Wpfaevent_Meta_Event {
 	 * @param array<int>        $speaker_ids        Linked speaker post IDs.
 	 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
 	 * @return array<int>
-	 * @phpstan-param array<int, array<string, mixed>> $dashboard_speakers
+	 * @phpstan-param array<array-key, mixed> $dashboard_speakers
 	 */
 	public static function resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers = array() ) {
 		$event_id    = absint( $event_id );

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -501,7 +501,14 @@ class Wpfaevent_Meta_Event {
 	 * @return bool
 	 */
 	public static function sanitize_boolean_value( $value ) {
-		return rest_sanitize_boolean( $value );
+		// rest_sanitize_boolean() is documented for bool|string|int. Anything else
+		// reaches its `return (bool) $value` unchanged, so this narrows the call
+		// without altering the result.
+		if ( is_bool( $value ) || is_string( $value ) || is_int( $value ) ) {
+			return rest_sanitize_boolean( $value );
+		}
+
+		return (bool) $value;
 	}
 
 	/**
@@ -540,7 +547,7 @@ class Wpfaevent_Meta_Event {
 		$value = get_post_meta( $event_id, 'wpfa_event_all_day', true );
 
 		if ( '' !== $value ) {
-			return rest_sanitize_boolean( $value );
+			return self::sanitize_boolean_value( $value );
 		}
 
 		return '' === self::sanitize_time_value( get_post_meta( $event_id, 'wpfa_event_start_time', true ) )

--- a/includes/meta/class-wpfaevent-meta-event.php
+++ b/includes/meta/class-wpfaevent-meta-event.php
@@ -29,6 +29,7 @@ class Wpfaevent_Meta_Event {
 	 * Registers all event meta fields.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function register() {
 		// Event date fields.
@@ -306,6 +307,8 @@ class Wpfaevent_Meta_Event {
 	 *
 	 * @param array $speaker_ids Array of speaker post IDs.
 	 * @return array Sanitized array of integers.
+	 * @phpstan-param array<int|string, mixed> $speaker_ids
+	 * @phpstan-return list<int>
 	 */
 	public static function sanitize_speaker_ids( $speaker_ids ) {
 		if ( ! is_array( $speaker_ids ) ) {
@@ -326,6 +329,7 @@ class Wpfaevent_Meta_Event {
 	 * @param int        $event_id          Event post ID.
 	 * @param array<int> $previous_speakers Speaker IDs before save.
 	 * @param array<int> $current_speakers  Speaker IDs after save.
+	 * @return void
 	 */
 	public static function sync_event_speaker_relationships( $event_id, $previous_speakers, $current_speakers ) {
 		$event_id          = absint( $event_id );
@@ -733,6 +737,7 @@ class Wpfaevent_Meta_Event {
 	 * @param array<int>        $speaker_ids        Linked speaker post IDs.
 	 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
 	 * @return array<int, int> Dashboard row index to speaker post ID.
+	 * @phpstan-param array<int, array<string, mixed>> $dashboard_speakers
 	 */
 	public static function map_dashboard_speakers_to_post_ids( $speaker_ids, $dashboard_speakers ) {
 		$speaker_ids = self::sanitize_post_id_list( $speaker_ids );
@@ -795,6 +800,7 @@ class Wpfaevent_Meta_Event {
 	 * @param array<int>        $speaker_ids        Linked speaker post IDs.
 	 * @param array<int, array> $dashboard_speakers Imported dashboard speaker rows.
 	 * @return array<int>
+	 * @phpstan-param array<int, array<string, mixed>> $dashboard_speakers
 	 */
 	public static function resolve_event_featured_speaker_ids( $event_id, $speaker_ids, $dashboard_speakers = array() ) {
 		$event_id    = absint( $event_id );
@@ -847,6 +853,7 @@ class Wpfaevent_Meta_Event {
 	 *
 	 * @param mixed $tabs Raw custom tabs.
 	 * @return array
+	 * @phpstan-return list<array{title: string, slug: string, content: string}>
 	 */
 	public static function sanitize_custom_tabs( $tabs ) {
 		if ( is_string( $tabs ) ) {

--- a/includes/meta/class-wpfaevent-meta-speaker.php
+++ b/includes/meta/class-wpfaevent-meta-speaker.php
@@ -29,6 +29,7 @@ class Wpfaevent_Meta_Speaker {
 	 * Registers all speaker meta fields.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function register() {
 		$string_meta_fields = array(
@@ -115,6 +116,7 @@ class Wpfaevent_Meta_Speaker {
 	 * Register the Speaker Details meta box.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function add_meta_boxes() {
 		add_meta_box(
@@ -135,6 +137,7 @@ class Wpfaevent_Meta_Speaker {
 	 * @since 1.0.0
 	 *
 	 * @param WP_Post $post Speaker post object.
+	 * @return void
 	 */
 	public static function render_meta_box( $post ) {
 		wp_nonce_field( 'wpfa_speaker_meta_nonce', 'wpfa_speaker_meta_nonce' );
@@ -183,6 +186,7 @@ class Wpfaevent_Meta_Speaker {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id Speaker post ID.
+	 * @return void
 	 */
 	public static function save_meta( $post_id ) {
 		$speaker_nonce = isset( $_POST['wpfa_speaker_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['wpfa_speaker_meta_nonce'] ) ) : '';
@@ -247,6 +251,7 @@ class Wpfaevent_Meta_Speaker {
 	 * @param int          $speaker_id  Speaker post ID.
 	 * @param string|array $post_status Event post status filter.
 	 * @return array<int>
+	 * @phpstan-param string|array<int, string> $post_status
 	 */
 	public static function get_events_referencing_speaker( $speaker_id, $post_status = 'any' ) {
 		return Wpfaevent_Event_Speaker_Relation_Manager::get_events_referencing_speaker( $speaker_id, $post_status );
@@ -260,6 +265,7 @@ class Wpfaevent_Meta_Speaker {
 	 * @param int          $speaker_id  Speaker post ID.
 	 * @param string|array $post_status Event post status filter.
 	 * @return array<int>
+	 * @phpstan-param string|array<int, string> $post_status
 	 */
 	public static function get_events_linked_to_speaker( $speaker_id, $post_status = 'publish' ) {
 		return Wpfaevent_Event_Speaker_Relation_Manager::get_events_linked_to_speaker( $speaker_id, $post_status );
@@ -273,6 +279,7 @@ class Wpfaevent_Meta_Speaker {
 	 * @param int  $speaker_id       Speaker post ID.
 	 * @param int  $event_id         Event post ID.
 	 * @param bool $check_capability Whether to require edit access to the speaker.
+	 * @return void
 	 */
 	public static function add_event_to_speaker( $speaker_id, $event_id, $check_capability = true ) {
 		Wpfaevent_Event_Speaker_Relation_Manager::add_event_to_speaker( $speaker_id, $event_id, $check_capability );
@@ -286,6 +293,7 @@ class Wpfaevent_Meta_Speaker {
 	 * @param int  $speaker_id       Speaker post ID.
 	 * @param int  $event_id         Event post ID.
 	 * @param bool $check_capability Whether to require edit access to the speaker.
+	 * @return void
 	 */
 	public static function remove_event_from_speaker( $speaker_id, $event_id, $check_capability = true ) {
 		Wpfaevent_Event_Speaker_Relation_Manager::remove_event_from_speaker( $speaker_id, $event_id, $check_capability );
@@ -333,6 +341,8 @@ class Wpfaevent_Meta_Speaker {
 	 * @since 1.0.0
 	 * @param array $event_ids Array of event post IDs.
 	 * @return array Sanitized array of integers.
+	 * @phpstan-param array<int|string, mixed> $event_ids
+	 * @phpstan-return array<int>
 	 */
 	public static function sanitize_event_ids( $event_ids ) {
 		return Wpfaevent_Event_Speaker_Relation_Manager::sanitize_post_id_list( $event_ids );

--- a/includes/taxonomies/class-wpfaevent-taxonomies-speaker.php
+++ b/includes/taxonomies/class-wpfaevent-taxonomies-speaker.php
@@ -22,6 +22,7 @@ class Wpfaevent_Taxonomies_Speaker {
 	 * Registers all speaker taxonomies.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function register() {
 		self::register_speaker_category_taxonomy();
@@ -34,6 +35,7 @@ class Wpfaevent_Taxonomies_Speaker {
 	 * (e.g., "AI", "Web Development", "Cloud", "Open Source").
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	private static function register_speaker_category_taxonomy() {
 		$labels = array(

--- a/includes/taxonomies/class-wpfaevent-taxonomies.php
+++ b/includes/taxonomies/class-wpfaevent-taxonomies.php
@@ -22,6 +22,7 @@ class Wpfaevent_Taxonomies {
 	 * Registers all taxonomies.
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	public static function register() {
 		self::register_track_taxonomy();
@@ -35,6 +36,7 @@ class Wpfaevent_Taxonomies {
 	 * (e.g., "AI Track", "Web Development Track").
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	private static function register_track_taxonomy() {
 		$labels = array(
@@ -84,6 +86,7 @@ class Wpfaevent_Taxonomies {
 	 * (e.g., "beginner-friendly", "hands-on", "keynote").
 	 *
 	 * @since 1.0.0
+	 * @return void
 	 */
 	private static function register_tag_taxonomy() {
 		$labels = array(

--- a/public/class-wpfaevent-bookmark-controller.php
+++ b/public/class-wpfaevent-bookmark-controller.php
@@ -24,6 +24,7 @@ class Wpfaevent_Bookmark_Controller {
 	 * Toggle bookmark/favorite status of an event for the current logged-in user.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function ajax_toggle_bookmark() {
 		// Verify nonce.

--- a/public/class-wpfaevent-public.php
+++ b/public/class-wpfaevent-public.php
@@ -147,6 +147,7 @@ class Wpfaevent_Public {
 	 *
 	 * @since    1.0.0
 	 * @return   array    Associative array of color values.
+	 * @phpstan-return array<string, mixed>
 	 */
 	private function get_theme_colors() {
 		$colors = array(
@@ -222,6 +223,7 @@ class Wpfaevent_Public {
 	 * Register public assets so templates, shortcodes, and blocks can enqueue them.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	private function register_assets() {
 		$event_base_path         = WPFAEVENT_PATH . 'public/css/templates/event-base.css';
@@ -423,6 +425,7 @@ class Wpfaevent_Public {
 	 * Register the stylesheets for the public-facing side of the site.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function enqueue_styles() {
 
@@ -589,6 +592,7 @@ class Wpfaevent_Public {
 	 * Register the JavaScript for the public-facing side of the site.
 	 *
 	 * @since    1.0.0
+	 * @return   void
 	 */
 	public function enqueue_scripts() {
 

--- a/wpfaevent.php
+++ b/wpfaevent.php
@@ -65,6 +65,7 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-wpfaevent.php';
  * not affect the page life cycle.
  *
  * @since    1.0.0
+ * @return   void
  */
 function run_wpfaevent() {
 


### PR DESCRIPTION
## What

Adds the type information PHPStan level 6 asks for, so the check passes again. Docblocks
only: the existing `@param` / `@return` / `@var` lines stay as they are, and `@return`,
`@phpstan-param`, `@phpstan-return` and `@phpstan-var` lines are added beside them.

617 errors to 0 across 48 files. The configuration is untouched and still says `level: 6`.

## Why

Closes #279. `8afa44b` raised the level from 5 to 6, which turned on the missing-typehint
rules. The check has been red on every pull request touching PHP since, and the run the
issue links to is `main`'s own. The 617 errors were only three kinds:

- 510 `missingType.iterableValue` - an `array` with no value type
- 103 `missingType.return` - no return type at all
- 4 `argument.templateType` - `mixed` reaching a WordPress function with a `@phpstan-template`

## How

Docblocks rather than native return types. The codebase has no native return type today,
PHP 7.4 cannot express several of the unions these methods need, and a wrong `: void` is a
fatal at runtime where a wrong docblock is not.

Eventyay payloads are typed `array<array-key, mixed>`, not `array<string, mixed>`.
`decode_eventyay_rest_response()` returns `json_decode( $body, true )` after only an
`is_array()` check, so a top-level JSON array arrives as a 0-indexed list, and
`$_POST['event']` in the AJAX import path is validated the same way. The code already knew:
`eventyay_list_value()` branches on `! array_key_exists( 0, $value )`. Once a payload is
normalised into a literal `array( 'id' => ..., 'name' => ... )` the keys are the plugin's
own, so those returns stay `array<string, mixed>`, as do settings arrays and the
accumulators the code keys itself. The rule throughout: where a body defends against a
shape, the annotation permits it.

Three of the four `argument.templateType` errors needed the only executable change in the
diff. `rest_sanitize_boolean()` is documented for `bool|string|int`, so
`Wpfaevent_Meta_Event::sanitize_boolean_value()` narrows before calling it and
`get_event_all_day()` reuses that helper. The third site keeps the guard inline rather than
calling the helper, because that line currently depends only on WordPress core. Behaviour is
unchanged for every input: `rest_sanitize_boolean()` only treats strings specially and
otherwise returns `(bool) $value`, exactly what the guarded branch falls through to. The
fourth error resolved itself once the surrounding settings array was typed.

Commits are split by subsystem so they can be read one at a time, and the branch splits
cleanly into separate pull requests if you would prefer that.

## Testing

- `vendor/bin/phpstan analyse --memory-limit=2048M` - no errors, against 617 on `main`.
- `vendor/bin/phpcs` - exit 0 over 106 files. `git diff --check` clean.
- `vendor/bin/phpunit` - OK, 76 tests, 243 assertions. The two `test_ajax_handler_*` tests
  are excluded: they fail on `main` too whenever WordPress's update check cannot reach
  api.wordpress.org, because `phpunit.xml.dist` converts that warning into an exception.
- Comparing the PHP token stream of every changed file against `main`, comments and
  whitespace stripped, **46 of the 48 files are byte-identical** and so cannot behave
  differently. The two that are not are the `rest_sanitize_boolean` files above.
- Those two were exercised on a local WordPress with fixture events. The ICS endpoint, the
  route that reaches the changed line, returns identical output before and after apart from
  its own `DTSTAMP`, and ten public pages are byte-identical.

Reading these files turned up several unrelated bugs that are out of scope here. Happy to
open separate issues for them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of event “all-day” values by normalizing boolean, string, and numeric inputs consistently.

- **Documentation**
  - Expanded PHPDoc and static-analysis type annotations across event, speaker, partner, importer, calendar, and administration features.
  - Clarified return values, parameter types, and data structures without changing existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->